### PR TITLE
Use UUID identifiers for users, sessions, and alerts

### DIFF
--- a/backend/models/alert.py
+++ b/backend/models/alert.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 from datetime import datetime
+import uuid
 
 from sqlalchemy import DateTime, Float, ForeignKey, String
+from sqlalchemy.dialects.postgresql import UUID as PGUUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 try:  # pragma: no cover - compatibilidad con distintos puntos de entrada
@@ -16,8 +18,12 @@ class Alert(Base):
 
     __tablename__ = "alerts"
 
-    id: Mapped[int] = mapped_column(primary_key=True)
-    user_id: Mapped[int] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
+    id: Mapped[uuid.UUID] = mapped_column(
+        PGUUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        PGUUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+    )
     asset: Mapped[str] = mapped_column(String(50), nullable=False)
     condition: Mapped[str] = mapped_column(String(20), default="above", nullable=False)
     value: Mapped[float] = mapped_column(Float, nullable=False)

--- a/backend/models/session.py
+++ b/backend/models/session.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 from datetime import datetime
+import uuid
 
 from sqlalchemy import DateTime, ForeignKey, String
+from sqlalchemy.dialects.postgresql import UUID as PGUUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 try:  # pragma: no cover
@@ -16,8 +18,12 @@ class Session(Base):
 
     __tablename__ = "sessions"
 
-    id: Mapped[int] = mapped_column(primary_key=True)
-    user_id: Mapped[int] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
+    id: Mapped[uuid.UUID] = mapped_column(
+        PGUUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        PGUUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+    )
     token: Mapped[str] = mapped_column(String, unique=True, nullable=False)
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
     expires_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)

--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 from datetime import datetime
+import uuid
 
-from sqlalchemy import DateTime, Integer, String
+from sqlalchemy import DateTime, String
+from sqlalchemy.dialects.postgresql import UUID as PGUUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 try:  # pragma: no cover
@@ -21,7 +23,9 @@ class User(Base):
 
     __tablename__ = "users"
 
-    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    id: Mapped[uuid.UUID] = mapped_column(
+        PGUUID(as_uuid=True), primary_key=True, index=True, default=uuid.uuid4
+    )
     email: Mapped[str] = mapped_column(String, unique=True, index=True, nullable=False)
     password_hash: Mapped[str] = mapped_column(String, nullable=False)
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
@@ -43,7 +47,7 @@ class User(Base):
     def to_dict(self) -> dict:
         """Representación serializable del usuario."""
         return {
-            "id": self.id,
+            "id": str(self.id) if self.id else None,
             "email": self.email,
             "created_at": self.created_at.isoformat() if self.created_at else None,
             "updated_at": self.updated_at.isoformat() if self.updated_at else None,

--- a/backend/services/user_service.py
+++ b/backend/services/user_service.py
@@ -4,6 +4,7 @@ import os
 from contextlib import contextmanager
 from datetime import datetime, timedelta
 from typing import Iterable, Optional
+from uuid import UUID
 
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session as OrmSession, sessionmaker, selectinload
@@ -102,7 +103,7 @@ class UserService:
         return user
 
     def create_session(
-        self, user_id: int, token: str, expires_in: timedelta | None = None
+        self, user_id: UUID, token: str, expires_in: timedelta | None = None
     ) -> SessionModel:
         expires_at: datetime | None = None
         if expires_in is not None:
@@ -121,7 +122,7 @@ class UserService:
             session.add(session_obj)
             return self._detach_entity(session, session_obj)
 
-    def get_active_sessions(self, user_id: int) -> list[SessionModel]:
+    def get_active_sessions(self, user_id: UUID) -> list[SessionModel]:
         with self._session_scope() as session:
             now = datetime.utcnow()
             sessions = (
@@ -143,7 +144,7 @@ class UserService:
 
     def create_alert(
         self,
-        user_id: int,
+        user_id: UUID,
         *,
         asset: str,
         value: float,
@@ -162,7 +163,7 @@ class UserService:
             session.add(alert)
             return self._detach_entity(session, alert)
 
-    def get_alerts_for_user(self, user_id: int) -> list[Alert]:
+    def get_alerts_for_user(self, user_id: UUID) -> list[Alert]:
         with self._session_scope() as session:
             alerts = session.query(Alert).filter(Alert.user_id == user_id).all()
             for alert in alerts:


### PR DESCRIPTION
## Summary
- move user, session, and alert SQLAlchemy models to PostgreSQL UUID primary keys and relationships
- update authentication and alert routers plus user service to pass UUID identifiers through JWTs and service calls
- refresh API tests and dummy services to work with UUID-based identifiers

## Testing
- pytest backend/tests


------
https://chatgpt.com/codex/tasks/task_e_68d1d8c7bc808321a16cdcddd4fb50e3