### PR TITLE
Implement persistent user management with SQLAlchemy

### DIFF
--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -1,0 +1,3 @@
+from .user import Base, User
+
+__all__ = ["Base", "User"]

--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -1,32 +1,48 @@
-from pydantic import BaseModel
-from typing import Optional
+from __future__ import annotations
+
 from datetime import datetime
+
+from sqlalchemy import Column, DateTime, Integer, String
+from sqlalchemy.orm import declarative_base
 
 from utils.config import password_context
 
-def hash_password(password: str) -> str:
-    """Función simple para hashear contraseñas"""
-    return password_context.hash(password)
+Base = declarative_base()
 
-class User(BaseModel):
-    id: Optional[int] = None
-    email: str
-    username: str
-    hashed_password: str
-    created_at: str = datetime.now().isoformat()
-    subscription_level: str = "free"  # free, premium, institutional
-    api_calls_today: int = 0
-    last_reset: str = datetime.now().isoformat()
-    
+
+class User(Base):
+    """Modelo persistente de usuario."""
+
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True, index=True)
+    email = Column(String, unique=True, index=True, nullable=False)
+    username = Column(String, nullable=False)
+    hashed_password = Column(String, nullable=False)
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    subscription_level = Column(String, default="free", nullable=False)
+    api_calls_today = Column(Integer, default=0, nullable=False)
+    last_reset = Column(DateTime, default=datetime.utcnow, nullable=False)
+
     def verify_password(self, password: str) -> bool:
-        """Verificar si la contraseña coincide"""
+        """Verificar si la contraseña coincide."""
         return password_context.verify(password, self.hashed_password)
-    
-    def reset_api_counter(self):
-        """Resetear el contador de API calls si es un nuevo día"""
-        now = datetime.now()
-        last_reset = datetime.fromisoformat(self.last_reset)
-        
-        if now.date() > last_reset.date():
+
+    def reset_api_counter(self) -> None:
+        """Resetear el contador de llamadas diarias si cambió la fecha."""
+        now = datetime.utcnow()
+        if self.last_reset.date() < now.date():
             self.api_calls_today = 0
-            self.last_reset = now.isoformat()
+            self.last_reset = now
+
+    def to_dict(self) -> dict:
+        """Representación serializable del usuario."""
+        return {
+            "id": self.id,
+            "email": self.email,
+            "username": self.username,
+            "subscription_level": self.subscription_level,
+            "api_calls_today": self.api_calls_today,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+            "last_reset": self.last_reset.isoformat() if self.last_reset else None,
+        }

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,3 +7,4 @@ python-dotenv==1.0.0
 requests==2.31.0
 PyJWT==2.8.0
 passlib[bcrypt]==1.7.4
+SQLAlchemy==2.0.23

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -1,10 +1,18 @@
-from fastapi import APIRouter, HTTPException, Depends
-from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
-from typing import Optional
-import jwt
-from datetime import datetime, timedelta
+from __future__ import annotations
 
-from utils.config import password_context
+from datetime import datetime, timedelta
+from typing import Dict
+
+import jwt
+from fastapi import APIRouter, Depends, HTTPException
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+
+from models import User
+from services.user_service import (
+    InvalidCredentialsError,
+    UserAlreadyExistsError,
+    user_service,
+)
 
 router = APIRouter()
 security = HTTPBearer()
@@ -13,98 +21,54 @@ security = HTTPBearer()
 SECRET_KEY = "bullbearbroker_secret_key_2024"
 ALGORITHM = "HS256"
 
-# Función para hashear contraseñas
-def hash_password(password: str) -> str:
-    """Función simple para hashear contraseñas"""
-    return password_context.hash(password)
-
-# Modelo de usuario simplificado (sin Pydantic para evitar dependencias)
-class User:
-    def __init__(self, email: str, username: str, hashed_password: str):
-        self.id = None
-        self.email = email
-        self.username = username
-        self.hashed_password = hashed_password
-        self.created_at = datetime.now().isoformat()
-        self.subscription_level = "free"
-        self.api_calls_today = 0
-        self.last_reset = datetime.now().isoformat()
-    
-    def verify_password(self, password: str) -> bool:
-        """Verificar si la contraseña coincide"""
-        return password_context.verify(password, self.hashed_password)
-    
-    def reset_api_counter(self):
-        """Resetear el contador de API calls si es un nuevo día"""
-        now = datetime.now()
-        last_reset = datetime.fromisoformat(self.last_reset)
-        
-        if now.date() > last_reset.date():
-            self.api_calls_today = 0
-            self.last_reset = now.isoformat()
-
-# Base de datos temporal en memoria - luego reemplazaremos con PostgreSQL
-users_db = {}
-
-# Simulación de base de datos para desarrollo
-def init_sample_users():
-    """Crear algunos usuarios de ejemplo para testing"""
-    sample_users = [
-        {"email": "test@bullbear.com", "username": "testuser", "password": "password123"},
-        {"email": "trader@bullbear.com", "username": "traderpro", "password": "trading123"}
-    ]
-    
-    for user_data in sample_users:
-        user = User(
-            email=user_data["email"],
-            username=user_data["username"],
-            hashed_password=hash_password(user_data["password"])
-        )
-        users_db[user_data["email"]] = user
-
-# Inicializar usuarios de muestra
-init_sample_users()
 
 def create_jwt_token(user: User) -> str:
     """Crear token JWT para el usuario"""
     payload = {
         "sub": user.email,
         "username": user.username,
-        "exp": datetime.utcnow() + timedelta(hours=24)
+        "exp": datetime.utcnow() + timedelta(hours=24),
     }
     return jwt.encode(payload, SECRET_KEY, algorithm=ALGORITHM)
+
+
+def serialize_user(user: User) -> Dict[str, object]:
+    """Serializar la información básica del usuario."""
+    return {
+        "email": user.email,
+        "username": user.username,
+        "subscription_level": user.subscription_level,
+        "api_calls_today": user.api_calls_today,
+    }
+
 
 @router.post("/register")
 async def register(user_data: dict):
     """Endpoint para registrar nuevo usuario"""
     try:
-        if user_data["email"] in users_db:
-            raise HTTPException(status_code=400, detail="Email ya está registrado")
-        
         if len(user_data["password"]) < 6:
             raise HTTPException(status_code=400, detail="La contraseña debe tener al menos 6 caracteres")
-        
-        new_user = User(
-            email=user_data["email"],
-            username=user_data["username"],
-            hashed_password=hash_password(user_data["password"])
-        )
-        
-        users_db[user_data["email"]] = new_user
+
+        try:
+            new_user = user_service.create_user(
+                email=user_data["email"],
+                username=user_data["username"],
+                password=user_data["password"],
+            )
+        except UserAlreadyExistsError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+
         token = create_jwt_token(new_user)
-        
+
         return {
             "message": "Usuario registrado exitosamente",
             "token": token,
-            "user": {
-                "email": new_user.email,
-                "username": new_user.username,
-                "subscription_level": new_user.subscription_level
-            }
+            "user": serialize_user(new_user),
         }
-        
+
     except KeyError as e:
         raise HTTPException(status_code=400, detail=f"Campo faltante: {str(e)}")
+
 
 @router.post("/login")
 async def login(credentials: dict):
@@ -112,29 +76,23 @@ async def login(credentials: dict):
     try:
         email = credentials["email"]
         password = credentials["password"]
-        
-        if email not in users_db:
-            raise HTTPException(status_code=401, detail="Credenciales inválidas")
-        
-        user = users_db[email]
-        
-        if not user.verify_password(password):
-            raise HTTPException(status_code=401, detail="Credenciales inválidas")
-        
+
+        try:
+            user = user_service.authenticate_user(email=email, password=password)
+        except InvalidCredentialsError as exc:
+            raise HTTPException(status_code=401, detail=str(exc)) from exc
+
         token = create_jwt_token(user)
-        
+
         return {
             "message": "Login exitoso",
             "token": token,
-            "user": {
-                "email": user.email,
-                "username": user.username,
-                "subscription_level": user.subscription_level
-            }
+            "user": serialize_user(user),
         }
-        
+
     except KeyError:
         raise HTTPException(status_code=400, detail="Email y password requeridos")
+
 
 @router.get("/users/me")
 async def get_current_user(token: HTTPAuthorizationCredentials = Depends(security)):
@@ -142,18 +100,13 @@ async def get_current_user(token: HTTPAuthorizationCredentials = Depends(securit
     try:
         payload = jwt.decode(token.credentials, SECRET_KEY, algorithms=[ALGORITHM])
         email = payload["sub"]
-        
-        if email not in users_db:
+
+        user = user_service.get_user_by_email(email)
+        if not user:
             raise HTTPException(status_code=404, detail="Usuario no encontrado")
-        
-        user = users_db[email]
-        return {
-            "email": user.email,
-            "username": user.username,
-            "subscription_level": user.subscription_level,
-            "api_calls_today": user.api_calls_today
-        }
-        
+
+        return serialize_user(user)
+
     except jwt.ExpiredSignatureError:
         raise HTTPException(status_code=401, detail="Token expirado")
     except jwt.InvalidTokenError:

--- a/backend/services/user_service.py
+++ b/backend/services/user_service.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import os
+from contextlib import contextmanager
+from typing import Optional
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from models import Base, User
+from utils.config import password_context
+
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./bullbearbroker.db")
+
+connect_args = {"check_same_thread": False} if DATABASE_URL.startswith("sqlite") else {}
+engine = create_engine(DATABASE_URL, echo=False, future=True, connect_args=connect_args)
+SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False, future=True)
+
+Base.metadata.create_all(bind=engine)
+
+
+class UserAlreadyExistsError(Exception):
+    """Se lanza cuando se intenta crear un usuario ya registrado."""
+
+
+class UserNotFoundError(Exception):
+    """Se lanza cuando el usuario no existe en la base de datos."""
+
+
+class InvalidCredentialsError(Exception):
+    """Se lanza cuando las credenciales proporcionadas no son válidas."""
+
+
+class UserService:
+    def __init__(self, session_factory: sessionmaker = SessionLocal):
+        self._session_factory = session_factory
+
+    @contextmanager
+    def _session_scope(self) -> Session:
+        session = self._session_factory()
+        try:
+            yield session
+            session.commit()
+        except Exception:
+            session.rollback()
+            raise
+        finally:
+            session.close()
+
+    def _detach_user(self, session: Session, user: User) -> User:
+        session.flush()
+        session.refresh(user)
+        session.expunge(user)
+        return user
+
+    def create_user(self, email: str, username: str, password: str) -> User:
+        hashed_password = password_context.hash(password)
+        with self._session_scope() as session:
+            if session.query(User).filter(User.email == email).first():
+                raise UserAlreadyExistsError("Email ya está registrado")
+
+            user = User(
+                email=email,
+                username=username,
+                hashed_password=hashed_password,
+            )
+            session.add(user)
+            return self._detach_user(session, user)
+
+    def get_user_by_email(self, email: str) -> Optional[User]:
+        with self._session_scope() as session:
+            user = session.query(User).filter(User.email == email).first()
+            if not user:
+                return None
+            return self._detach_user(session, user)
+
+    def authenticate_user(self, email: str, password: str) -> User:
+        user = self.get_user_by_email(email)
+        if not user or not user.verify_password(password):
+            raise InvalidCredentialsError("Credenciales inválidas")
+        return user
+
+    def increment_api_usage(self, email: str) -> User:
+        with self._session_scope() as session:
+            user = session.query(User).filter(User.email == email).first()
+            if not user:
+                raise UserNotFoundError("Usuario no encontrado")
+
+            user.reset_api_counter()
+            user.api_calls_today += 1
+            return self._detach_user(session, user)
+
+
+user_service = UserService()


### PR DESCRIPTION
## Summary
- add a persistent SQLAlchemy `User` model and expose it through the models package
- implement a reusable user service backed by SQLite that manages creation, lookup, authentication, and API usage
- refactor auth endpoints to rely on the database service instead of the in-memory dictionary and remove seeded users

## Testing
- pytest *(fails: async def functions are not natively supported; requires pytest-asyncio or similar plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68cf9187a5e48321a2a6e12d83f4e4bb