### PR TITLE
Fix API URL builder keeping /api segment

### DIFF
--- a/frontend/js/config.js
+++ b/frontend/js/config.js
@@ -109,6 +109,9 @@
                 const origin = window.location?.origin || 'http://localhost:8000';
                 absoluteBase = base.startsWith('/') ? `${origin}${base}` : `${origin}/${base}`;
             }
+            if (!absoluteBase.endsWith('/')) {
+                absoluteBase += '/';
+            }
             const url = new URL(normalisedPath, absoluteBase);
             return url.href;
         } catch (error) {


### PR DESCRIPTION
## Summary
- ensure buildApiUrl always provides a base URL with a trailing slash before using the URL constructor so the /api segment is kept

## Testing
- node - <<'NODE' (config buildApiUrl checks)
- curl -i -X POST http://127.0.0.1:8000/api/auth/register -H 'Content-Type: application/json' -d '{"email":"test@example.com","username":"testuser","password":"secret123"}'
- curl -i -X POST http://127.0.0.1:8000/api/auth/login -H 'Content-Type: application/json' -d '{"email":"test@example.com","password":"secret123"}'

------
https://chatgpt.com/codex/tasks/task_e_68cf9a22ba2c8321929c2fab840301af