### PR TITLE
Add Docker infrastructure and update documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 __pycache__/
 *.pyc
 venv/
+.venv/
 
 # Node.js
 node_modules/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+COMPOSE ?= docker compose
+
+.PHONY: up build down clean logs
+
+up:
+	$(COMPOSE) up
+
+build:
+	$(COMPOSE) up --build
+
+down:
+	$(COMPOSE) down
+
+clean:
+	$(COMPOSE) down -v --remove-orphans
+
+logs:
+	$(COMPOSE) logs -f

--- a/README.md
+++ b/README.md
@@ -1,22 +1,82 @@
 ## BullBearBroker
 
-### Configuración de entorno
+### Requisitos previos
 
-La API utiliza JWT para autenticar a los usuarios. Define una clave secreta fuerte antes de ejecutar el backend creando un archivo `.env` en la raíz del proyecto (o configurando las variables de entorno en tu plataforma de despliegue) con el siguiente contenido:
+- [Docker](https://docs.docker.com/get-docker/)
+- [Docker Compose](https://docs.docker.com/compose/) (Docker Desktop ya lo incluye)
+- Opcional: `make` si prefieres ejecutar comandos abreviados
+
+### Variables de entorno
+
+Crea un archivo `.env` en la raíz del proyecto con las variables necesarias para la API. Puedes usar el siguiente ejemplo como punto de partida:
 
 ```env
+# Seguridad JWT
 BULLBEARBROKER_SECRET_KEY="coloca_aquí_una_clave_aleatoria_segura"
-# Opcional: BULLBEARBROKER_JWT_ALGORITHM="HS256"
+# BULLBEARBROKER_JWT_ALGORITHM="HS256"  # opcional
+
+# Credenciales para la base de datos (opcional si usas docker-compose por defecto)
+# POSTGRES_USER=bullbear
+# POSTGRES_PASSWORD=bullbear
+# POSTGRES_DB=bullbear
+
+# Claves para servicios externos (todas opcionales)
+# ALPHA_VANTAGE_API_KEY=
+# TWELVEDATA_API_KEY=
+# COINGECKO_API_KEY=
+# COINMARKETCAP_API_KEY=
+# NEWSAPI_API_KEY=
+# CRYPTOPANIC_API_KEY=
 ```
 
-> 💡 Puedes generar una cadena segura ejecutando en tu terminal `python -c "import secrets; print(secrets.token_urlsafe(64))"`.
+> 💡 Genera una clave segura ejecutando `python -c "import secrets; print(secrets.token_urlsafe(64))"`.
 
-Si la clave no está definida, el backend generará automáticamente una de un solo uso al iniciarse, lo cual es útil para desarrollo pero invalidará los tokens emitidos previamente tras cada reinicio.
+Si la variable `BULLBEARBROKER_SECRET_KEY` no está definida, el backend creará una clave aleatoria en cada arranque, lo que invalida cualquier token emitido previamente.
 
-### Ejecución local
+### Ejecución con Docker Compose
 
-1. Instala las dependencias con `npm install`.
-2. Para levantar el frontend estático, ejecuta `npm run start` y accede a [http://localhost:8080](http://localhost:8080).
-3. En otra terminal, inicia el backend con `npm run backend`, lo que lanza el servidor FastAPI en [http://localhost:8000](http://localhost:8000).
+1. Construye e inicia los servicios (backend, PostgreSQL y Redis):
+
+   ```bash
+   docker compose up --build
+   ```
+
+   El backend quedará disponible en [http://localhost:8000](http://localhost:8000).
+
+2. Cuando termines, detén los servicios con:
+
+   ```bash
+   docker compose down
+   ```
+
+   Para limpiar completamente los volúmenes de datos (por ejemplo, reiniciar la base de datos), ejecuta `docker compose down -v`.
+
+#### Atajos con `make`
+
+Si cuentas con `make`, el proyecto incluye un `Makefile` con los siguientes atajos:
+
+- `make build` – equivalente a `docker compose up --build`
+- `make up` – levanta los servicios ya construidos
+- `make down` – detiene los contenedores
+- `make clean` – elimina contenedores, redes y volúmenes asociados
+- `make logs` – muestra los logs combinados de los servicios
+
+### Migraciones de base de datos
+
+Actualmente, los modelos de SQLAlchemy se sincronizan automáticamente al iniciar el backend (`Base.metadata.create_all`). No existe todavía un flujo formal de migraciones, por lo que no es necesario ejecutar un comando adicional.
+
+Si en el futuro se añade Alembic (u otra herramienta), podrás ejecutar las migraciones sobre los contenedores con un comando similar a:
+
+```bash
+docker compose run --rm backend alembic upgrade head
+```
+
+### Desarrollo sin Docker
+
+Los scripts de `npm` siguen disponibles para desarrollo local sin contenedores:
+
+1. Instala las dependencias del frontend con `npm install`.
+2. Levanta el frontend estático con `npm run start` y accede a [http://localhost:8080](http://localhost:8080).
+3. Inicia el backend con `npm run backend` (lanza Uvicorn en [http://localhost:8000](http://localhost:8000)).
 
 Detén cada proceso con `Ctrl+C` cuando termines.

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,22 @@
+# syntax=docker/dockerfile:1
+FROM python:3.11-slim AS base
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+# Instalamos dependencias del sistema necesarias para construir dependencias de Python
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y build-essential libpq-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt ./requirements.txt
+RUN pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir -r requirements.txt
+
+COPY . ./
+
+EXPOSE 8000
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,3 +8,4 @@ requests==2.31.0
 PyJWT==2.8.0
 passlib[bcrypt]==1.7.4
 SQLAlchemy==2.0.23
+psycopg2-binary==2.9.9

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,59 @@
+version: "3.9"
+
+services:
+  backend:
+    build:
+      context: ./backend
+    image: bullbearbroker-backend:latest
+    env_file:
+      - .env
+    environment:
+      DATABASE_URL: postgresql+psycopg2://bullbear:bullbear@postgres:5432/bullbear
+      REDIS_URL: redis://redis:6379/0
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    ports:
+      - "8000:8000"
+    volumes:
+      - ./backend:/app
+    networks:
+      - backend
+
+  postgres:
+    image: postgres:15
+    environment:
+      POSTGRES_DB: bullbear
+      POSTGRES_USER: bullbear
+      POSTGRES_PASSWORD: bullbear
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - backend
+
+  redis:
+    image: redis:7-alpine
+    volumes:
+      - redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - backend
+
+networks:
+  backend:
+    driver: bridge
+
+volumes:
+  postgres_data:
+  redis_data:


### PR DESCRIPTION
## Summary
- add a FastAPI Dockerfile and docker-compose stack with PostgreSQL and Redis
- add make targets for compose workflows and extend gitignore for local virtualenvs
- document container usage, environment variables, and migration guidance

## Testing
- pytest *(fails: async tests require an additional pytest plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68d094d0dd208321bf0b43e00599ac3b