### PR TITLE
Add session expiration to auth login response

### DIFF
--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -84,12 +84,15 @@ async def login(credentials: dict):
             raise HTTPException(status_code=401, detail=str(exc)) from exc
 
         token = create_jwt_token(user)
-        user_service.create_session(user_id=user.id, token=token, expires_in=timedelta(hours=24))
+        session = user_service.create_session(
+            user_id=user.id, token=token, expires_in=timedelta(hours=24)
+        )
 
         return {
             "message": "Login exitoso",
             "token": token,
             "user": serialize_user(user),
+            "expires_at": session.expires_at.isoformat(),
         }
 
     except KeyError:

--- a/backend/services/user_service.py
+++ b/backend/services/user_service.py
@@ -105,9 +105,10 @@ class UserService:
     def create_session(
         self, user_id: UUID, token: str, expires_in: timedelta | None = None
     ) -> SessionModel:
-        expires_at: datetime | None = None
-        if expires_in is not None:
-            expires_at = datetime.utcnow() + expires_in
+        if expires_in is None:
+            expires_in = timedelta(hours=24)
+
+        expires_at = datetime.utcnow() + expires_in
 
         with self._session_scope() as session:
             user = session.get(User, user_id)

--- a/backend/tests/test_api_endpoints.py
+++ b/backend/tests/test_api_endpoints.py
@@ -304,6 +304,12 @@ def test_login_returns_token_for_valid_credentials(
     payload = response.json()
     assert payload["user"]["email"] == "bob@example.com"
     assert isinstance(payload["token"], str)
+    assert "expires_at" in payload
+    assert isinstance(payload["expires_at"], str)
+    expires_at = datetime.fromisoformat(payload["expires_at"])
+    delta_seconds = (expires_at - datetime.utcnow()).total_seconds()
+    assert delta_seconds > 0
+    assert delta_seconds == pytest.approx(timedelta(hours=24).total_seconds(), rel=0.01)
 
 
 def test_login_rejects_invalid_credentials(


### PR DESCRIPTION
## Summary
- capture the created session during login so the API returns its expiration timestamp
- ensure user sessions always receive a 24-hour expiry by default in the service layer
- extend the login endpoint test to validate the expires_at field and its format

## Testing
- `cd backend && pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d1e7be315c8321afdf8b2e7a9a698a