### PR TITLE
Enforce non-null session expiration timestamps

### DIFF
--- a/backend/alembic/versions/0003_make_session_expires_at_not_null.py
+++ b/backend/alembic/versions/0003_make_session_expires_at_not_null.py
@@ -1,0 +1,43 @@
+"""make session expires_at not nullable"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0003_make_session_expires_at_not_null"
+down_revision = "0002_add_updated_at_to_alerts"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        sa.text(
+            """
+            UPDATE sessions
+            SET expires_at = COALESCE(
+                expires_at,
+                created_at + INTERVAL '24 hours',
+                NOW() + INTERVAL '24 hours'
+            )
+            WHERE expires_at IS NULL
+            """
+        )
+    )
+    op.alter_column(
+        "sessions",
+        "expires_at",
+        existing_type=sa.DateTime(),
+        nullable=False,
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        "sessions",
+        "expires_at",
+        existing_type=sa.DateTime(),
+        nullable=True,
+    )

--- a/backend/models/session.py
+++ b/backend/models/session.py
@@ -26,6 +26,6 @@ class Session(Base):
     )
     token: Mapped[str] = mapped_column(String, unique=True, nullable=False)
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
-    expires_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    expires_at: Mapped[datetime] = mapped_column(DateTime, nullable=False)
 
     user: Mapped["User"] = relationship("User", back_populates="sessions")

--- a/backend/services/user_service.py
+++ b/backend/services/user_service.py
@@ -130,8 +130,7 @@ class UserService:
                 session.query(SessionModel)
                 .filter(
                     SessionModel.user_id == user_id,
-                    (SessionModel.expires_at.is_(None))
-                    | (SessionModel.expires_at > now),
+                    SessionModel.expires_at > now,
                 )
                 .all()
             )

--- a/backend/tests/test_api_endpoints.py
+++ b/backend/tests/test_api_endpoints.py
@@ -124,9 +124,10 @@ class DummyUserService:
     def create_session(
         self, user_id: uuid.UUID, token: str, expires_in: Optional[timedelta] = None
     ) -> SimpleNamespace:
-        expires_at = (
-            datetime.utcnow() + expires_in if expires_in is not None else None
-        )
+        if expires_in is None:
+            expires_in = timedelta(hours=24)
+
+        expires_at = datetime.utcnow() + expires_in
         session = SimpleNamespace(user_id=user_id, token=token, expires_at=expires_at)
         self._sessions.append(session)
         return session


### PR DESCRIPTION
## Summary
- require session records to persist a non-null expires_at value and ensure service queries only return non-expired sessions
- update API test double to always set an expiration when creating sessions
- add an Alembic migration that backfills missing expiry timestamps before making the column non-nullable

## Testing
- pytest backend/tests

------
https://chatgpt.com/codex/tasks/task_e_68d1ea5d716083219fe63c1d8ec54536