### PR TITLE
Integrate frontend with backend APIs and add tests

### DIFF
--- a/frontend/jest.setup.ts
+++ b/frontend/jest.setup.ts
@@ -1,1 +1,25 @@
 import "@testing-library/jest-dom";
+
+const mockRouter: {
+  push: jest.Mock;
+  replace: jest.Mock;
+  refresh: jest.Mock;
+  prefetch: jest.Mock;
+  back: jest.Mock;
+  forward: jest.Mock;
+} = {
+  push: jest.fn(),
+  replace: jest.fn(),
+  refresh: jest.fn(),
+  prefetch: jest.fn(),
+  back: jest.fn(),
+  forward: jest.fn()
+};
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => mockRouter
+}));
+
+beforeEach(() => {
+  Object.values(mockRouter).forEach((fn) => fn.mockClear());
+});

--- a/frontend/src/components/forms/__tests__/register-form.test.tsx
+++ b/frontend/src/components/forms/__tests__/register-form.test.tsx
@@ -1,0 +1,70 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import { RegisterForm } from "../register-form";
+
+const registerMock = jest.fn();
+
+jest.mock("@/components/providers/auth-provider", () => ({
+  useAuth: () => ({
+    register: registerMock
+  })
+}));
+
+describe("RegisterForm", () => {
+  beforeEach(() => {
+    registerMock.mockReset();
+  });
+
+  it("muestra error cuando las contraseñas no coinciden", async () => {
+    render(<RegisterForm />);
+
+    fireEvent.input(screen.getByLabelText(/correo electrónico/i), {
+      target: { value: "user@example.com" }
+    });
+
+    fireEvent.input(screen.getByLabelText(/^contraseña$/i), {
+      target: { value: "password" }
+    });
+
+    fireEvent.input(screen.getByLabelText(/confirmar contraseña/i), {
+      target: { value: "otra" }
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /registrarse/i }));
+
+    expect(
+      await screen.findByText(/las contraseñas no coinciden/i)
+    ).toBeInTheDocument();
+    expect(registerMock).not.toHaveBeenCalled();
+  });
+
+  it("envía los datos válidos", async () => {
+    render(<RegisterForm />);
+
+    fireEvent.input(screen.getByLabelText(/nombre/i), {
+      target: { value: "Jane" }
+    });
+
+    fireEvent.input(screen.getByLabelText(/correo electrónico/i), {
+      target: { value: "jane@example.com" }
+    });
+
+    fireEvent.input(screen.getByLabelText(/^contraseña$/i), {
+      target: { value: "password" }
+    });
+
+    fireEvent.input(screen.getByLabelText(/confirmar contraseña/i), {
+      target: { value: "password" }
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /registrarse/i }));
+
+    await waitFor(() => {
+      expect(registerMock).toHaveBeenCalledWith({
+        name: "Jane",
+        email: "jane@example.com",
+        password: "password"
+      });
+    });
+  });
+});

--- a/frontend/src/components/news/__tests__/news-panel.test.tsx
+++ b/frontend/src/components/news/__tests__/news-panel.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from "@testing-library/react";
+import useSWR from "swr";
+
+import { NewsPanel } from "../news-panel";
+
+jest.mock("swr", () => ({
+  __esModule: true,
+  default: jest.fn()
+}));
+
+const useSWRMock = useSWR as unknown as jest.Mock;
+
+describe("NewsPanel", () => {
+  beforeEach(() => {
+    useSWRMock.mockReturnValue({
+      data: [
+        {
+          id: 1,
+          title: "Mercados al alza",
+          url: "https://example.com/news",
+          source: "Ejemplo",
+          summary: "Resumen de prueba",
+          published_at: new Date("2024-01-01T00:00:00Z").toISOString()
+        }
+      ],
+      error: undefined,
+      isLoading: false
+    });
+  });
+
+  afterEach(() => {
+    useSWRMock.mockReset();
+  });
+
+  it("muestra las noticias recibidas", () => {
+    render(<NewsPanel token="token" />);
+
+    expect(screen.getByText(/mercados al alza/i)).toBeInTheDocument();
+    expect(screen.getByText(/ejemplo/i)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /leer noticia/i })).toHaveAttribute(
+      "href",
+      "https://example.com/news"
+    );
+  });
+});

--- a/frontend/src/components/sidebar/__tests__/market-sidebar.test.tsx
+++ b/frontend/src/components/sidebar/__tests__/market-sidebar.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from "@testing-library/react";
+import useSWR from "swr";
+
+import { MarketSidebar } from "../market-sidebar";
+
+jest.mock("swr", () => ({
+  __esModule: true,
+  default: jest.fn()
+}));
+
+const useSWRMock = useSWR as unknown as jest.Mock;
+
+describe("MarketSidebar", () => {
+  const user = { id: 1, email: "user@example.com" } as const;
+  const onLogout = jest.fn();
+
+  beforeEach(() => {
+    onLogout.mockReset();
+    useSWRMock.mockImplementation((key: unknown[]) => {
+      const [, type] = key as [string, "crypto" | "stocks" | "forex", string | undefined];
+      const mockData = {
+        crypto: [
+          { symbol: "BTC", price: 50000, change_24h: 2.5 },
+          { symbol: "ETH", price: 3000, change_24h: -1.2 }
+        ],
+        stocks: [{ symbol: "AAPL", price: 180.5, change_24h: 1.1 }],
+        forex: [{ symbol: "EUR/USD", price: 1.08, change_24h: 0.2 }]
+      } satisfies Record<"crypto" | "stocks" | "forex", unknown>;
+
+      return {
+        data: mockData[type],
+        error: undefined,
+        isLoading: false
+      };
+    });
+  });
+
+  afterEach(() => {
+    useSWRMock.mockReset();
+  });
+
+  it("muestra los datos de los mercados", () => {
+    render(<MarketSidebar token="token" user={user} onLogout={onLogout} />);
+
+    expect(screen.getByText(/bullbearbroker/i)).toBeInTheDocument();
+    expect(screen.getByText(user.email)).toBeInTheDocument();
+    expect(screen.getByText("BTC")).toBeInTheDocument();
+    expect(screen.getByText("AAPL")).toBeInTheDocument();
+    expect(screen.getByText(/eur\/usd/i)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- ensure authentication tokens persist locally with non-secure local dev cookies and retry profile loads with refresh tokens when needed
- add streaming-aware chat API helper and update the chat panel to surface live assistant responses
- cover register form, market sidebar, and news panel with jest tests and centralize next/navigation mocking for consistency

## Testing
- pnpm test *(fails: jest not found because dependencies could not be installed due to registry 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d5a89817f08321ba48e9f771f8feb4