### PR TITLE
Use passlib bcrypt hashing

### DIFF
--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -1,11 +1,12 @@
 from pydantic import BaseModel
 from typing import Optional
 from datetime import datetime
-import hashlib
+
+from utils.config import password_context
 
 def hash_password(password: str) -> str:
     """Función simple para hashear contraseñas"""
-    return hashlib.sha256(password.encode()).hexdigest()
+    return password_context.hash(password)
 
 class User(BaseModel):
     id: Optional[int] = None
@@ -19,7 +20,7 @@ class User(BaseModel):
     
     def verify_password(self, password: str) -> bool:
         """Verificar si la contraseña coincide"""
-        return self.hashed_password == hash_password(password)
+        return password_context.verify(password, self.hashed_password)
     
     def reset_api_counter(self):
         """Resetear el contador de API calls si es un nuevo día"""

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,3 +6,4 @@ aiohttp==3.9.1
 python-dotenv==1.0.0
 requests==2.31.0
 PyJWT==2.8.0
+passlib[bcrypt]==1.7.4

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -3,7 +3,8 @@ from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from typing import Optional
 import jwt
 from datetime import datetime, timedelta
-import hashlib
+
+from utils.config import password_context
 
 router = APIRouter()
 security = HTTPBearer()
@@ -15,7 +16,7 @@ ALGORITHM = "HS256"
 # Función para hashear contraseñas
 def hash_password(password: str) -> str:
     """Función simple para hashear contraseñas"""
-    return hashlib.sha256(password.encode()).hexdigest()
+    return password_context.hash(password)
 
 # Modelo de usuario simplificado (sin Pydantic para evitar dependencias)
 class User:
@@ -31,7 +32,7 @@ class User:
     
     def verify_password(self, password: str) -> bool:
         """Verificar si la contraseña coincide"""
-        return self.hashed_password == hash_password(password)
+        return password_context.verify(password, self.hashed_password)
     
     def reset_api_counter(self):
         """Resetear el contador de API calls si es un nuevo día"""

--- a/backend/utils/config.py
+++ b/backend/utils/config.py
@@ -1,5 +1,6 @@
 import os
 from dotenv import load_dotenv
+from passlib.context import CryptContext
 
 load_dotenv()
 
@@ -19,3 +20,6 @@ class Config:
     # Binance no necesita key
     # Yahoo Finance no necesita key
     # Twitter API necesita app registration
+
+
+password_context = CryptContext(schemes=["bcrypt"], deprecated="auto")


### PR DESCRIPTION
## Summary
- add passlib[bcrypt] to backend dependencies and configure a shared CryptContext
- update auth and user password hashing to use bcrypt via the centralized context
- ensure sample users are created with bcrypt-hashed passwords

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cf90d81e148321b6a0841bb57ec7b0