### PR TITLE
Prevent auth redirect loops and reuse auth manager

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -15,7 +15,9 @@
     <script src="js/auth.js"></script>
     <script>
     document.addEventListener('DOMContentLoaded', function() {
-        const authManager = new AuthManager();
+        const authManager = (window.authManager instanceof AuthManager)
+            ? window.authManager
+            : (window.authManager = new AuthManager());
         
         if (!authManager.isAuthenticated()) {
             window.location.href = 'login.html';

--- a/frontend/js/auth.js
+++ b/frontend/js/auth.js
@@ -138,8 +138,17 @@ class AuthManager {
     }
 
     redirectToApp() {
+        const targetUrl = new URL('index.html', window.location.href);
+        const normalizePath = (path) => path.replace(/\/+$/, '').replace(/\/index\.html$/, '');
+        const currentPath = normalizePath(window.location.pathname);
+        const targetPath = normalizePath(targetUrl.pathname);
+
+        if (currentPath === targetPath) {
+            return;
+        }
+
         setTimeout(() => {
-            window.location.href = 'index.html';
+            window.location.href = targetUrl.href;
         }, 1000);
     }
 


### PR DESCRIPTION
## Summary
- prevent AuthManager from redirecting when already on the app page by comparing normalised paths
- reuse the existing global AuthManager instance in index.html to avoid duplicate initialisation

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cf885bcf44832186871427b75df161