### PR TITLE
Clean backend script entry and document npm usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,11 @@ BULLBEARBROKER_SECRET_KEY="coloca_aquí_una_clave_aleatoria_segura"
 > 💡 Puedes generar una cadena segura ejecutando en tu terminal `python -c "import secrets; print(secrets.token_urlsafe(64))"`.
 
 Si la clave no está definida, el backend generará automáticamente una de un solo uso al iniciarse, lo cual es útil para desarrollo pero invalidará los tokens emitidos previamente tras cada reinicio.
+
+### Ejecución local
+
+1. Instala las dependencias con `npm install`.
+2. Para levantar el frontend estático, ejecuta `npm run start` y accede a [http://localhost:8080](http://localhost:8080).
+3. En otra terminal, inicia el backend con `npm run backend`, lo que lanza el servidor FastAPI en [http://localhost:8000](http://localhost:8000).
+
+Detén cada proceso con `Ctrl+C` cuando termines.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "start": "python -m http.server 8080 --directory frontend",
     "dev": "node -e \"const http = require('http'); const fs = require('fs'); const path = require('path'); const server = http.createServer((req, res) => { let filePath = path.join(__dirname, 'frontend', req.url === '/' ? 'index.html' : req.url); const extname = path.extname(filePath); let contentType = 'text/html'; switch(extname) { case '.js': contentType = 'text/javascript'; break; case '.css': contentType = 'text/css'; break; case '.json': contentType = 'application/json'; break; } fs.readFile(filePath, (err, content) => { if (err) { if (err.code === 'ENOENT') { res.writeHead(404); res.end('File not found'); } else { res.writeHead(500); res.end('Server error'); } } else { res.writeHead(200, { 'Content-Type': contentType }); res.end(content, 'utf-8'); } }); }); server.listen(8080, () => console.log('Server running on http://localhost:8080'));\"",
     "backend": "cd backend && python -m uvicorn app.main:app --reload --host 0.0.0.0 --port 8000",
-    "backend": "cd backend && python -m uvicorn app.main:app --reload --host 0.0.0.0 --port 8000",
     "test": "echo \"No tests specified\" && exit 0"
   },
   "keywords": [


### PR DESCRIPTION
## Summary
- remove the duplicate backend script entry from package.json so npm only exposes a single backend command
- document the npm start and backend workflows in the README for local development

## Testing
- npm run backend *(fails: ModuleNotFoundError: No module named 'passlib')*
- npm run start

------
https://chatgpt.com/codex/tasks/task_e_68cf948c69d483219626570de8bda6cb