### PR TITLE
Add realtime crypto watchlist and alert management

### DIFF
--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -248,7 +248,7 @@ body {
     gap: 0.5rem;
 }
 
-.watchlist-items, .ticker-list {
+.watchlist-items, .ticker-list, .alerts-list {
     display: flex;
     flex-direction: column;
     gap: 0.75rem;
@@ -302,6 +302,58 @@ body {
 .item-change.negative, .negative {
     background: rgba(239, 68, 68, 0.2);
     color: #f87171;
+}
+
+.alerts-list {
+    max-height: 250px;
+    overflow-y: auto;
+    padding-right: 0.25rem;
+}
+
+.alert-list-item {
+    background: rgba(255, 255, 255, 0.05);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: var(--radius-lg);
+    padding: 0.85rem 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.alert-list-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.alert-asset {
+    font-weight: 700;
+    color: #fff;
+}
+
+.alert-condition {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.8rem;
+    color: rgba(255, 255, 255, 0.85);
+}
+
+.alert-list-meta {
+    font-size: 0.75rem;
+    color: rgba(255, 255, 255, 0.6);
+}
+
+.form-error,
+.error-text {
+    color: #f87171;
+    font-size: 0.8rem;
+    margin-top: 0.5rem;
+}
+
+.info-text,
+.empty-state {
+    font-size: 0.85rem;
+    color: rgba(255, 255, 255, 0.7);
+    padding: 0.5rem 0;
 }
 
 .sidebar-btn, .quick-btn {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -127,6 +127,13 @@
             </div>
 
             <div class="sidebar-section">
+                <h3><i class="fas fa-bell"></i> Alertas Activas</h3>
+                <div class="alerts-list" id="alertsList">
+                    <div class="empty-state">Cargando alertas...</div>
+                </div>
+            </div>
+
+            <div class="sidebar-section">
                 <h3><i class="fas fa-fire"></i> Top Performers</h3>
                 <div class="ticker-list" id="topTickers">
                     <div class="loading-text">Cargando datos en tiempo real...</div>
@@ -266,6 +273,7 @@
                     <label>Valor</label>
                     <input type="number" id="alertValue" placeholder="0.00" step="0.01" />
                 </div>
+                <div class="form-error" id="alertFormError" style="display: none;"></div>
             </div>
             <div class="modal-footer">
                 <button class="btn-secondary" onclick="closeModal('alertModal')">Cancelar</button>


### PR DESCRIPTION
## Summary
- pull realtime BTC/ETH pricing from the /crypto endpoint, emit dedicated watchlist updates, and forward alert payloads from the market-data WebSocket
- render watchlist updates in the sidebar, manage alert CRUD workflows, and surface realtime alert notifications with defensive error handling
- surface active alerts in the dashboard UI and add styling/validation feedback for the alert modal

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1b3dab9a08321a8a4ebc7861e5f7e