### PR TITLE
Add PyJWT dependency to backend requirements

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,3 +5,4 @@ python-multipart==0.0.6
 aiohttp==3.9.1
 python-dotenv==1.0.0
 requests==2.31.0
+PyJWT==2.8.0


### PR DESCRIPTION
## Summary
- add PyJWT to the backend requirements list to support JWT usage

## Testing
- pip install -r backend/requirements.txt *(fails: proxy blocks downloading PyJWT)*
- uvicorn backend.app.main:app *(fails: PyJWT module not installed due to proxy restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68cf87bede4c8321af3e78b635fd3740