### PR TITLE
Improve Mistral service resilience and add tests

### DIFF
--- a/backend/services/mistral_service.py
+++ b/backend/services/mistral_service.py
@@ -1,10 +1,28 @@
+import asyncio
 import aiohttp
 import json
-from typing import Dict, Any, Optional
+import logging
+from collections import defaultdict
+from typing import Dict, Any, Optional, List
 import os
 from dotenv import load_dotenv
 
 load_dotenv()
+
+
+logger = logging.getLogger(__name__)
+
+
+class MistralAPIError(Exception):
+    """Exception raised when the Mistral API returns an error response."""
+
+    def __init__(self, status: Optional[int], body: str, model: str):
+        self.status = status
+        self.body = body
+        self.model = model
+        message = f"Mistral API error ({status}) on model {model}: {body}"
+        super().__init__(message)
+
 
 class MistralService:
     def __init__(self):
@@ -12,74 +30,161 @@ class MistralService:
         self.base_url = "https://api.mistral.ai/v1"
         self.models = {
             'small': 'mistral-small-latest',
-            'medium': 'mistral-medium-latest', 
+            'medium': 'mistral-medium-latest',
             'large': 'mistral-large-latest'
         }
-    
+        self.max_retries = 3
+        self.initial_backoff = 1
+        self.retryable_statuses = {429} | set(range(500, 600))
+        self.metrics = {
+            'attempts': 0,
+            'model_attempts': defaultdict(int)
+        }
+
     async def chat_completion(self, messages: list, model: str = 'medium') -> Optional[str]:
         """
         Enviar mensajes a Mistral AI y obtener respuesta
         """
         if not self.api_key:
             raise ValueError("Mistral API key no configurada")
-        
+
         headers = {
             'Authorization': f'Bearer {self.api_key}',
             'Content-Type': 'application/json'
         }
-        
+
+        models_to_try = self._build_model_fallback(model)
+
+        last_error: Optional[MistralAPIError] = None
+
+        try:
+            async with aiohttp.ClientSession() as session:
+                for model_name in models_to_try:
+                    try:
+                        return await self._attempt_model(
+                            session=session,
+                            headers=headers,
+                            messages=messages,
+                            model_name=model_name
+                        )
+                    except asyncio.TimeoutError:
+                        logger.error("Timeout while calling Mistral model %s", model_name)
+                        raise
+                    except MistralAPIError as exc:
+                        last_error = exc
+                        if exc.status not in self.retryable_statuses:
+                            raise
+                        logger.warning(str(exc))
+                        continue
+        except aiohttp.ClientError as exc:
+            logger.error("Client error while calling Mistral AI: %s", exc)
+        except Exception:
+            logger.exception("Unexpected error while calling Mistral AI")
+
+        if last_error:
+            raise last_error
+
+        return None
+
+    def _build_model_fallback(self, preferred: str) -> List[str]:
+        ordered_models = ['medium', 'small', 'large']
+        fallback = [preferred] if preferred in ordered_models else []
+        fallback.extend(model for model in ordered_models if model not in fallback)
+        return fallback
+
+    async def _attempt_model(
+        self,
+        session: aiohttp.ClientSession,
+        headers: Dict[str, str],
+        messages: list,
+        model_name: str
+    ) -> str:
         payload = {
-            'model': self.models[model],
+            'model': self.models[model_name],
             'messages': messages,
             'temperature': 0.1,  # Baja temperatura para respuestas precisas
             'max_tokens': 1000
         }
-        
-        try:
-            async with aiohttp.ClientSession() as session:
-                async with session.post(
-                    f'{self.base_url}/chat/completions',
-                    headers=headers,
-                    json=payload,
-                    timeout=30
-                ) as response:
-                    
-                    if response.status == 200:
-                        data = await response.json()
-                        return data['choices'][0]['message']['content']
-                    else:
-                        error_data = await response.text()
-                        print(f"Mistral API error: {response.status} - {error_data}")
-                        return None
-                        
-        except Exception as e:
-            print(f"Error calling Mistral AI: {e}")
-            return None
-    
+
+        backoff = self.initial_backoff
+        last_error: Optional[MistralAPIError] = None
+
+        for attempt in range(1, self.max_retries + 1):
+            self.metrics['attempts'] += 1
+            self.metrics['model_attempts'][model_name] += 1
+            try:
+                data = await self._perform_request(session, headers, payload)
+                return data['choices'][0]['message']['content']
+            except asyncio.TimeoutError:
+                raise
+            except MistralAPIError as exc:
+                last_error = exc
+                if exc.status not in self.retryable_statuses:
+                    raise
+                if attempt >= self.max_retries:
+                    break
+                await asyncio.sleep(backoff)
+                backoff *= 2
+
+        if last_error:
+            raise last_error
+        raise MistralAPIError(None, 'Unknown error', payload['model'])
+
+    async def _perform_request(
+        self,
+        session: aiohttp.ClientSession,
+        headers: Dict[str, str],
+        payload: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        async with session.post(
+            f'{self.base_url}/chat/completions',
+            headers=headers,
+            json=payload,
+            timeout=30
+        ) as response:
+            if response.status == 200:
+                return await response.json()
+
+            error_body = await response.text()
+            if 400 <= response.status < 600:
+                raise MistralAPIError(response.status, error_body, payload['model'])
+
+            raise MistralAPIError(response.status, error_body, payload['model'])
+
+    def get_metrics(self) -> Dict[str, Any]:
+        return {
+            'attempts': self.metrics['attempts'],
+            'model_attempts': dict(self.metrics['model_attempts'])
+        }
+
     async def generate_financial_response(self, user_message: str, context: Dict[str, Any] = None) -> str:
         """
         Generar respuesta especializada en finanzas
         """
         # Preparar el contexto del sistema
         system_prompt = self._create_system_prompt(context)
-        
+
         messages = [
             {"role": "system", "content": system_prompt},
             {"role": "user", "content": user_message}
         ]
-        
-        response = await self.chat_completion(messages, model='medium')
-        
+
+        try:
+            response = await self.chat_completion(messages, model='medium')
+        except (MistralAPIError, asyncio.TimeoutError) as exc:
+            logger.error("Error generating financial response: %s", exc)
+            return "Lo siento, estoy teniendo dificultades para procesar tu solicitud. Por favor intenta nuevamente."
+
         if not response:
             return "Lo siento, estoy teniendo dificultades para procesar tu solicitud. Por favor intenta nuevamente."
-        
+
         return response
-    
+
     def _create_system_prompt(self, context: Dict[str, Any] = None) -> str:
         """
         Crear prompt del sistema especializado en finanzas
         """
-        base_prompt = """Eres BullBearBroker, un asistente de IA especializado en mercados financieros. 
+        base_prompt = """Eres BullBearBroker, un asistente de IA especializado en mercados financieros.
         Tu expertise incluye: acciones, criptomonedas, forex, análisis técnico y fundamental.
 
         Reglas importantes:
@@ -102,11 +207,11 @@ class MistralService:
                 context_str += f"Datos de mercado: {context['market_data']}\n"
             if 'user_portfolio' in context:
                 context_str += f"Portfolio usuario: {context['user_portfolio']}\n"
-            
+
             return base_prompt + context_str
-        
+
         return base_prompt
-    
+
     async def analyze_market_sentiment(self, news_text: str) -> Dict[str, float]:
         """
         Analizar sentimiento de noticias financieras
@@ -125,15 +230,20 @@ class MistralService:
             {"role": "user", "content": prompt}
         ]
 
-        response = await self.chat_completion(messages, model='small')
-        
+        try:
+            response = await self.chat_completion(messages, model='small')
+        except (MistralAPIError, asyncio.TimeoutError) as exc:
+            logger.error("Error analyzing market sentiment: %s", exc)
+            return {"sentiment_score": 0.0, "confidence": 0.0, "keywords": []}
+
         try:
             if response:
                 return json.loads(response.strip())
-        except:
+        except Exception:
             pass
-        
+
         return {"sentiment_score": 0.0, "confidence": 0.0, "keywords": []}
+
 
 # Singleton instance
 mistral_service = MistralService()

--- a/backend/tests/test_mistral_service.py
+++ b/backend/tests/test_mistral_service.py
@@ -1,0 +1,144 @@
+from typing import List, Optional
+
+import pytest
+
+from backend.services import mistral_service as mistral_module
+from backend.services.mistral_service import MistralService, MistralAPIError
+
+
+@pytest.fixture
+def anyio_backend():
+    return 'asyncio'
+
+
+class MockResponse:
+    def __init__(self, status: int, json_data=None, text_data: str = ""):
+        self.status = status
+        self._json = json_data or {}
+        self._text = text_data
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def json(self):
+        return self._json
+
+    async def text(self):
+        return self._text
+
+
+class MockSession:
+    def __init__(self, responses: List[MockResponse]):
+        self._responses = responses
+        self.calls = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    def post(self, url, headers, json, timeout):
+        response = self._responses.pop(0)
+        self.calls.append((json['model'], response.status))
+        return response
+
+
+class SessionFactory:
+    def __init__(self, responses: List[MockResponse]):
+        self.responses = responses
+        self.last_session: Optional[MockSession] = None
+
+    def __call__(self, *args, **kwargs):
+        session = MockSession(self.responses)
+        self.last_session = session
+        return session
+
+
+@pytest.mark.anyio
+async def test_fallback_to_small_on_429(monkeypatch):
+    service = MistralService()
+    service.api_key = 'test-key'
+
+    responses = [
+        MockResponse(429, text_data='Too Many Requests'),
+        MockResponse(429, text_data='Too Many Requests'),
+        MockResponse(429, text_data='Too Many Requests'),
+        MockResponse(200, json_data={'choices': [{'message': {'content': 'fallback-small'}}]})
+    ]
+    factory = SessionFactory(responses)
+    monkeypatch.setattr(mistral_module.aiohttp, 'ClientSession', factory)
+
+    async def immediate_sleep(delay):
+        pass
+
+    monkeypatch.setattr(mistral_module.asyncio, 'sleep', immediate_sleep)
+
+    result = await service.chat_completion([{"role": "user", "content": "hola"}], model='medium')
+
+    assert result == 'fallback-small'
+    metrics = service.get_metrics()
+    assert metrics['model_attempts']['medium'] == 3
+    assert metrics['model_attempts']['small'] == 1
+    assert factory.last_session is not None
+    assert factory.last_session.calls[-1][0] == service.models['small']
+
+
+@pytest.mark.anyio
+async def test_fallback_to_large_on_500(monkeypatch):
+    service = MistralService()
+    service.api_key = 'test-key'
+
+    responses = [
+        MockResponse(500, text_data='Server Error'),
+        MockResponse(500, text_data='Server Error'),
+        MockResponse(500, text_data='Server Error'),
+        MockResponse(500, text_data='Server Error'),
+        MockResponse(500, text_data='Server Error'),
+        MockResponse(500, text_data='Server Error'),
+        MockResponse(200, json_data={'choices': [{'message': {'content': 'fallback-large'}}]})
+    ]
+    factory = SessionFactory(responses)
+    monkeypatch.setattr(mistral_module.aiohttp, 'ClientSession', factory)
+
+    async def immediate_sleep(delay):
+        pass
+
+    monkeypatch.setattr(mistral_module.asyncio, 'sleep', immediate_sleep)
+
+    result = await service.chat_completion([{"role": "user", "content": "hola"}], model='medium')
+
+    assert result == 'fallback-large'
+    metrics = service.get_metrics()
+    assert metrics['model_attempts']['medium'] == 3
+    assert metrics['model_attempts']['small'] == 3
+    assert metrics['model_attempts']['large'] == 1
+    assert factory.last_session is not None
+    assert factory.last_session.calls[-1][0] == service.models['large']
+
+
+@pytest.mark.anyio
+async def test_raises_error_body_for_4xx(monkeypatch):
+    service = MistralService()
+    service.api_key = 'test-key'
+
+    responses = [
+        MockResponse(400, text_data='Bad Request')
+    ]
+    factory = SessionFactory(responses)
+    monkeypatch.setattr(mistral_module.aiohttp, 'ClientSession', factory)
+
+    async def immediate_sleep(delay):
+        pass
+
+    monkeypatch.setattr(mistral_module.asyncio, 'sleep', immediate_sleep)
+
+    with pytest.raises(MistralAPIError) as excinfo:
+        await service.chat_completion([{"role": "user", "content": "hola"}], model='small')
+
+    assert 'Bad Request' in str(excinfo.value)
+    metrics = service.get_metrics()
+    assert metrics['model_attempts']['small'] == 1


### PR DESCRIPTION
## Summary
- replace print-based error handling with structured logging and raise rich exceptions for 4xx/5xx responses
- add retry logic with exponential backoff, automatic model fallback, and basic metrics tracking to the Mistral service
- cover retry and fallback behaviour with async unit tests simulating 429, 500, and 400 API responses

## Testing
- pytest backend/tests/test_mistral_service.py

------
https://chatgpt.com/codex/tasks/task_e_68d094c420f883219002cbf804436eca