### PR TITLE
Use dynamic configuration for frontend API endpoints

### DIFF
--- a/frontend/js/api.js
+++ b/frontend/js/api.js
@@ -1,11 +1,20 @@
 class APIService {
     constructor() {
-        this.baseURL = 'http://localhost:8000';
+        const computedBase = typeof window.buildApiUrl === 'function'
+            ? window.buildApiUrl('')
+            : (window.APP_CONFIG?.API_BASE_URL || 'http://localhost:8000/api');
+
+        this.baseURL = computedBase.replace(/\/$/, '');
+    }
+
+    buildUrl(endpoint = '') {
+        const normalisedEndpoint = endpoint ? `/${endpoint.replace(/^\/+/, '')}` : '';
+        return `${this.baseURL}${normalisedEndpoint}`;
     }
 
     async request(endpoint, options = {}) {
         try {
-            const response = await fetch(`${this.baseURL}${endpoint}`, {
+            const response = await fetch(this.buildUrl(endpoint), {
                 headers: {
                     'Content-Type': 'application/json',
                     ...options.headers
@@ -26,7 +35,7 @@ class APIService {
 
     async getMarketData() {
         try {
-            const response = await this.request('/api/market/top-performers');
+            const response = await this.request('market/top-performers');
             return response.data;
         } catch (error) {
             console.log('Using simulated market data');
@@ -36,7 +45,7 @@ class APIService {
 
     async getPrice(symbol) {
         try {
-            const response = await this.request(`/api/market/price/${symbol}`);
+            const response = await this.request(`market/price/${symbol}`);
             return response.data;
         } catch (error) {
             console.log(`Price not available for ${symbol}`);
@@ -46,7 +55,7 @@ class APIService {
 
     async sendChatMessage(message) {
         try {
-            const response = await this.request('/api/chat/message', {
+            const response = await this.request('chat/message', {
                 method: 'POST',
                 body: JSON.stringify({ message })
             });

--- a/frontend/js/auth.js
+++ b/frontend/js/auth.js
@@ -2,7 +2,22 @@ class AuthManager {
     constructor() {
         this.token = localStorage.getItem('bb_token');
         this.user = JSON.parse(localStorage.getItem('bb_user') || 'null');
+
+        const computedBase = typeof window.buildApiUrl === 'function'
+            ? window.buildApiUrl('')
+            : (window.APP_CONFIG?.API_BASE_URL || 'http://localhost:8000/api');
+
+        this.apiBase = computedBase.replace(/\/$/, '');
         this.init();
+    }
+
+    buildUrl(path = '') {
+        if (typeof window.buildApiUrl === 'function') {
+            return window.buildApiUrl(path);
+        }
+
+        const normalisedPath = path ? `/${String(path).replace(/^\/+/g, '')}` : '';
+        return `${this.apiBase}${normalisedPath}`;
     }
 
     init() {
@@ -41,7 +56,7 @@ class AuthManager {
         const password = document.getElementById('loginPassword').value;
 
         try {
-            const response = await fetch('http://127.0.0.1:8000/api/auth/login', {
+            const response = await fetch(this.buildUrl('auth/login'), {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
@@ -83,7 +98,7 @@ class AuthManager {
         }
 
         try {
-            const response = await fetch('http://127.0.0.1:8000/api/auth/register', {
+            const response = await fetch(this.buildUrl('auth/register'), {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',

--- a/frontend/js/chat.js
+++ b/frontend/js/chat.js
@@ -95,7 +95,11 @@ class ChatManager {
 
     async fetchAIResponse(message) {
         try {
-            const response = await fetch('http://localhost:8000/api/chat/message', {
+            const apiUrl = typeof window.buildApiUrl === 'function'
+                ? window.buildApiUrl('chat/message')
+                : `${(window.APP_CONFIG?.API_BASE_URL || 'http://localhost:8000/api').replace(/\/$/, '')}/chat/message`;
+
+            const response = await fetch(apiUrl, {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',

--- a/frontend/js/config.js
+++ b/frontend/js/config.js
@@ -1,27 +1,92 @@
 // config.js - Configuración global de la aplicación
-window.APP_CONFIG = {
-    API_BASE_URL: 'http://localhost:8000/api',
-    WS_URL: 'ws://localhost:8000/ws/market-data',
-    ENV: 'development',
-    DEBUG: true
-};
+(function initializeAppConfig() {
+    const existingConfig = typeof window.APP_CONFIG === 'object' ? window.APP_CONFIG : {};
+    const fallbackHttpOrigin = 'http://localhost:8000';
 
-console.log('🚀 Configuración de la aplicación cargada:', window.APP_CONFIG);
+    const getWindowOrigin = () => {
+        try {
+            if (window?.location?.origin && window.location.origin !== 'null') {
+                return window.location.origin;
+            }
+        } catch (error) {
+            console.warn('No se pudo obtener window.location.origin:', error);
+        }
+        return null;
+    };
 
-// Función para verificar la conectividad
-window.checkConnectivity = async function() {
-    try {
-        const response = await fetch(`${window.APP_CONFIG.API_BASE_URL}/health`);
-        const data = await response.json();
-        console.log('✅ Backend conectado:', data);
-        return true;
-    } catch (error) {
-        console.error('❌ Error conectando al backend:', error);
-        return false;
-    }
-};
+    const resolveOrigin = () => {
+        if (existingConfig.API_BASE_URL) {
+            try {
+                return new URL(existingConfig.API_BASE_URL).origin;
+            } catch (error) {
+                console.warn('API_BASE_URL inválido. Usando valores por defecto.', error);
+            }
+        }
 
-// Verificar conectividad al cargar
-setTimeout(() => {
-    window.checkConnectivity();
-}, 2000);
+        return getWindowOrigin() || fallbackHttpOrigin;
+    };
+
+    const ensureTrailingRemoved = (value) => value.replace(/\/$/, '');
+
+    const origin = ensureTrailingRemoved(resolveOrigin());
+    const defaultApiBase = `${origin}/api`;
+
+    const normalizeApiBase = (value) => ensureTrailingRemoved(value || defaultApiBase);
+
+    const resolveWsUrl = () => {
+        if (existingConfig.WS_URL) {
+            return ensureTrailingRemoved(existingConfig.WS_URL);
+        }
+
+        try {
+            const url = new URL(origin);
+            const protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
+            return `${protocol}//${url.host}/ws/market-data`;
+        } catch (error) {
+            console.warn('No se pudo construir la URL de WebSocket. Usando valores por defecto.', error);
+            return 'ws://localhost:8000/ws/market-data';
+        }
+    };
+
+    window.APP_CONFIG = {
+        ...existingConfig,
+        ENV: existingConfig.ENV || 'development',
+        DEBUG: existingConfig.DEBUG !== undefined ? existingConfig.DEBUG : true,
+        API_BASE_URL: normalizeApiBase(existingConfig.API_BASE_URL),
+        WS_URL: resolveWsUrl()
+    };
+
+    window.buildApiUrl = function buildApiUrl(path = '') {
+        const base = ensureTrailingRemoved(window.APP_CONFIG.API_BASE_URL);
+        if (!path) return base;
+        const normalisedPath = `/${String(path).replace(/^\/+/g, '')}`;
+        return `${base}${normalisedPath}`;
+    };
+
+    window.buildWsUrl = function buildWsUrl(path = '') {
+        const base = ensureTrailingRemoved(window.APP_CONFIG.WS_URL);
+        if (!path) return base;
+        const normalisedPath = `/${String(path).replace(/^\/+/g, '')}`;
+        return `${base}${normalisedPath}`;
+    };
+
+    console.log('🚀 Configuración de la aplicación cargada:', window.APP_CONFIG);
+
+    // Función para verificar la conectividad
+    window.checkConnectivity = async function checkConnectivity() {
+        try {
+            const response = await fetch(window.buildApiUrl('health'));
+            const data = await response.json();
+            console.log('✅ Backend conectado:', data);
+            return true;
+        } catch (error) {
+            console.error('❌ Error conectando al backend:', error);
+            return false;
+        }
+    };
+
+    // Verificar conectividad al cargar
+    setTimeout(() => {
+        window.checkConnectivity();
+    }, 2000);
+})();

--- a/frontend/login.html
+++ b/frontend/login.html
@@ -63,6 +63,7 @@
         </div>
     </div>
 
+    <script src="js/config.js"></script>
     <script src="js/auth.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- load the shared config script before auth logic and expose helpers to build API/WS URLs dynamically
- update the API, auth, and chat services to consume the dynamic configuration instead of hardcoded localhost values

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cf7c7b6f68832198a464bb2afe9e8e