### PR TITLE
Configure JWT secrets via environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,14 @@
-## Hi there 👋
+## BullBearBroker
 
-<!--
-**BullBearBroker/BullBearBroker** is a ✨ _special_ ✨ repository because its `README.md` (this file) appears on your GitHub profile.
+### Configuración de entorno
 
-Here are some ideas to get you started:
+La API utiliza JWT para autenticar a los usuarios. Define una clave secreta fuerte antes de ejecutar el backend creando un archivo `.env` en la raíz del proyecto (o configurando las variables de entorno en tu plataforma de despliegue) con el siguiente contenido:
 
-- 🔭 I’m currently working on ...
-- 🌱 I’m currently learning ...
-- 👯 I’m looking to collaborate on ...
-- 🤔 I’m looking for help with ...
-- 💬 Ask me about ...
-- 📫 How to reach me: ...
-- 😄 Pronouns: ...
-- ⚡ Fun fact: ...
--->
+```env
+BULLBEARBROKER_SECRET_KEY="coloca_aquí_una_clave_aleatoria_segura"
+# Opcional: BULLBEARBROKER_JWT_ALGORITHM="HS256"
+```
+
+> 💡 Puedes generar una cadena segura ejecutando en tu terminal `python -c "import secrets; print(secrets.token_urlsafe(64))"`.
+
+Si la clave no está definida, el backend generará automáticamente una de un solo uso al iniciarse, lo cual es útil para desarrollo pero invalidará los tokens emitidos previamente tras cada reinicio.

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -15,6 +15,7 @@ sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 
 from services.market_service import market_service
 from services.ai_service import ai_service
+from utils.config import Config
 
 # Importar routers de autenticación
 try:
@@ -33,8 +34,8 @@ app = FastAPI(title="BullBearBroker API", version="1.0.0")
 
 # Configuración de seguridad
 security = HTTPBearer()
-SECRET_KEY = "bullbearbroker_secret_key_2024"
-ALGORITHM = "HS256"
+SECRET_KEY = Config.JWT_SECRET_KEY
+ALGORITHM = Config.JWT_ALGORITHM
 
 # ✅ CONFIGURACIÓN CORS MEJORADA - ORIGENS COMPLETOS PARA DESARROLLO
 app.add_middleware(

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -13,13 +13,14 @@ from services.user_service import (
     UserAlreadyExistsError,
     user_service,
 )
+from utils.config import Config
 
 router = APIRouter()
 security = HTTPBearer()
 
-# Secret key para JWT - EN PRODUCCIÓN USAR VARIABLE DE ENTORNO
-SECRET_KEY = "bullbearbroker_secret_key_2024"
-ALGORITHM = "HS256"
+# Secret key para JWT - obtenido desde configuración centralizada
+SECRET_KEY = Config.JWT_SECRET_KEY
+ALGORITHM = Config.JWT_ALGORITHM
 
 
 def create_jwt_token(user: User) -> str:

--- a/backend/utils/config.py
+++ b/backend/utils/config.py
@@ -1,4 +1,6 @@
 import os
+from secrets import token_urlsafe
+
 from dotenv import load_dotenv
 from passlib.context import CryptContext
 
@@ -16,6 +18,13 @@ class Config:
     # News APIs
     NEWSAPI_API_KEY = os.getenv('NEWSAPI_API_KEY')
     CRYPTOPANIC_API_KEY = os.getenv('CRYPTOPANIC_API_KEY')
+
+    # Authentication / security
+    JWT_SECRET_KEY = os.getenv(
+        'BULLBEARBROKER_SECRET_KEY',
+        token_urlsafe(64)
+    )
+    JWT_ALGORITHM = os.getenv('BULLBEARBROKER_JWT_ALGORITHM', 'HS256')
     
     # Binance no necesita key
     # Yahoo Finance no necesita key


### PR DESCRIPTION
## Summary
- load the JWT secret key and algorithm from environment variables with secure defaults in the shared config module
- update the FastAPI application and authentication router to consume the centralized configuration instead of hardcoded secrets
- document the required environment variables for JWT configuration in the README

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cf9278e2cc8321aff99aad48868050