### PR TITLE
Fix top/worst performers processing from backend response

### DIFF
--- a/frontend/js/market-data.js
+++ b/frontend/js/market-data.js
@@ -125,10 +125,15 @@ class MarketDataService {
     }
 
     processApiData(apiData) {
-        if (apiData && apiData.data) {
-            this.tickers.top = apiData.data.top_performers || [];
-            this.tickers.worst = apiData.data.worst_performers || [];
+        if (!apiData) {
+            console.warn('⚠️ Datos de API no válidos para procesar');
+            return;
         }
+
+        const { top_performers = [], worst_performers = [] } = apiData;
+
+        this.tickers.top = Array.isArray(top_performers) ? top_performers : [];
+        this.tickers.worst = Array.isArray(worst_performers) ? worst_performers : [];
     }
 
     async getPrice(symbol) {


### PR DESCRIPTION
## Summary
- handle top and worst performer data directly from the backend response in the market data service
- add validation to avoid processing invalid API payloads

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cf7c942ac4832199be23ce11130fe5