### PR TITLE
Add __MACOSX ignore entry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .DS_Store
 .AppleDouble
 .LSOverride
+__MACOSX/
 
 # Python
 __pycache__/


### PR DESCRIPTION
## Summary
- add __MACOSX directory to macOS section of .gitignore to prevent committing macOS archive metadata

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d1dbed54a48321a2d8ae75e35608ba