### PR TITLE
Add dedicated routers for markets, news, and alerts

### DIFF
--- a/backend/routers/alerts.py
+++ b/backend/routers/alerts.py
@@ -1,0 +1,146 @@
+"""User alert management routes."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+from typing import Any, Literal, Optional, List
+
+import jwt
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from pydantic import BaseModel, Field, validator
+
+USER_SERVICE_ERROR: Optional[Exception] = None
+
+try:  # pragma: no cover - allow running from different entrypoints
+    from models import Alert, User
+    from services.user_service import UserNotFoundError, user_service
+    from utils.config import Config
+except RuntimeError as exc:  # pragma: no cover - missing configuration
+    from models import Alert, User  # type: ignore
+    from utils.config import Config  # type: ignore
+
+    user_service = None  # type: ignore[assignment]
+    UserNotFoundError = RuntimeError  # type: ignore[assignment]
+    USER_SERVICE_ERROR = exc
+except ImportError:  # pragma: no cover - fallback for package-based imports
+    from backend.models import Alert, User  # type: ignore
+    from backend.utils.config import Config  # type: ignore
+
+    try:
+        from backend.services.user_service import (  # type: ignore
+            UserNotFoundError,
+            user_service,
+        )
+    except RuntimeError as exc:  # pragma: no cover - missing configuration
+        user_service = None  # type: ignore[assignment]
+        UserNotFoundError = RuntimeError  # type: ignore[assignment]
+        USER_SERVICE_ERROR = exc
+
+router = APIRouter(prefix="/alerts", tags=["Alerts"])
+security = HTTPBearer()
+
+SECRET_KEY = Config.JWT_SECRET_KEY
+ALGORITHM = Config.JWT_ALGORITHM
+
+
+class AlertCreate(BaseModel):
+    asset: str = Field(..., min_length=1, max_length=50)
+    value: float = Field(..., description="Precio objetivo de la alerta")
+    condition: Literal["above", "below", "equal"] = Field(
+        "above", description="Condición de activación"
+    )
+
+    @validator("asset")
+    def _strip_asset(cls, value: str) -> str:
+        cleaned = value.strip()
+        if not cleaned:
+            raise ValueError("El símbolo del activo es obligatorio")
+        return cleaned.upper()
+
+
+class AlertResponse(BaseModel):
+    id: int
+    asset: str
+    condition: str
+    value: float
+    created_at: datetime
+    updated_at: datetime
+
+    @classmethod
+    def from_model(cls, alert: Alert) -> "AlertResponse":
+        return cls(
+            id=alert.id,
+            asset=alert.asset,
+            condition=alert.condition,
+            value=alert.value,
+            created_at=alert.created_at,
+            updated_at=alert.updated_at,
+        )
+
+
+def _ensure_user_service_available() -> None:
+    if user_service is None:
+        detail = "Servicio de usuarios no disponible"
+        if USER_SERVICE_ERROR is not None:
+            detail = f"{detail}. {USER_SERVICE_ERROR}"
+        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=detail)
+
+
+async def get_current_user(
+    credentials: HTTPAuthorizationCredentials = Depends(security),
+) -> User:
+    _ensure_user_service_available()
+
+    try:
+        payload: dict[str, Any] = jwt.decode(
+            credentials.credentials, SECRET_KEY, algorithms=[ALGORITHM]
+        )
+    except jwt.ExpiredSignatureError as exc:  # pragma: no cover - depends on runtime
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Token expirado") from exc
+    except jwt.InvalidTokenError as exc:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Token inválido") from exc
+
+    email = payload.get("sub")
+    user_id = payload.get("user_id")
+    if not email or not user_id:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Token inválido")
+
+    user = await asyncio.to_thread(user_service.get_user_by_email, email)
+    if not user or user.id != user_id:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Usuario no encontrado")
+
+    return user
+
+
+@router.get("", response_model=List[AlertResponse])
+async def list_alerts(current_user: User = Depends(get_current_user)) -> List[AlertResponse]:
+    """List alerts for the authenticated user."""
+
+    _ensure_user_service_available()
+
+    alerts = await asyncio.to_thread(user_service.get_alerts_for_user, current_user.id)
+    return [AlertResponse.from_model(alert) for alert in alerts]
+
+
+@router.post("", response_model=AlertResponse, status_code=status.HTTP_201_CREATED)
+async def create_alert(
+    alert_in: AlertCreate, current_user: User = Depends(get_current_user)
+) -> AlertResponse:
+    """Create a new alert associated with the authenticated user."""
+
+    _ensure_user_service_available()
+
+    try:
+        alert = await asyncio.to_thread(
+            user_service.create_alert,
+            current_user.id,
+            asset=alert_in.asset,
+            value=alert_in.value,
+            condition=alert_in.condition,
+        )
+    except UserNotFoundError as exc:  # pragma: no cover - defensive safety
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+
+    return AlertResponse.from_model(alert)

--- a/backend/routers/markets.py
+++ b/backend/routers/markets.py
@@ -1,0 +1,113 @@
+"""Market-related API routes."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from fastapi import APIRouter, HTTPException
+
+try:  # pragma: no cover - allow running from different entrypoints
+    from services.market_service import market_service
+    from services.forex_service import forex_service
+except ImportError:  # pragma: no cover - fallback for package-based imports
+    from backend.services.market_service import market_service  # type: ignore
+    from backend.services.forex_service import forex_service  # type: ignore
+
+router = APIRouter(tags=["Markets"])
+
+
+@router.get("/crypto/{symbol}")
+async def get_crypto(symbol: str) -> Dict[str, Any]:
+    """Retrieve crypto pricing information ensuring service fallback order."""
+
+    try:
+        primary_price = await market_service.crypto_service.get_price(symbol)
+    except Exception as exc:  # pragma: no cover - defensive logging happens in the service
+        raise HTTPException(
+            status_code=502,
+            detail=f"Error obteniendo precio de {symbol}: {exc}",
+        ) from exc
+
+    binance_data: Optional[Dict[str, Any]] = await market_service.get_binance_price(symbol)
+
+    price: Optional[float] = primary_price if primary_price is not None else None
+    if price is None and binance_data:
+        try:
+            price = float(binance_data.get("price")) if binance_data.get("price") is not None else None
+        except (TypeError, ValueError):
+            price = None
+
+    if price is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"No se encontró información para {symbol}",
+        )
+
+    response: Dict[str, Any] = {
+        "symbol": symbol.upper(),
+        "type": "crypto",
+        "price": float(price),
+        "source": "CryptoService" if primary_price is not None else None,
+    }
+
+    if binance_data:
+        response.update(
+            {
+                "raw_change": binance_data.get("change"),
+                "high": binance_data.get("high"),
+                "low": binance_data.get("low"),
+                "volume": binance_data.get("volume"),
+            }
+        )
+        binance_source = binance_data.get("source")
+        if response["source"] and binance_source:
+            response["source"] = f"{response['source']} + {binance_source}"
+        elif response["source"] is None:
+            response["source"] = binance_source
+
+    if response["source"] is None:
+        response["source"] = "CryptoService"
+
+    return response
+
+
+@router.get("/stock/{symbol}")
+async def get_stock(symbol: str) -> Dict[str, Any]:
+    """Retrieve stock pricing information delegating to the StockService cascade."""
+
+    try:
+        result = await market_service.get_stock_price(symbol)
+    except Exception as exc:  # pragma: no cover - defensive logging happens in the service
+        raise HTTPException(
+            status_code=502,
+            detail=f"Error obteniendo precio de {symbol}: {exc}",
+        ) from exc
+
+    if not result or result.get("price") is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"No se encontró información para {symbol}",
+        )
+
+    return result
+
+
+@router.get("/forex/{pair}")
+async def get_forex(pair: str) -> Dict[str, Any]:
+    """Retrieve forex quote information honouring the configured fallback chain."""
+
+    try:
+        result = await forex_service.get_quote(pair)
+    except Exception as exc:  # pragma: no cover - defensive logging happens in the service
+        raise HTTPException(
+            status_code=502,
+            detail=f"Error obteniendo FX {pair}: {exc}",
+        ) from exc
+
+    if not result or result.get("price") is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"No se encontró información para {pair}",
+        )
+
+    return result

--- a/backend/routers/news.py
+++ b/backend/routers/news.py
@@ -1,0 +1,48 @@
+"""News-related API routes."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from fastapi import APIRouter, HTTPException
+
+try:  # pragma: no cover - allow running from different entrypoints
+    from services.market_service import market_service
+except ImportError:  # pragma: no cover - fallback for package-based imports
+    from backend.services.market_service import market_service  # type: ignore
+
+router = APIRouter(prefix="/news", tags=["News"])
+
+
+async def _get_news(category: str, limit: int) -> List[Dict[str, Any]]:
+    try:
+        articles = await market_service.get_news(category, limit=limit)
+    except Exception as exc:  # pragma: no cover - defensive logging happens in the service
+        raise HTTPException(
+            status_code=502,
+            detail=f"Error obteniendo noticias de {category}: {exc}",
+        ) from exc
+
+    if not articles:
+        raise HTTPException(
+            status_code=404,
+            detail=f"No hay noticias disponibles para {category}",
+        )
+
+    return articles
+
+
+@router.get("/crypto")
+async def get_crypto_news(limit: int = 10) -> Dict[str, Any]:
+    """Return crypto-related news articles following the configured fallbacks."""
+
+    articles = await _get_news("crypto", limit)
+    return {"category": "crypto", "articles": articles}
+
+
+@router.get("/finance")
+async def get_finance_news(limit: int = 10) -> Dict[str, Any]:
+    """Return finance news articles following the configured fallbacks."""
+
+    articles = await _get_news("finance", limit)
+    return {"category": "finance", "articles": articles}


### PR DESCRIPTION
## Summary
- add market, news, and alerts routers that delegate to the appropriate services and enforce fallbacks and auth requirements
- refactor the FastAPI app to include the new routers and expose shared service instances for compatibility

## Testing
- pytest backend/tests

------
https://chatgpt.com/codex/tasks/task_e_68d1abc7681c8321a7a3dede33d84245