### PR TITLE
Improve crypto service resilience and expose API endpoint

### DIFF
--- a/backend/tests/test_crypto_service.py
+++ b/backend/tests/test_crypto_service.py
@@ -5,10 +5,15 @@ from typing import Any, Dict, List
 
 import pytest
 
+import aiohttp
+
 BACKEND_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 if BACKEND_DIR not in sys.path:
     sys.path.insert(0, BACKEND_DIR)
 
+from fastapi import HTTPException
+
+from app.main import crypto_service, get_crypto
 from services.crypto_service import CryptoService
 
 
@@ -28,7 +33,7 @@ def test_coingecko_symbol_resolution(monkeypatch):
 
     expected_calls: List[Dict[str, Any]] = []
 
-    async def fake_request(self, url: str, **kwargs):  # noqa: ANN001 - firma requerida para monkeypatch
+    async def fake_request(self, url: str, *, session=None, **kwargs):  # noqa: ANN001 - firma requerida para monkeypatch
         if not expected_calls:
             pytest.fail("Se realizaron más llamadas de las esperadas a _request_json")
         call = expected_calls.pop(0)
@@ -71,3 +76,62 @@ def test_coingecko_symbol_resolution(monkeypatch):
     missing_price = asyncio.run(service.coingecko("UNKNOWN"))
     assert missing_price is None
     assert not expected_calls
+
+
+def test_binance_failure(monkeypatch):
+    service = CryptoService(cache_client=DummyCache())
+
+    async def fake_request(*args, **kwargs):  # noqa: ANN001 - firma requerida para monkeypatch
+        raise aiohttp.ClientError("network down")
+
+    monkeypatch.setattr(service, "_request_json", fake_request)
+
+    result = asyncio.run(service.binance("BTC"))
+    assert result is None
+
+
+def test_coinmarketcap_invalid_response(monkeypatch):
+    service = CryptoService(cache_client=DummyCache())
+
+    async def fake_request(*args, **kwargs):  # noqa: ANN001 - firma requerida para monkeypatch
+        return {"data": {"ETH": {"quote": {"USD": {}}}}}
+
+    monkeypatch.setattr(service, "_request_json", fake_request)
+
+    result = asyncio.run(service.coinmarketcap("BTC"))
+    assert result is None
+
+
+def test_crypto_endpoint_success(monkeypatch):
+    async def fake_get_price(symbol):  # noqa: ANN001 - firma requerida para monkeypatch
+        return 123.45
+
+    monkeypatch.setattr(crypto_service, "get_price", fake_get_price)
+
+    body = asyncio.run(get_crypto("BTC"))
+    assert body["symbol"] == "BTC"
+    assert body["price"] == 123.45
+
+
+def test_crypto_endpoint_not_found(monkeypatch):
+    async def fake_get_price(symbol):  # noqa: ANN001 - firma requerida para monkeypatch
+        return None
+
+    monkeypatch.setattr(crypto_service, "get_price", fake_get_price)
+
+    with pytest.raises(HTTPException) as excinfo:
+        asyncio.run(get_crypto("UNKNOWN"))
+
+    assert excinfo.value.status_code == 404
+
+
+def test_crypto_endpoint_failure(monkeypatch):
+    async def fake_get_price(symbol):  # noqa: ANN001 - firma requerida para monkeypatch
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(crypto_service, "get_price", fake_get_price)
+
+    with pytest.raises(HTTPException) as excinfo:
+        asyncio.run(get_crypto("ETH"))
+
+    assert excinfo.value.status_code == 502


### PR DESCRIPTION
## Summary
- add shared aiohttp timeout handling and robust error logging for Binance and CoinMarketCap clients
- surface a reusable CryptoService instance through a new /crypto/{symbol} FastAPI endpoint
- expand crypto service tests to cover network failures and endpoint behaviour

## Testing
- pytest backend/tests

------
https://chatgpt.com/codex/tasks/task_e_68d0a6e3618c83218522ca50e28aa5dc