### PR TITLE
docs: actualizar guia de despliegue y ejemplos API

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,48 +12,64 @@
 
 ### Variables de entorno
 
-Crea un archivo `.env` en la raíz del proyecto con las variables necesarias para la API. Puedes usar el siguiente ejemplo como punto de partida:
+Crea un archivo `.env` en la raíz del proyecto para compartirlo entre el backend y el worker de alertas. Como referencia mínima:
 
 ```env
-# Seguridad JWT
+# Autenticación y sesiones
 BULLBEARBROKER_SECRET_KEY="coloca_aquí_una_clave_aleatoria_segura"
 # BULLBEARBROKER_JWT_ALGORITHM="HS256"  # opcional
 
-# Credenciales para la base de datos (opcional si usas docker-compose por defecto)
-# POSTGRES_USER=bullbear
-# POSTGRES_PASSWORD=bullbear
-# POSTGRES_DB=bullbear
+# Base de datos (Supabase)
+DATABASE_URL="postgresql://usuario:password@db.<proyecto>.supabase.co:5432/postgres?sslmode=require"
 
-# Claves para servicios externos (todas opcionales)
-# ALPHA_VANTAGE_API_KEY=
-# TWELVEDATA_API_KEY=
-# HUGGINGFACE_API_TOKEN=
-# HUGGINGFACE_SENTIMENT_MODEL=distilbert-base-uncased-finetuned-sst-2-english
-# COINGECKO_API_KEY=
-# COINMARKETCAP_API_KEY=
-# NEWSAPI_API_KEY=
-# CRYPTOPANIC_API_KEY=
-# FINFEED_API_KEY=
-# MEDIASTACK_API_KEY=
-# TELEGRAM_BOT_TOKEN=
-# TELEGRAM_DEFAULT_CHAT_ID=
+# Servicios internos
+REDIS_URL="redis://redis:6379/0"
+
+# Claves para proveedores externos (habilitan funcionalidades avanzadas)
+ALPHA_VANTAGE_API_KEY=
+TWELVEDATA_API_KEY=
+COINGECKO_API_KEY=
+COINMARKETCAP_API_KEY=
+NEWSAPI_API_KEY=
+CRYPTOPANIC_API_KEY=
+FINFEED_API_KEY=
+MEDIASTACK_API_KEY=
+HUGGINGFACE_API_TOKEN=
+HUGGINGFACE_SENTIMENT_MODEL="distilbert-base-uncased-finetuned-sst-2-english"
+MISTRAL_API_KEY=
+TELEGRAM_BOT_TOKEN=
+TELEGRAM_DEFAULT_CHAT_ID=
+# Variables opcionales para inferencia local
+# OLLAMA_HOST=http://localhost:11434
+# OLLAMA_MODEL=llama3
 ```
 
 > 💡 Genera una clave segura ejecutando `python -c "import secrets; print(secrets.token_urlsafe(64))"`.
 
-Si la variable `BULLBEARBROKER_SECRET_KEY` no está definida, el backend creará una clave aleatoria en cada arranque, lo que invalida cualquier token emitido previamente.
+Si `BULLBEARBROKER_SECRET_KEY` no está definida, el backend generará una clave aleatoria en cada arranque y se invalidarán los tokens previos.
+
+#### Variables destacadas
+
+- **DATABASE_URL**: Debe apuntar al clúster de Supabase (PostgreSQL gestionado). El formato recomendado es el que proporciona Supabase con `sslmode=require` para garantizar conexiones seguras.
+- **Backend y alert-worker**: requieren `BULLBEARBROKER_SECRET_KEY`, `DATABASE_URL` y `REDIS_URL` para operar.
+- **Mercados**: `ALPHA_VANTAGE_API_KEY`, `TWELVEDATA_API_KEY`, `COINGECKO_API_KEY` y `COINMARKETCAP_API_KEY` habilitan los distintos proveedores de precios.
+- **Noticias**: `NEWSAPI_API_KEY`, `CRYPTOPANIC_API_KEY`, `FINFEED_API_KEY` y `MEDIASTACK_API_KEY` enriquecen los listados.
+- **IA y notificaciones**: `HUGGINGFACE_API_TOKEN`, `HUGGINGFACE_SENTIMENT_MODEL`, `MISTRAL_API_KEY`, `TELEGRAM_BOT_TOKEN` y `TELEGRAM_DEFAULT_CHAT_ID` son usados por los servicios de sentimiento, generación y alertas.
 
 ### Ejecución con Docker Compose
 
-1. Construye e inicia los servicios (backend, PostgreSQL y Redis):
+1. Construye e inicia los servicios (`backend`, `alert-worker`, `redis` y `frontend`):
 
    ```bash
    docker compose up --build
    ```
 
-   El backend quedará disponible en [http://localhost:8000](http://localhost:8000).
-   El servicio `alert-worker` se levanta en paralelo para evaluar alertas con APScheduler
-   y enviar notificaciones en segundo plano.
+   - El backend expone la API en [http://localhost:8000](http://localhost:8000).
+   - El `alert-worker` comparte la imagen del backend y procesa alertas en segundo plano.
+   - `redis` actúa como broker para colas y caché.
+   - El `frontend` estático queda disponible en [http://localhost:3000](http://localhost:3000).
+
+   > ℹ️ Ambos servicios de Python leerán `DATABASE_URL` desde `.env` para conectarse al PostgreSQL gestionado por Supabase. No se despliega una base de datos local en este `docker-compose`.
 
 2. Cuando termines, detén los servicios con:
 
@@ -81,7 +97,75 @@ El backend utiliza [Alembic](https://alembic.sqlalchemy.org/) para gestionar los
 docker compose run --rm backend alembic upgrade head
 ```
 
-> Si ejecutas el backend fuera de Docker, asegúrate de tener la variable `DATABASE_URL` apuntando a tu instancia de PostgreSQL antes de lanzar `alembic upgrade head`.
+> Si ejecutas el backend fuera de Docker, asegúrate de que `DATABASE_URL` apunte al clúster de Supabase (o a la instancia de PostgreSQL equivalente) antes de lanzar `alembic upgrade head`.
+
+#### Ejemplos de llamadas HTTP
+
+A continuación se muestran ejemplos rápidos usando `curl` con la API levantada en `http://localhost:8000`:
+
+- Registro de usuario:
+
+  ```bash
+  curl -X POST http://localhost:8000/api/auth/register \
+    -H "Content-Type: application/json" \
+    -d '{"email":"alice@example.com","password":"secreto123"}'
+  ```
+
+  Respuesta abreviada:
+
+  ```json
+  {
+    "message": "Usuario registrado exitosamente",
+    "token": "<jwt>",
+    "user": { "id": "...", "email": "alice@example.com" }
+  }
+  ```
+
+- Precio de Bitcoin:
+
+  ```bash
+  curl http://localhost:8000/crypto/BTC
+  ```
+
+  ```json
+  {
+    "symbol": "BTC",
+    "type": "crypto",
+    "price": 62000.42,
+    "source": "CryptoService + Binance"
+  }
+  ```
+
+- Precio de la acción de Apple:
+
+  ```bash
+  curl http://localhost:8000/stock/AAPL
+  ```
+
+- Cotización EUR/USD:
+
+  ```bash
+  curl http://localhost:8000/forex/EURUSD
+  ```
+
+- Noticias de criptomonedas:
+
+  ```bash
+  curl http://localhost:8000/news/crypto
+  ```
+
+- Listado de alertas (requiere token JWT):
+
+  ```bash
+  curl http://localhost:8000/alerts \
+    -H "Authorization: Bearer <jwt>"
+  ```
+
+  ```json
+  [
+    { "id": "...", "asset": "BTC", "condition": "above", "value": 65000.0 }
+  ]
+  ```
 
 ### Desarrollo sin Docker
 
@@ -96,7 +180,7 @@ Detén cada proceso con `Ctrl+C` cuando termines.
 ### Nuevas capacidades del mercado
 
 - **Pares FX y materias primas**: `forex_service` reutiliza Twelve Data y Yahoo Finance
-  con caché en memoria para entregar cotizaciones rápidas a través de `/api/forex/{symbol}`.
+  con caché en memoria para entregar cotizaciones rápidas a través de `/forex/{pair}`.
 - **Sentimiento de mercado**: `sentiment_service` fusiona el índice Fear & Greed de Alternative.me
   con análisis de sentimiento de HuggingFace disponible en `/api/market/sentiment/{symbol}`.
 - **Gráficos dinámicos**: la ruta `/api/market/chart/{symbol}` genera imágenes PNG en base64


### PR DESCRIPTION
## Summary
- actualizar la guía de variables de entorno resaltando la conexión a Supabase y las claves por servicio
- detallar los servicios reales levantados por docker-compose y su relación con la base de datos externa
- añadir ejemplos de llamadas HTTP para autenticación, mercados, noticias y alertas

## Testing
- no tests were run

------
https://chatgpt.com/codex/tasks/task_e_68d1dcb430f88321a2305a7d2d9d5656