### PR TITLE
Add unified price helpers and news fallback pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,17 @@ BULLBEARBROKER_SECRET_KEY="coloca_aquí_una_clave_aleatoria_segura"
 
 Si la clave no está definida, el backend generará automáticamente una de un solo uso al iniciarse, lo cual es útil para desarrollo pero invalidará los tokens emitidos previamente tras cada reinicio.
 
+### Registro de nuevas fuentes de datos y API keys
+
+Los servicios de mercado comparten una arquitectura basada en _helpers_ reutilizables y caché para acceder a distintos proveedores. Para integrar una nueva fuente (por ejemplo, otra API de precios o noticias) sigue estos pasos:
+
+1. **Declara la clave** en `.env` (p. ej. `NUEVA_API_KEY=...`) y expórtala desde `backend/utils/config.py` o el diccionario `api_keys` de `backend/services/market_service.py`.
+2. **Implementa un método asíncrono** en el servicio correspondiente (`CryptoService`, `StockService` o `MarketService`) que devuelva datos en el formato estándar (`price`, `change`, `high`, `low`, `volume`, etc.). Puedes inspirarte en `_format_price_payload` para mantener la homogeneidad.
+3. **Registra la fuente en el helper** adecuado (`get_crypto_price`, `get_stock_price` o `get_news`) añadiendo la función a la cadena de _fallbacks_. El helper se encargará de controlar las excepciones y de poblar la caché compartida.
+4. **Actualiza las pruebas** añadiendo _stubs_ o _fixtures_ que simulen respuestas exitosas y fallos de red para la nueva fuente.
+
+Con esta estructura, cualquier consumidor del servicio recibirá un payload consistente sin importar el proveedor elegido.
+
 ### Ejecución local
 
 1. Instala las dependencias con `npm install`.

--- a/backend/services/crypto_service.py
+++ b/backend/services/crypto_service.py
@@ -1,5 +1,6 @@
 import aiohttp
 import asyncio
+import logging
 from typing import List, Optional
 from utils.config import Config
 
@@ -10,6 +11,7 @@ class CryptoService:
             'secondary': self.binance,
             'fallback': self.coinmarketcap
         }
+        self.logger = logging.getLogger(__name__)
     
     async def get_price(self, symbol: str) -> Optional[float]:
         """Obtener precio crypto de 3 fuentes en paralelo"""
@@ -25,7 +27,7 @@ class CryptoService:
             return self._calculate_final_price(valid_prices)
             
         except Exception as e:
-            print(f"Error getting crypto price: {e}")
+            self.logger.exception("Error getting crypto price: %s", e)
             return None
     
     async def coingecko(self, symbol: str) -> float:

--- a/backend/services/stock_service.py
+++ b/backend/services/stock_service.py
@@ -1,5 +1,6 @@
 import aiohttp
 import asyncio
+import logging
 from typing import List, Dict, Optional
 from utils.config import Config
 
@@ -7,9 +8,10 @@ class StockService:
     def __init__(self):
         self.apis = {
             'primary': self.alpha_vantage,
-            'secondary': self.twelvedata, 
+            'secondary': self.twelvedata,
             'fallback': self.yahoo_finance
         }
+        self.logger = logging.getLogger(__name__)
     
     async def get_price(self, symbol: str) -> Optional[float]:
         """Obtener precio de stock de 3 fuentes en paralelo"""
@@ -25,7 +27,7 @@ class StockService:
             return self._calculate_final_price(valid_prices)
             
         except Exception as e:
-            print(f"Error getting stock price: {e}")
+            self.logger.exception("Error getting stock price: %s", e)
             return None
     
     async def alpha_vantage(self, symbol: str) -> float:

--- a/backend/tests/test_market_service.py
+++ b/backend/tests/test_market_service.py
@@ -1,0 +1,116 @@
+import sys
+from pathlib import Path
+import asyncio
+
+import pytest
+
+ROOT_DIR = Path(__file__).resolve().parents[2]
+BACKEND_DIR = ROOT_DIR / 'backend'
+
+sys.path.append(str(ROOT_DIR))
+sys.path.append(str(BACKEND_DIR))
+
+from backend.services.market_service import MarketService
+
+
+def test_get_crypto_price_uses_cache(monkeypatch):
+    service = MarketService()
+    payload = service._format_price_payload(
+        'BTC',
+        'crypto',
+        price=50000.0,
+        change=2.5,
+        high=51000.0,
+        low=49000.0,
+        volume=1000000.0,
+        source='mock'
+    )
+
+    call_counter = {'count': 0}
+
+    async def fake_binance(symbol: str, force_refresh: bool = False):
+        call_counter['count'] += 1
+        service._set_cached_price(symbol, 'crypto', payload)
+        return payload
+
+    monkeypatch.setattr(service, 'get_binance_price', fake_binance)
+
+    async def _run_test():
+        result_first = await service.get_crypto_price('BTC', force_refresh=True)
+        result_second = await service.get_crypto_price('BTC')
+
+        assert result_first['price'] == pytest.approx(50000.0)
+        assert result_second['price'] == pytest.approx(50000.0)
+        assert call_counter['count'] == 1
+
+    asyncio.run(_run_test())
+
+
+def test_get_crypto_price_fallback_to_service(monkeypatch):
+    service = MarketService()
+
+    async def fail_binance(symbol: str, force_refresh: bool = False):
+        return None
+
+    async def empty_parallel(symbol: str):
+        return None
+
+    async def fake_crypto_price(symbol: str):
+        return 123.45
+
+    monkeypatch.setattr(service, 'get_binance_price', fail_binance)
+    monkeypatch.setattr(service, 'get_crypto_price_parallel', empty_parallel)
+    monkeypatch.setattr(service.crypto_service, 'get_price', fake_crypto_price)
+
+    async def _run_test():
+        result = await service.get_crypto_price('ETH', force_refresh=True)
+
+        assert result is not None
+        assert result['price'] == pytest.approx(123.45)
+        assert result['source'] == 'CryptoService'
+
+    asyncio.run(_run_test())
+
+
+def test_get_stock_price_network_failure(monkeypatch):
+    service = MarketService()
+
+    async def fail_parallel(symbol: str):
+        raise RuntimeError('network down')
+
+    async def fail_service(symbol: str):
+        raise RuntimeError('fallback down')
+
+    monkeypatch.setattr(service, 'get_stock_price_parallel', fail_parallel)
+    monkeypatch.setattr(service.stock_service, 'get_price', fail_service)
+
+    async def _run_test():
+        result = await service.get_stock_price('AAPL', force_refresh=True)
+        assert result is None
+
+    asyncio.run(_run_test())
+
+
+def test_get_news_fallback(monkeypatch):
+    service = MarketService()
+
+    async def fail_newsapi(symbol: str):
+        raise RuntimeError('boom')
+
+    async def empty_mediastack(symbol: str):
+        return []
+
+    async def rss_articles(symbol: str):
+        return [{'title': 'Fallback', 'url': 'http://example.com', 'published_at': 'now'}]
+
+    monkeypatch.setattr(service, '_fetch_newsapi', fail_newsapi)
+    monkeypatch.setattr(service, '_fetch_mediastack', empty_mediastack)
+    monkeypatch.setattr(service, '_fetch_rss', rss_articles)
+
+    async def _run_test():
+        result = await service.get_news('TSLA')
+
+        assert result['source'] == 'rss'
+        assert result['articles'] == [{'title': 'Fallback', 'url': 'http://example.com', 'published_at': 'now'}]
+
+    asyncio.run(_run_test())


### PR DESCRIPTION
## Summary
- add reusable get_crypto_price and get_stock_price helpers with shared cache and service fallbacks
- integrate NewsAPI/Mediastack/RSS strategy with logging-based error handling
- update README with guidance for registering new data sources and add tests for happy and failure paths

## Testing
- pytest backend/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68d094c957588321a1ca79e1f6fbc996