### PR TITLE
Refactor database layer for async Postgres support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,19 @@ Si la clave no está definida, el backend generará automáticamente una de un s
 3. En otra terminal, inicia el backend con `npm run backend`, lo que lanza el servidor FastAPI en [http://localhost:8000](http://localhost:8000).
 
 Detén cada proceso con `Ctrl+C` cuando termines.
+
+### Base de datos y migraciones
+
+Configura la variable de entorno `DATABASE_URL` apuntando a tu instancia de PostgreSQL usando el driver asíncrono de SQLAlchemy, por ejemplo:
+
+```env
+DATABASE_URL=postgresql+asyncpg://usuario:password@localhost:5432/bullbearbroker
+```
+
+Una vez definidas las variables, aplica las migraciones con Alembic antes de iniciar el backend:
+
+```bash
+alembic upgrade head
+```
+
+El archivo de configuración `backend/alembic.ini` ya apunta al directorio de migraciones localizado en `backend/alembic`.

--- a/backend/alembic.ini
+++ b/backend/alembic.ini
@@ -1,0 +1,35 @@
+[alembic]
+script_location = backend/alembic
+sqlalchemy.url = postgresql+asyncpg://postgres:postgres@localhost:5432/bullbearbroker
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers = console
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers = console
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import asyncio
+from logging.config import fileConfig
+
+from alembic import context
+from sqlalchemy import pool
+from sqlalchemy.engine import Connection
+from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
+
+from db.session import DATABASE_URL
+from models import Base
+
+config = context.config
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+config.set_main_option("sqlalchemy.url", DATABASE_URL)
+
+target_metadata = Base.metadata
+
+
+def run_migrations_offline() -> None:
+    """Ejecutar migraciones en modo offline."""
+
+    url = DATABASE_URL
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def do_run_migrations(connection: Connection) -> None:
+    context.configure(connection=connection, target_metadata=target_metadata)
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    """Ejecutar migraciones en modo online usando motor asíncrono."""
+
+    connectable: AsyncEngine = create_async_engine(
+        DATABASE_URL,
+        poolclass=pool.NullPool,
+    )
+
+    async def run() -> None:
+        async with connectable.connect() as connection:
+            await connection.run_sync(do_run_migrations)
+
+    asyncio.run(run())
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/backend/alembic/script.py.mako
+++ b/backend/alembic/script.py.mako
@@ -1,0 +1,20 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+
+def upgrade() -> None:
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    ${downgrades if downgrades else "pass"}

--- a/backend/alembic/versions/202401151200_create_core_tables.py
+++ b/backend/alembic/versions/202401151200_create_core_tables.py
@@ -1,0 +1,76 @@
+"""create users alerts sessions tables
+
+Revision ID: 202401151200
+Revises: 
+Create Date: 2024-01-15 12:00:00
+
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "202401151200"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "users",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("email", sa.String(length=255), nullable=False),
+        sa.Column("username", sa.String(length=255), nullable=False),
+        sa.Column("hashed_password", sa.String(length=255), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("subscription_level", sa.String(length=50), server_default="free", nullable=False),
+        sa.Column("api_calls_today", sa.Integer(), server_default="0", nullable=False),
+        sa.Column("last_reset", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_users_email"), "users", ["email"], unique=True)
+    op.create_index(op.f("ix_users_id"), "users", ["id"], unique=False)
+
+    op.create_table(
+        "alerts",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("symbol", sa.String(length=50), nullable=False),
+        sa.Column("condition", sa.String(length=20), nullable=False),
+        sa.Column("target_price", sa.Float(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("triggered_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_alerts_id"), "alerts", ["id"], unique=False)
+    op.create_index(op.f("ix_alerts_user_id"), "alerts", ["user_id"], unique=False)
+
+    op.create_table(
+        "sessions",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("token", sa.String(length=255), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("revoked", sa.Boolean(), server_default=sa.text("false"), nullable=False),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("token"),
+    )
+    op.create_index(op.f("ix_sessions_id"), "sessions", ["id"], unique=False)
+    op.create_index(op.f("ix_sessions_user_id"), "sessions", ["user_id"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_sessions_user_id"), table_name="sessions")
+    op.drop_index(op.f("ix_sessions_id"), table_name="sessions")
+    op.drop_table("sessions")
+    op.drop_index(op.f("ix_alerts_user_id"), table_name="alerts")
+    op.drop_index(op.f("ix_alerts_id"), table_name="alerts")
+    op.drop_table("alerts")
+    op.drop_index(op.f("ix_users_id"), table_name="users")
+    op.drop_index(op.f("ix_users_email"), table_name="users")
+    op.drop_table("users")

--- a/backend/db/__init__.py
+++ b/backend/db/__init__.py
@@ -1,0 +1,9 @@
+from .session import DATABASE_URL, SessionLocal, engine, get_session, session_scope
+
+__all__ = [
+    "DATABASE_URL",
+    "SessionLocal",
+    "engine",
+    "get_session",
+    "session_scope",
+]

--- a/backend/db/session.py
+++ b/backend/db/session.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import os
+from contextlib import asynccontextmanager
+from typing import AsyncGenerator, AsyncIterator
+
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker, create_async_engine
+
+DEFAULT_DATABASE_URL = "postgresql+asyncpg://postgres:postgres@localhost:5432/bullbearbroker"
+DATABASE_URL = os.getenv("DATABASE_URL", DEFAULT_DATABASE_URL)
+
+if not DATABASE_URL.startswith("postgresql"):
+    raise RuntimeError(
+        "DATABASE_URL debe utilizar el driver de PostgreSQL (por ejemplo postgresql+asyncpg).",
+    )
+
+try:
+    engine: AsyncEngine = create_async_engine(DATABASE_URL, echo=False, future=True)
+except ModuleNotFoundError as exc:
+    raise RuntimeError("Se requiere instalar asyncpg para usar la base de datos PostgreSQL.") from exc
+
+SessionLocal = async_sessionmaker(bind=engine, expire_on_commit=False, autoflush=False, class_=AsyncSession)
+
+
+@asynccontextmanager
+async def session_scope() -> AsyncIterator[AsyncSession]:
+    """Contexto de sesión con manejo de commit/rollback automático."""
+
+    async with SessionLocal() as session:
+        try:
+            yield session
+            await session.commit()
+        except Exception:
+            await session.rollback()
+            raise
+
+
+async def get_session() -> AsyncGenerator[AsyncSession, None]:
+    """Dependencia para FastAPI que entrega una sesión asincrónica."""
+
+    async with SessionLocal() as session:
+        try:
+            yield session
+        finally:
+            await session.close()

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -1,3 +1,6 @@
-from .user import Base, User
+from .alert import Alert
+from .base import Base
+from .session import UserSession
+from .user import User
 
-__all__ = ["Base", "User"]
+__all__ = ["Base", "User", "Alert", "UserSession"]

--- a/backend/models/alert.py
+++ b/backend/models/alert.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import DateTime, Float, ForeignKey, Integer, String
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.sql import func
+
+from typing import TYPE_CHECKING
+
+from .base import Base
+
+if TYPE_CHECKING:
+    from .user import User
+
+
+class Alert(Base):
+    """Alertas configuradas por los usuarios."""
+
+    __tablename__ = "alerts"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True)
+    symbol: Mapped[str] = mapped_column(String(50), nullable=False)
+    condition: Mapped[str] = mapped_column(String(20), nullable=False)
+    target_price: Mapped[float] = mapped_column(Float, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    triggered_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+    user: Mapped["User"] = relationship("User", back_populates="alerts")
+

--- a/backend/models/base.py
+++ b/backend/models/base.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from sqlalchemy.orm import DeclarativeBase
+
+
+class Base(DeclarativeBase):
+    """Base declarativa compartida para todos los modelos."""
+
+    pass

--- a/backend/models/session.py
+++ b/backend/models/session.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import Boolean, DateTime, ForeignKey, Integer, String
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.sql import func
+
+from typing import TYPE_CHECKING
+
+from .base import Base
+
+if TYPE_CHECKING:
+    from .user import User
+
+
+class UserSession(Base):
+    """Sesiones persistidas para tokens de acceso o refresh."""
+
+    __tablename__ = "sessions"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True)
+    token: Mapped[str] = mapped_column(String(255), unique=True, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    revoked: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+
+    user: Mapped["User"] = relationship("User", back_populates="sessions")
+

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,3 +8,5 @@ requests==2.31.0
 PyJWT==2.8.0
 passlib[bcrypt]==1.7.4
 SQLAlchemy==2.0.23
+asyncpg==0.29.0
+alembic==1.12.1

--- a/backend/utils/config.py
+++ b/backend/utils/config.py
@@ -25,7 +25,12 @@ class Config:
         token_urlsafe(64)
     )
     JWT_ALGORITHM = os.getenv('BULLBEARBROKER_JWT_ALGORITHM', 'HS256')
-    
+
+    DATABASE_URL = os.getenv(
+        'DATABASE_URL',
+        'postgresql+asyncpg://postgres:postgres@localhost:5432/bullbearbroker'
+    )
+
     # Binance no necesita key
     # Yahoo Finance no necesita key
     # Twitter API necesita app registration


### PR DESCRIPTION
## Summary
- add an async SQLAlchemy session factory backed by PostgreSQL and expose the new configuration helpers
- wire up Alembic with an initial migration for users, alerts, and sessions plus supporting models
- refactor the auth router and docs to use the async user service and describe database setup

## Testing
- pytest *(fails: async def functions are not natively supported; missing pytest-asyncio plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68d094c31688832187df57ffa6d91898