### PR TITLE
Load environment variables for Alembic migrations

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -7,6 +7,7 @@ from alembic import context
 from sqlalchemy import engine_from_config, pool
 
 from models import Base
+from dotenv import load_dotenv
 
 # Alembic Config object
 config = context.config
@@ -14,6 +15,7 @@ config = context.config
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)
 
+load_dotenv()
 DATABASE_URL = os.getenv("DATABASE_URL")
 if not DATABASE_URL:
     raise RuntimeError("DATABASE_URL debe estar configurada para ejecutar migraciones")


### PR DESCRIPTION
## Summary
- import and invoke `load_dotenv` so Alembic picks up DATABASE_URL from .env files

## Testing
- alembic current

------
https://chatgpt.com/codex/tasks/task_e_68d1e89e2ac48321b96325526e487917