### PR TITLE
Add migration for alerts updated_at column

### DIFF
--- a/backend/alembic/versions/0002_add_updated_at_to_alerts.py
+++ b/backend/alembic/versions/0002_add_updated_at_to_alerts.py
@@ -1,0 +1,29 @@
+"""add updated_at column to alerts"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0002_add_updated_at_to_alerts"
+down_revision = "0001_initial_schema"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "alerts",
+        sa.Column(
+            "updated_at",
+            sa.DateTime(),
+            server_default=sa.func.now(),
+            server_onupdate=sa.func.now(),
+            nullable=False,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("alerts", "updated_at")

--- a/backend/tests/test_api_endpoints.py
+++ b/backend/tests/test_api_endpoints.py
@@ -474,6 +474,9 @@ def test_alert_workflow_triggers_notification(
         headers=headers,
     )
     assert response.status_code == 201
+    created_payload = response.json()
+    assert "updated_at" in created_payload
+    assert created_payload["updated_at"]
 
     user_id = uuid.UUID(register.json()["user"]["id"])
     created_alert = dummy_user_service.get_alerts_for_user(user_id)[0]
@@ -516,6 +519,9 @@ def test_alerts_list_returns_created_alert(
         headers=headers,
     )
     assert create.status_code == 201
+    created_alert = create.json()
+    assert "updated_at" in created_alert
+    assert created_alert["updated_at"]
 
     listing = client.get("/alerts", headers=headers)
     assert listing.status_code == 200
@@ -523,3 +529,5 @@ def test_alerts_list_returns_created_alert(
     assert len(alerts) == 1
     assert alerts[0]["asset"] == "ETH"
     assert alerts[0]["condition"] == "below"
+    assert "updated_at" in alerts[0]
+    assert alerts[0]["updated_at"]


### PR DESCRIPTION
## Summary
- add an Alembic migration that introduces the alerts.updated_at column with server defaults matching the model
- extend alert API endpoint tests to ensure updated_at is returned in creation and listing responses

## Testing
- pytest backend/tests/test_api_endpoints.py -k alerts -q
- alembic upgrade head *(fails: ModuleNotFoundError: No module named 'psycopg')*

------
https://chatgpt.com/codex/tasks/task_e_68d1e4674aa883219edb15048f940c22