### PR TITLE
Set up Alembic migrations and session tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,13 +64,13 @@ Si cuentas con `make`, el proyecto incluye un `Makefile` con los siguientes ataj
 
 ### Migraciones de base de datos
 
-Actualmente, los modelos de SQLAlchemy se sincronizan automáticamente al iniciar el backend (`Base.metadata.create_all`). No existe todavía un flujo formal de migraciones, por lo que no es necesario ejecutar un comando adicional.
-
-Si en el futuro se añade Alembic (u otra herramienta), podrás ejecutar las migraciones sobre los contenedores con un comando similar a:
+El backend utiliza [Alembic](https://alembic.sqlalchemy.org/) para gestionar los cambios de esquema. Cada vez que actualices el código asegúrate de aplicar las migraciones más recientes con:
 
 ```bash
 docker compose run --rm backend alembic upgrade head
 ```
+
+> Si ejecutas el backend fuera de Docker, asegúrate de tener la variable `DATABASE_URL` apuntando a tu instancia de PostgreSQL antes de lanzar `alembic upgrade head`.
 
 ### Desarrollo sin Docker
 

--- a/backend/alembic.ini
+++ b/backend/alembic.ini
@@ -1,0 +1,39 @@
+[alembic]
+script_location = alembic
+prepend_sys_path = .
+
+sqlalchemy.url =
+
+dispatcher = sqlalchemy
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import os
+from logging.config import fileConfig
+
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+
+from models import Base
+
+# Alembic Config object
+config = context.config
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+DATABASE_URL = os.getenv("DATABASE_URL")
+if not DATABASE_URL:
+    raise RuntimeError("DATABASE_URL debe estar configurada para ejecutar migraciones")
+
+config.set_main_option("sqlalchemy.url", DATABASE_URL)
+
+target_metadata = Base.metadata
+
+
+def run_migrations_offline() -> None:
+    """Run migrations in 'offline' mode."""
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(url=url, target_metadata=target_metadata, literal_binds=True)
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    """Run migrations in 'online' mode."""
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section, {}),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/backend/alembic/script.py.mako
+++ b/backend/alembic/script.py.mako
@@ -1,0 +1,17 @@
+"""${message}"""
+
+revision = ${repr(revision)}
+down_revision = ${repr(down_revision)}
+branch_labels = ${repr(branch_labels)}
+depends_on = ${repr(depends_on)}
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade() -> None:
+    ${upgrades if upgrades else 'pass'}
+
+
+def downgrade() -> None:
+    ${downgrades if downgrades else 'pass'}

--- a/backend/alembic/versions/0001_initial_schema.py
+++ b/backend/alembic/versions/0001_initial_schema.py
@@ -1,0 +1,58 @@
+"""initial schema"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0001_initial_schema"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "users",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("email", sa.String(), nullable=False),
+        sa.Column("username", sa.String(), nullable=False),
+        sa.Column("hashed_password", sa.String(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.Column("subscription_level", sa.String(), server_default="free", nullable=False),
+        sa.Column("api_calls_today", sa.Integer(), server_default="0", nullable=False),
+        sa.Column("last_reset", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+    )
+    op.create_index(op.f("ix_users_email"), "users", ["email"], unique=True)
+    op.create_index(op.f("ix_users_id"), "users", ["id"], unique=False)
+
+    op.create_table(
+        "alerts",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("user_id", sa.Integer(), sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("channel", sa.String(length=50), nullable=False),
+        sa.Column("message", sa.String(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.Column("acknowledged_at", sa.DateTime(), nullable=True),
+    )
+
+    op.create_table(
+        "sessions",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("user_id", sa.Integer(), sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("token", sa.String(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.Column("expires_at", sa.DateTime(), nullable=True),
+        sa.Column("last_seen_at", sa.DateTime(), nullable=True),
+        sa.Column("revoked_at", sa.DateTime(), nullable=True),
+    )
+    op.create_index("ix_sessions_token", "sessions", ["token"], unique=True)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_sessions_token", table_name="sessions")
+    op.drop_table("sessions")
+    op.drop_table("alerts")
+    op.drop_index(op.f("ix_users_id"), table_name="users")
+    op.drop_index(op.f("ix_users_email"), table_name="users")
+    op.drop_table("users")

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -1,3 +1,6 @@
-from .user import Base, User
+from .alert import Alert
+from .base import Base
+from .session import Session
+from .user import User
 
-__all__ = ["Base", "User"]
+__all__ = ["Alert", "Base", "Session", "User"]

--- a/backend/models/alert.py
+++ b/backend/models/alert.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, String
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from models.base import Base
+
+
+class Alert(Base):
+    """Alerta asociada a un usuario."""
+
+    __tablename__ = "alerts"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
+    channel: Mapped[str] = mapped_column(String(50), nullable=False)
+    message: Mapped[str] = mapped_column(String, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
+    acknowledged_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+
+    user: Mapped["User"] = relationship("User", back_populates="alerts")

--- a/backend/models/base.py
+++ b/backend/models/base.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from sqlalchemy.orm import DeclarativeBase
+
+
+class Base(DeclarativeBase):
+    """Base declarativa compartida por todos los modelos."""
+
+    pass

--- a/backend/models/session.py
+++ b/backend/models/session.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, String
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from models.base import Base
+
+
+class Session(Base):
+    """Sesión autenticada del usuario."""
+
+    __tablename__ = "sessions"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
+    token: Mapped[str] = mapped_column(String, unique=True, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
+    expires_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    last_seen_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    revoked_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+
+    user: Mapped["User"] = relationship("User", back_populates="sessions")

--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -2,12 +2,11 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from sqlalchemy import Column, DateTime, Integer, String
-from sqlalchemy.orm import declarative_base
+from sqlalchemy import DateTime, Integer, String
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
+from models.base import Base
 from utils.config import password_context
-
-Base = declarative_base()
 
 
 class User(Base):
@@ -15,14 +14,21 @@ class User(Base):
 
     __tablename__ = "users"
 
-    id = Column(Integer, primary_key=True, index=True)
-    email = Column(String, unique=True, index=True, nullable=False)
-    username = Column(String, nullable=False)
-    hashed_password = Column(String, nullable=False)
-    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
-    subscription_level = Column(String, default="free", nullable=False)
-    api_calls_today = Column(Integer, default=0, nullable=False)
-    last_reset = Column(DateTime, default=datetime.utcnow, nullable=False)
+    id: Mapped[int] = mapped_column(primary_key=True, index=True)
+    email: Mapped[str] = mapped_column(String, unique=True, index=True, nullable=False)
+    username: Mapped[str] = mapped_column(String, nullable=False)
+    hashed_password: Mapped[str] = mapped_column(String, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
+    subscription_level: Mapped[str] = mapped_column(String, default="free", nullable=False)
+    api_calls_today: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+    last_reset: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
+
+    alerts: Mapped[list["Alert"]] = relationship(
+        "Alert", back_populates="user", cascade="all, delete-orphan"
+    )
+    sessions: Mapped[list["Session"]] = relationship(
+        "Session", back_populates="user", cascade="all, delete-orphan"
+    )
 
     def verify_password(self, password: str) -> bool:
         """Verificar si la contraseña coincide."""

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,3 +9,4 @@ PyJWT==2.8.0
 passlib[bcrypt]==1.7.4
 SQLAlchemy==2.0.23
 psycopg2-binary==2.9.9
+alembic==1.13.1

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -84,6 +84,7 @@ async def login(credentials: dict):
             raise HTTPException(status_code=401, detail=str(exc)) from exc
 
         token = create_jwt_token(user)
+        user_service.create_session(user_id=user.id, token=token, expires_in=timedelta(hours=24))
 
         return {
             "message": "Login exitoso",
@@ -95,7 +96,7 @@ async def login(credentials: dict):
         raise HTTPException(status_code=400, detail="Email y password requeridos")
 
 
-@router.get("/users/me")
+@router.get("/me")
 async def get_current_user(token: HTTPAuthorizationCredentials = Depends(security)):
     """Obtener información del usuario actual"""
     try:
@@ -105,6 +106,8 @@ async def get_current_user(token: HTTPAuthorizationCredentials = Depends(securit
         user = user_service.get_user_by_email(email)
         if not user:
             raise HTTPException(status_code=404, detail="Usuario no encontrado")
+
+        user_service.register_session_activity(token.credentials)
 
         return serialize_user(user)
 


### PR DESCRIPTION
## Summary
- initialize Alembic under `backend/alembic` with PostgreSQL-aware configuration and add the first migration for users, alerts and sessions tables
- add persistent SQLAlchemy models for alerts and sessions while updating the shared base and user model exports
- require a PostgreSQL `DATABASE_URL`, record login sessions, and document the new Alembic workflow

## Testing
- `DATABASE_URL=postgresql://user:pass@localhost:5432/test pytest backend/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68d0b4137e248321b1da4280e343e82e