### PR TITLE
Add resilient AI provider orchestration with fallbacks

### DIFF
--- a/backend/services/ai_service.py
+++ b/backend/services/ai_service.py
@@ -1,102 +1,275 @@
-from typing import Dict, Any
 import asyncio
+import logging
 import re
+import time
+from typing import Any, Awaitable, Callable, Dict, List, Tuple
+
+import aiohttp
+
+from .huggingface_service import huggingface_service
 from .mistral_service import mistral_service
 
+
+logger = logging.getLogger(__name__)
+
+
+ProviderHandler = Callable[[str, Dict[str, Any]], Awaitable[str]]
+
+
 class AIService:
-    def __init__(self):
+    def __init__(self) -> None:
         self.market_service = None
-        self.use_real_ai = True  # Cambiar a False si falla Mistral
-        
-    def set_market_service(self, market_service):
+        self.max_retries = 3
+        self._ollama_base_url = "http://127.0.0.1:11434"
+        self._ollama_model = "llama3"
+        self._ollama_cache: Dict[str, Any] = {"available": False, "checked_at": 0.0}
+        self._ollama_cache_ttl = 60
+
+    def set_market_service(self, market_service) -> None:
         self.market_service = market_service
 
-    async def process_message(self, message: str, context: Dict[str, Any] = None) -> str:
-        """Procesar mensaje del usuario y generar respuesta"""
-        try:
-            if self.use_real_ai:
-                # 🚀 USAR MISTRAL AI REAL
-                return await self.process_with_mistral(message, context)
-            else:
-                # 🆘 FALLBACK a respuestas locales
-                return await self.generate_response(message)
-                
-        except Exception as e:
-            print(f"Error processing message: {e}")
-            return await self.get_fallback_response(message)
+    async def process_message(self, message: str, context: Dict[str, Any] | None = None) -> str:
+        """Procesar mensaje del usuario y generar respuesta."""
+        prepared_context = await self._prepare_context(message, context)
+        provider_pipeline = await self._get_provider_pipeline()
+        errors: List[str] = []
 
-    async def process_with_mistral(self, message: str, context: Dict[str, Any] = None) -> str:
-        """Procesar mensaje con Mistral AI"""
-        try:
-            # Obtener contexto de mercado si está disponible
-            market_context = await self.get_market_context(message)
-            if context is None:
-                context = {}
-            context.update(market_context)
+        for provider_name, handler in provider_pipeline:
+            for attempt in range(1, self.max_retries + 1):
+                try:
+                    response = await handler(message, prepared_context)
+                    if not response or not response.strip():
+                        raise RuntimeError(f"{provider_name} devolvió una respuesta vacía")
 
-            # Generar respuesta con Mistral AI
-            response = await mistral_service.generate_financial_response(message, context)
-            
-            # Verificar que la respuesta sea válida
-            if response and len(response.strip()) > 10:
-                return response
-            else:
-                raise ValueError("Respuesta vacía de Mistral AI")
-                
-        except Exception as e:
-            print(f"Mistral AI failed, using fallback: {e}")
-            self.use_real_ai = False  # Temporalmente desactivar IA real
-            return await self.generate_response(message)
+                    logger.info(
+                        "Respuesta generada con %s en el intento %d", provider_name, attempt
+                    )
+                    return response
+                except Exception as exc:  # noqa: BLE001 - queremos registrar cualquier fallo
+                    error_message = f"{provider_name} intento {attempt}: {exc}"
+                    errors.append(error_message)
+                    logger.warning(
+                        "Fallo proveedor %s en intento %d: %s", provider_name, attempt, exc
+                    )
+
+                    if attempt < self.max_retries:
+                        await asyncio.sleep(self._calculate_backoff(attempt))
+                    else:
+                        break
+
+        if errors:
+            logger.error(
+                "Todos los proveedores fallaron. Se utilizará la respuesta local. Detalles: %s",
+                "; ".join(errors),
+            )
+        else:
+            logger.error("No se encontraron proveedores de IA disponibles. Se usa fallback local.")
+
+        return await self.generate_response(message)
+
+    async def _prepare_context(
+        self, message: str, context: Dict[str, Any] | None = None
+    ) -> Dict[str, Any]:
+        context_data: Dict[str, Any] = dict(context or {})
+        market_context = await self.get_market_context(message)
+        context_data.update(market_context)
+        return context_data
+
+    async def _get_provider_pipeline(self) -> List[Tuple[str, ProviderHandler]]:
+        providers: List[Tuple[str, ProviderHandler]] = []
+
+        if getattr(mistral_service, "api_key", None):
+            providers.append(("mistral", self.process_with_mistral))
+
+        if huggingface_service.is_configured:
+            providers.append(("huggingface", self._process_with_huggingface))
+
+        if await self._is_ollama_available():
+            providers.append(("ollama", self._process_with_ollama))
+
+        return providers
+
+    def _calculate_backoff(self, attempt: int) -> float:
+        return min(2 ** (attempt - 1), 8)
+
+    async def process_with_mistral(
+        self, message: str, context: Dict[str, Any] | None = None
+    ) -> str:
+        """Procesar mensaje con Mistral AI."""
+        if not getattr(mistral_service, "api_key", None):
+            raise RuntimeError("Mistral API key no configurada")
+
+        try:
+            response = await mistral_service.generate_financial_response(message, context or {})
+        except Exception as exc:  # noqa: BLE001
+            raise RuntimeError(f"Error solicitando respuesta a Mistral: {exc}") from exc
+
+        if not response or len(response.strip()) <= 10:
+            raise RuntimeError("Respuesta vacía de Mistral")
+
+        if response.strip().lower().startswith("lo siento, estoy teniendo dificultades"):
+            raise RuntimeError("Mistral no pudo generar respuesta útil")
+
+        return response
+
+    async def _process_with_huggingface(
+        self, message: str, context: Dict[str, Any] | None = None
+    ) -> str:
+        try:
+            return await huggingface_service.generate_financial_response(message, context or {})
+        except Exception as exc:  # noqa: BLE001
+            raise RuntimeError(f"Error solicitando respuesta a HuggingFace: {exc}") from exc
+
+    async def _process_with_ollama(
+        self, message: str, context: Dict[str, Any] | None = None
+    ) -> str:
+        if not await self._is_ollama_available(force_refresh=False):
+            raise RuntimeError("Ollama local no disponible")
+
+        system_prompt = self._create_system_prompt(context or {})
+        payload = {
+            "model": self._ollama_model,
+            "messages": [
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": message},
+            ],
+            "stream": False,
+        }
+
+        timeout = aiohttp.ClientTimeout(total=30)
+
+        try:
+            async with aiohttp.ClientSession(timeout=timeout) as session:
+                async with session.post(
+                    f"{self._ollama_base_url}/api/chat", json=payload
+                ) as response:
+                    if response.status != 200:
+                        error_detail = await response.text()
+                        raise RuntimeError(
+                            f"Ollama devolvió código {response.status}: {error_detail}"
+                        )
+
+                    data = await response.json()
+        except asyncio.TimeoutError as exc:
+            raise RuntimeError("Timeout al solicitar respuesta a Ollama") from exc
+        except aiohttp.ClientError as exc:
+            raise RuntimeError(f"Error de conexión con Ollama: {exc}") from exc
+
+        message_data = data.get("message") or {}
+        content = message_data.get("content", "").strip()
+        if not content:
+            raise RuntimeError("Respuesta vacía de Ollama")
+
+        return content
+
+    async def _is_ollama_available(self, force_refresh: bool = False) -> bool:
+        now = time.time()
+        if (
+            not force_refresh
+            and now - self._ollama_cache["checked_at"] < self._ollama_cache_ttl
+        ):
+            return bool(self._ollama_cache["available"])
+
+        timeout = aiohttp.ClientTimeout(total=5)
+        available = False
+
+        try:
+            async with aiohttp.ClientSession(timeout=timeout) as session:
+                async with session.get(f"{self._ollama_base_url}/api/version") as response:
+                    available = response.status == 200
+        except (aiohttp.ClientError, asyncio.TimeoutError) as exc:
+            logger.debug("No se pudo verificar Ollama: %s", exc)
+            available = False
+
+        self._ollama_cache["available"] = available
+        self._ollama_cache["checked_at"] = now
+
+        if available:
+            logger.info("Ollama local detectado en %s", self._ollama_base_url)
+        else:
+            logger.debug("Ollama no disponible en %s", self._ollama_base_url)
+
+        return available
+
+    def _create_system_prompt(self, context: Dict[str, Any] | None = None) -> str:
+        base_prompt = """Eres BullBearBroker, un asistente de IA especializado en mercados financieros.
+Tu expertise incluye acciones, criptomonedas, forex, análisis técnico y fundamental.
+Sigue siempre mejores prácticas de gestión de riesgo y comunica con tono profesional."""
+
+        if not context:
+            return base_prompt
+
+        context_lines = []
+        market_data = context.get("market_data")
+        if market_data:
+            context_lines.append(f"Datos de mercado: {market_data}")
+
+        user_portfolio = context.get("user_portfolio")
+        if user_portfolio:
+            context_lines.append(f"Portfolio usuario: {user_portfolio}")
+
+        if context_lines:
+            return base_prompt + "\nContexto adicional:\n" + "\n".join(context_lines)
+
+        return base_prompt
 
     async def get_market_context(self, message: str) -> Dict[str, Any]:
-        """Obtener contexto de mercado relevante"""
+        """Obtener contexto de mercado relevante."""
         if not self.market_service:
             return {}
 
-        context = {}
+        context: Dict[str, Any] = {}
         symbols = self.extract_symbols(message)
-        
+
         if symbols:
-            market_data = {}
+            market_data: Dict[str, Any] = {}
             for symbol in symbols:
                 try:
                     asset_type = await self.market_service.detect_asset_type(symbol)
                     price_data = await self.market_service.get_price(symbol, asset_type)
                     if price_data:
                         market_data[symbol] = {
-                            'price': price_data.get('price', 'N/A'),
-                            'change': price_data.get('change', 'N/A'),
-                            'raw_price': price_data.get('raw_price', 0),
-                            'raw_change': price_data.get('raw_change', 0)
+                            "price": price_data.get("price", "N/A"),
+                            "change": price_data.get("change", "N/A"),
+                            "raw_price": price_data.get("raw_price", 0),
+                            "raw_change": price_data.get("raw_change", 0),
                         }
-                except Exception as e:
-                    print(f"Error getting price for {symbol}: {e}")
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning("Error obteniendo precio para %s: %s", symbol, exc)
                     continue
-            
+
             if market_data:
-                context['market_data'] = market_data
-                context['symbols'] = list(market_data.keys())
+                context["market_data"] = market_data
+                context["symbols"] = list(market_data.keys())
 
         return context
 
-    def extract_symbols(self, message: str) -> list:
-        """Extraer símbolos de activos del mensaje"""
-        # Símbolos de cripto comunes
-        crypto_symbols = {'BTC', 'ETH', 'BNB', 'XRP', 'ADA', 'SOL', 'DOT', 'AVAX', 'MATIC', 'DOGE'}
-        
-        # Patrones regex para detectar símbolos
+    def extract_symbols(self, message: str) -> List[str]:
+        """Extraer símbolos de activos del mensaje."""
+        crypto_symbols = {
+            "BTC",
+            "ETH",
+            "BNB",
+            "XRP",
+            "ADA",
+            "SOL",
+            "DOT",
+            "AVAX",
+            "MATIC",
+            "DOGE",
+        }
+
         patterns = [
-            r'\b([A-Z]{2,5})\b',  # Símbolos de acciones (AAPL, TSLA)
-            r'precio de (\w+)',
-            r'valor de (\w+)', 
-            r'cotización de (\w+)',
-            r'price of (\w+)',
-            r'cuánto vale (\w+)'
+            r"\b([A-Z]{2,5})\b",
+            r"precio de (\w+)",
+            r"valor de (\w+)",
+            r"cotización de (\w+)",
+            r"price of (\w+)",
+            r"cuánto vale (\w+)",
         ]
-        
+
         found_symbols = set()
-        
-        # Buscar símbolos conocidos
+
         words = message.upper().split()
         for word in words:
             cleaned_word = word.strip('.,!?;:()[]{}')
@@ -104,8 +277,7 @@ class AIService:
                 found_symbols.add(cleaned_word)
             elif len(cleaned_word) in [3, 4, 5] and cleaned_word.isalpha():
                 found_symbols.add(cleaned_word)
-        
-        # Buscar con patrones regex
+
         for pattern in patterns:
             matches = re.findall(pattern, message, re.IGNORECASE)
             for match in matches:
@@ -113,127 +285,112 @@ class AIService:
                     symbol = match[0].upper()
                 else:
                     symbol = match.upper()
-                
+
                 if len(symbol) >= 2 and symbol.isalpha():
                     found_symbols.add(symbol)
-        
+
         return list(found_symbols)
 
     async def generate_response(self, message: str) -> str:
-        """Generar respuesta local (fallback)"""
+        """Generar respuesta local (fallback)."""
         lower_message = message.lower()
-        
-        # Detectar consultas de precio
+
         if self.is_price_query(lower_message):
             return await self.handle_price_query(message)
-        
-        # Respuestas predefinidas
+
         responses = {
-            'bitcoin': '📈 Bitcoin está mostrando fortaleza. Soporte clave en $40,000, resistencia en $45,000. Volumen aumentado 15% en 24h. Recomendación: acumular en dips.',
-            'ethereum': '🔷 Ethereum consolidando en $2,500. El upgrade próximamente podría impulsar el precio. Technicals muestran patrón alcista.',
-            'acciones': '💼 Recomiendo diversificar: Tech (AAPL, MSFT), Renewable Energy (ENPH), Healthcare (JNJ). Allocation sugerida: 60% stocks, 20% crypto, 20% cash.',
-            'estrategia': '🎯 Estrategias: Conservadora (40% bonds, 40% blue chips, 20% gold). Agresiva (50% growth stocks, 30% crypto, 20% emerging markets). Rebalancear trimestralmente.',
-            'mercado': '🌍 Mercados globales: S&P 500 +0.3%, NASDAQ +0.8%, DOW -0.2%. Recomiendo dollar-cost averaging y diversificación.',
-            'forex': '💱 Forex: EUR/USD 1.0850, GBP/USD 1.2450, USD/JPY 150.20. Atención a reuniones del Fed para cambios en tasas.',
-            'noticias': '📰 Sigue las noticias de: Fed meetings, earnings reports, GDP data, y regulatory announcements. Usa fuentes confiables como Bloomberg, Reuters, y Financial Times.',
-            'portfolio': '📊 Para construir portfolio: 1) Define tu risk tolerance, 2) Diversifica across asset classes, 3) Considera horizonte temporal, 4) Rebalancea regularmente.',
-            'riesgo': '⚖️ Gestión de riesgo: Nunca inviertas más de lo que puedes perder, diversifica, usa stop-loss orders, y mantén cash para oportunidades.',
-            'inversión': '💡 Principios de inversión: Long-term perspective, dollar-cost averaging, focus on fundamentals, and avoid emotional decisions.'
+            "bitcoin": "📈 Bitcoin está mostrando fortaleza. Soporte clave en $40,000, resistencia en $45,000. Volumen aumentado 15% en 24h. Recomendación: acumular en dips.",
+            "ethereum": "🔷 Ethereum consolidando en $2,500. El upgrade próximamente podría impulsar el precio. Technicals muestran patrón alcista.",
+            "acciones": "💼 Recomiendo diversificar: Tech (AAPL, MSFT), Renewable Energy (ENPH), Healthcare (JNJ). Allocation sugerida: 60% stocks, 20% crypto, 20% cash.",
+            "estrategia": "🎯 Estrategias: Conservadora (40% bonds, 40% blue chips, 20% gold). Agresiva (50% growth stocks, 30% crypto, 20% emerging markets). Rebalancear trimestralmente.",
+            "mercado": "🌍 Mercados globales: S&P 500 +0.3%, NASDAQ +0.8%, DOW -0.2%. Recomiendo dollar-cost averaging y diversificación.",
+            "forex": "💱 Forex: EUR/USD 1.0850, GBP/USD 1.2450, USD/JPY 150.20. Atención a reuniones del Fed para cambios en tasas.",
+            "noticias": "📰 Sigue las noticias de: Fed meetings, earnings reports, GDP data, y regulatory announcements. Usa fuentes confiables como Bloomberg, Reuters, y Financial Times.",
+            "portfolio": "📊 Para construir portfolio: 1) Define tu risk tolerance, 2) Diversifica across asset classes, 3) Considera horizonte temporal, 4) Rebalancea regularmente.",
+            "riesgo": "⚖️ Gestión de riesgo: Nunca inviertas más de lo que puedes perder, diversifica, usa stop-loss orders, y mantén cash para oportunidades.",
+            "inversión": "💡 Principios de inversión: Long-term perspective, dollar-cost averaging, focus on fundamentals, and avoid emotional decisions.",
         }
-        
+
         for keyword, response in responses.items():
             if keyword in lower_message:
                 return response
-        
-        # Respuesta por defecto para consultas generales
+
         return self.get_default_response(message)
 
     def is_price_query(self, message: str) -> bool:
-        """Detectar si es una consulta de precio"""
         price_keywords = [
-            'precio', 'valor', 'cuánto vale', 'price of', 'cotización',
-            'valor de', 'precio de', 'how much is', 'current price'
+            "precio",
+            "valor",
+            "cuánto vale",
+            "price of",
+            "cotización",
+            "valor de",
+            "precio de",
+            "how much is",
+            "current price",
         ]
         return any(keyword in message for keyword in price_keywords)
 
     async def handle_price_query(self, message: str) -> str:
-        """Manejar consultas de precio"""
         if not self.market_service:
             return "Servicio de mercado no disponible en este momento."
-        
+
         symbols = self.extract_symbols(message)
-        
+
         if not symbols:
-            return "No pude identificar el símbolo del activo. Por favor especifica, por ejemplo: 'precio de BTC' o 'valor de AAPL'."
-        
-        responses = []
-        for symbol in symbols[:3]:  # Limitar a 3 símbolos por respuesta
+            return (
+                "No pude identificar el símbolo del activo. Por favor especifica, por ejemplo: 'precio de BTC' o 'valor de AAPL'."
+            )
+
+        responses: List[str] = []
+        for symbol in symbols[:3]:
             try:
                 asset_type = await self.market_service.detect_asset_type(symbol)
                 price_data = await self.market_service.get_price(symbol, asset_type)
-                
+
                 if price_data:
                     response = f"**{symbol}**: {price_data['price']} ({price_data['change']})"
                     responses.append(response)
                 else:
                     responses.append(f"**{symbol}**: No disponible")
-                    
-            except Exception as e:
-                print(f"Error getting price for {symbol}: {e}")
+
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("Error obteniendo precio para %s: %s", symbol, exc)
                 responses.append(f"**{symbol}**: Error obteniendo datos")
-        
+
         if responses:
             return "📊 Precios actuales:\n" + "\n".join(responses)
-        else:
-            return "No pude obtener precios para los símbolos mencionados."
+
+        return "No pude obtener precios para los símbolos mencionados."
 
     def get_default_response(self, message: str) -> str:
-        """Respuesta por defecto para consultas generales"""
         return f"""🤖 **BullBearBroker Analysis**
 
 He analizado tu consulta sobre "{message}". Como asistente financiero especializado, te recomiendo:
 
 📊 **Diversificación**: Spread investments across stocks, crypto, bonds, and real estate
-⏰ **Horizonte Temporal**: Align investments with your time horizon and goals  
+⏰ **Horizonte Temporal**: Align investments with your time horizon and goals
 📉 **Gestión de Riesgo**: Never invest more than you can afford to lose
 🔍 **Due Diligence**: Research thoroughly before any investment
 💡 **Educación Continua**: Stay informed about market trends and developments
 
 **¿En qué aspecto te gustaría que profundice?**
 - 📈 Análisis técnico de algún activo
-- 💰 Estrategias de inversión específicas  
+- 💰 Estrategias de inversión específicas
 - 📰 Impacto de noticias recientes
 - 🎯 Recomendaciones de portfolio"""
 
-    async def get_fallback_response(self, message: str) -> str:
-        """Respuesta de fallback para errores"""
-        return f"""⚠️ **Estoy teniendo dificultades técnicas**
-
-Lo siento, estoy experimentando problemas temporales para procesar tu solicitud sobre "{message}".
-
-Mientras tanto, te sugiero:
-1. 📊 Verificar precios directamente en exchanges confiables
-2. 📰 Consultar noticias financieras recientes
-3. 🔍 Realizar tu propio análisis fundamental
-
-**Por favor intenta nuevamente en unos minutos.** Estoy trabajando para resolver el issue.
-
-¿Hay algo más en lo que pueda ayudarte?"""
-
     async def analyze_sentiment(self, text: str) -> Dict[str, float]:
-        """Analizar sentimiento de texto (para noticias)"""
         try:
-            if self.use_real_ai:
-                return await mistral_service.analyze_market_sentiment(text)
-        except:
-            pass
-        
-        # Fallback simple
+            return await mistral_service.analyze_market_sentiment(text)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Fallo analizando sentimiento con Mistral: %s", exc)
+
         return {
             "sentiment_score": 0.0,
             "confidence": 0.7,
-            "keywords": ["market", "analysis", "financial"]
+            "keywords": ["market", "analysis", "financial"],
         }
 
-# Singleton instance
+
 ai_service = AIService()

--- a/backend/services/huggingface_service.py
+++ b/backend/services/huggingface_service.py
@@ -1,0 +1,100 @@
+import asyncio
+import logging
+from typing import Any, Dict
+
+import aiohttp
+
+from utils.config import Config
+
+
+logger = logging.getLogger(__name__)
+
+
+class HuggingFaceService:
+    """Cliente asíncrono para el endpoint de chat de HuggingFace."""
+
+    def __init__(self) -> None:
+        self.api_key = Config.HF_API_KEY
+        self.base_url = "https://api-inference.huggingface.co/v1/chat/completions"
+        self.model = "meta-llama/Meta-Llama-3-8B-Instruct"
+
+    @property
+    def is_configured(self) -> bool:
+        return bool(self.api_key)
+
+    def configure(self, api_key: str) -> None:
+        """Permite ajustar la API key dinámicamente (útil en pruebas)."""
+        self.api_key = api_key
+
+    async def generate_financial_response(self, user_message: str, context: Dict[str, Any] | None = None) -> str:
+        if not self.is_configured:
+            raise RuntimeError("HuggingFace API key no configurada")
+
+        system_prompt = self._create_system_prompt(context)
+        payload = {
+            "model": self.model,
+            "messages": [
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": user_message},
+            ],
+            "max_tokens": 1024,
+            "temperature": 0.2,
+        }
+
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+
+        timeout = aiohttp.ClientTimeout(total=30)
+
+        try:
+            async with aiohttp.ClientSession(timeout=timeout) as session:
+                async with session.post(self.base_url, headers=headers, json=payload) as response:
+                    if response.status != 200:
+                        error_detail = await response.text()
+                        raise RuntimeError(
+                            f"HuggingFace devolvió código {response.status}: {error_detail}"
+                        )
+
+                    data = await response.json()
+        except asyncio.TimeoutError as exc:
+            raise RuntimeError("Timeout al solicitar respuesta a HuggingFace") from exc
+        except aiohttp.ClientError as exc:
+            raise RuntimeError(f"Error de conexión con HuggingFace: {exc}") from exc
+
+        try:
+            content = data["choices"][0]["message"]["content"]
+        except (KeyError, IndexError) as exc:
+            raise RuntimeError("Formato de respuesta inesperado de HuggingFace") from exc
+
+        if not content or not content.strip():
+            raise RuntimeError("Respuesta vacía de HuggingFace")
+
+        logger.debug("Respuesta obtenida de HuggingFace")
+        return content
+
+    def _create_system_prompt(self, context: Dict[str, Any] | None = None) -> str:
+        base_prompt = """Eres BullBearBroker, un asistente financiero profesional.
+Proporciona análisis de mercados (acciones, cripto, forex) con un tono claro y responsable.
+Incluye advertencias de riesgo cuando sea pertinente y datos concretos cuando estén disponibles."""
+
+        if not context:
+            return base_prompt
+
+        context_lines = []
+        market_data = context.get("market_data")
+        if market_data:
+            context_lines.append(f"Datos de mercado: {market_data}")
+
+        user_portfolio = context.get("user_portfolio")
+        if user_portfolio:
+            context_lines.append(f"Portfolio usuario: {user_portfolio}")
+
+        if context_lines:
+            return base_prompt + "\nContexto adicional:\n" + "\n".join(context_lines)
+
+        return base_prompt
+
+
+huggingface_service = HuggingFaceService()

--- a/backend/utils/config.py
+++ b/backend/utils/config.py
@@ -11,10 +11,13 @@ class Config:
     ALPHA_VANTAGE_API_KEY = os.getenv('ALPHA_VANTAGE_API_KEY')
     TWELVEDATA_API_KEY = os.getenv('TWELVEDATA_API_KEY')
     
-    # Crypto APIs  
+    # Crypto APIs
     COINGECKO_API_KEY = os.getenv('COINGECKO_API_KEY')
     COINMARKETCAP_API_KEY = os.getenv('COINMARKETCAP_API_KEY')
-    
+
+    # AI Providers
+    HF_API_KEY = os.getenv('HF_API_KEY')
+
     # News APIs
     NEWSAPI_API_KEY = os.getenv('NEWSAPI_API_KEY')
     CRYPTOPANIC_API_KEY = os.getenv('CRYPTOPANIC_API_KEY')

--- a/tests/test_ai_service.py
+++ b/tests/test_ai_service.py
@@ -1,0 +1,85 @@
+import asyncio
+import logging
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+repo_root = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(repo_root))
+sys.path.insert(0, str(repo_root / "backend"))
+
+from backend.services.ai_service import AIService  # noqa: E402
+from backend.services.huggingface_service import huggingface_service  # noqa: E402
+from backend.services.mistral_service import mistral_service  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def restore_providers():
+    original_mistral_key = getattr(mistral_service, "api_key", None)
+    original_hf_key = huggingface_service.api_key
+    yield
+    mistral_service.api_key = original_mistral_key
+    huggingface_service.configure(original_hf_key)
+
+
+def run_async(coro):
+    return asyncio.run(coro)
+
+
+def test_huggingface_fallback_after_mistral_failures(monkeypatch, caplog):
+    service = AIService()
+    mistral_service.api_key = "test-key"
+    huggingface_service.configure("hf-token")
+
+    monkeypatch.setattr(
+        "backend.services.ai_service.asyncio.sleep", AsyncMock(), raising=False
+    )
+    monkeypatch.setattr(service, "_is_ollama_available", AsyncMock(return_value=False))
+
+    mistral_mock = AsyncMock(side_effect=[RuntimeError("mistral down")] * service.max_retries)
+    monkeypatch.setattr(service, "process_with_mistral", mistral_mock)
+
+    huggingface_mock = AsyncMock(return_value="respuesta hf")
+    monkeypatch.setattr(service, "_process_with_huggingface", huggingface_mock)
+
+    caplog.set_level(logging.INFO)
+    result = run_async(service.process_message("Hola"))
+
+    assert result == "respuesta hf"
+    assert mistral_mock.await_count == service.max_retries
+    assert huggingface_mock.await_count == 1
+    assert "huggingface" in caplog.text.lower()
+
+
+def test_local_fallback_after_all_providers_fail(monkeypatch, caplog):
+    service = AIService()
+    mistral_service.api_key = "test-key"
+    huggingface_service.configure("hf-token")
+
+    monkeypatch.setattr(
+        "backend.services.ai_service.asyncio.sleep", AsyncMock(), raising=False
+    )
+    monkeypatch.setattr(service, "_is_ollama_available", AsyncMock(return_value=True))
+
+    mistral_mock = AsyncMock(side_effect=[RuntimeError("mistral down")] * service.max_retries)
+    huggingface_mock = AsyncMock(side_effect=[RuntimeError("hf down")] * service.max_retries)
+    ollama_mock = AsyncMock(side_effect=[RuntimeError("ollama down")] * service.max_retries)
+
+    monkeypatch.setattr(service, "process_with_mistral", mistral_mock)
+    monkeypatch.setattr(service, "_process_with_huggingface", huggingface_mock)
+    monkeypatch.setattr(service, "_process_with_ollama", ollama_mock)
+
+    fallback_mock = AsyncMock(return_value="fallback local")
+    monkeypatch.setattr(service, "generate_response", fallback_mock)
+
+    caplog.set_level(logging.ERROR)
+    result = run_async(service.process_message("Consulta"))
+
+    assert result == "fallback local"
+    assert mistral_mock.await_count == service.max_retries
+    assert huggingface_mock.await_count == service.max_retries
+    assert ollama_mock.await_count == service.max_retries
+    assert fallback_mock.await_count == 1
+    assert "todos los proveedores fallaron" in caplog.text.lower()


### PR DESCRIPTION
## Summary
- add an async HuggingFace client and expose the HF API key configuration
- orchestrate retries across Mistral, HuggingFace, and Ollama with logging-backed fallbacks
- cover the new provider selection flow with tests that assert order and log output

## Testing
- pytest tests/test_ai_service.py

------
https://chatgpt.com/codex/tasks/task_e_68d094c8810c8321a5cb7f7fb3720285