### PR TITLE
Allow alert operators and update tests

### DIFF
--- a/backend/models/alert.py
+++ b/backend/models/alert.py
@@ -25,7 +25,7 @@ class Alert(Base):
         PGUUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), nullable=False
     )
     asset: Mapped[str] = mapped_column(String(50), nullable=False)
-    condition: Mapped[str] = mapped_column(String(20), default="above", nullable=False)
+    condition: Mapped[str] = mapped_column(String(20), default=">", nullable=False)
     value: Mapped[float] = mapped_column(Float, nullable=False)
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
     updated_at: Mapped[datetime] = mapped_column(

--- a/backend/routers/alerts.py
+++ b/backend/routers/alerts.py
@@ -49,8 +49,8 @@ ALGORITHM = Config.JWT_ALGORITHM
 class AlertCreate(BaseModel):
     asset: str = Field(..., min_length=1, max_length=50)
     value: float = Field(..., description="Precio objetivo de la alerta")
-    condition: Literal["above", "below", "equal"] = Field(
-        "above", description="Condición de activación"
+    condition: Literal["<", ">", "=="] = Field(
+        ">", description="Condición de activación"
     )
 
     @validator("asset")

--- a/backend/services/alert_service.py
+++ b/backend/services/alert_service.py
@@ -142,12 +142,12 @@ class AlertService:
 
     @staticmethod
     def _should_trigger(alert: Alert, price: float) -> bool:
-        condition = (alert.condition or "above").lower()
-        if condition == "above":
+        condition = alert.condition or ">"
+        if condition in (">", "above"):
             return price >= alert.value
-        if condition == "below":
+        if condition in ("<", "below"):
             return price <= alert.value
-        if condition == "equal":
+        if condition in ("==", "equal"):
             return abs(price - alert.value) <= 1e-6
         return False
 

--- a/backend/services/user_service.py
+++ b/backend/services/user_service.py
@@ -148,7 +148,7 @@ class UserService:
         *,
         asset: str,
         value: float,
-        condition: str = "above",
+        condition: str = ">",
     ) -> Alert:
         with self._session_scope() as session:
             if not session.get(User, user_id):

--- a/backend/tests/test_alert_service.py
+++ b/backend/tests/test_alert_service.py
@@ -14,7 +14,7 @@ def test_alert_service_triggers_notification():
     alert = SimpleNamespace(
         id=1,
         asset="AAPL",
-        condition="above",
+        condition=">",
         value=100.0,
     )
 
@@ -41,9 +41,9 @@ def test_alert_service_triggers_notification():
 def test_alert_service_should_trigger_conditions():
     service = AlertService(session_factory=None)
 
-    alert_above = SimpleNamespace(condition="above", value=10.0)
-    alert_below = SimpleNamespace(condition="below", value=10.0)
-    alert_equal = SimpleNamespace(condition="equal", value=10.0)
+    alert_above = SimpleNamespace(condition=">", value=10.0)
+    alert_below = SimpleNamespace(condition="<", value=10.0)
+    alert_equal = SimpleNamespace(condition="==", value=10.0)
 
     assert service._should_trigger(alert_above, 10.0) is True
     assert service._should_trigger(alert_below, 9.5) is True

--- a/backend/tests/test_api_endpoints.py
+++ b/backend/tests/test_api_endpoints.py
@@ -470,11 +470,12 @@ def test_alert_workflow_triggers_notification(
     headers = {"Authorization": f"Bearer {token}"}
     response = client.post(
         "/alerts",
-        json={"asset": "AAPL", "value": 100.0, "condition": "above"},
+        json={"asset": "AAPL", "value": 120.0, "condition": "=="},
         headers=headers,
     )
     assert response.status_code == 201
     created_payload = response.json()
+    assert created_payload["condition"] == "=="
     assert "updated_at" in created_payload
     assert created_payload["updated_at"]
 
@@ -515,7 +516,7 @@ def test_alerts_list_returns_created_alert(
 
     create = client.post(
         "/alerts",
-        json={"asset": "ETH", "value": 1500.0, "condition": "below"},
+        json={"asset": "ETH", "value": 1500.0, "condition": "<"},
         headers=headers,
     )
     assert create.status_code == 201
@@ -528,6 +529,6 @@ def test_alerts_list_returns_created_alert(
     alerts = listing.json()
     assert len(alerts) == 1
     assert alerts[0]["asset"] == "ETH"
-    assert alerts[0]["condition"] == "below"
+    assert alerts[0]["condition"] == "<"
     assert "updated_at" in alerts[0]
     assert alerts[0]["updated_at"]


### PR DESCRIPTION
## Summary
- allow creating alerts with comparison operators `<`, `>` and `==`
- persist the selected operator unchanged in the database and service defaults
- extend alert evaluation logic and backend tests to cover the new operators

## Testing
- pytest backend/tests

------
https://chatgpt.com/codex/tasks/task_e_68d1e554afcc8321bfac5aa5ecf3534c