### PR TITLE
Integrate frontend with backend services

### DIFF
--- a/frontend/src/components/dashboard/dashboard-page.tsx
+++ b/frontend/src/components/dashboard/dashboard-page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import Link from "next/link";
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
+import { useRouter } from "next/navigation";
 
 import { useAuth } from "@/components/providers/auth-provider";
 import { ChatPanel } from "@/components/chat/chat-panel";
@@ -14,8 +14,15 @@ import { Button } from "@/components/ui/button";
 
 export function DashboardPage() {
   const { user, loading, accessToken, logout } = useAuth();
+  const router = useRouter();
 
   const sidebarToken = useMemo(() => accessToken ?? undefined, [accessToken]);
+
+  useEffect(() => {
+    if (!loading && !user) {
+      router.replace("/login");
+    }
+  }, [loading, router, user]);
 
   if (loading) {
     return (
@@ -27,24 +34,8 @@ export function DashboardPage() {
 
   if (!user) {
     return (
-      <div className="flex min-h-screen items-center justify-center bg-background p-4">
-        <Card className="max-w-md w-full">
-          <CardContent className="space-y-4 pt-6">
-            <h2 className="text-2xl font-semibold">Acceso requerido</h2>
-            <p className="text-muted-foreground">
-              Inicia sesión o regístrate para acceder al panel de mercado inteligente de
-              BullBearBroker.
-            </p>
-            <div className="flex flex-col gap-2 sm:flex-row">
-              <Button asChild>
-                <Link href="/login">Iniciar sesión</Link>
-              </Button>
-              <Button asChild variant="secondary">
-                <Link href="/register">Crear cuenta</Link>
-              </Button>
-            </div>
-          </CardContent>
-        </Card>
+      <div className="flex min-h-screen items-center justify-center">
+        <p className="text-muted-foreground">Redirigiendo al acceso...</p>
       </div>
     );
   }

--- a/frontend/src/components/news/news-panel.tsx
+++ b/frontend/src/components/news/news-panel.tsx
@@ -18,6 +18,14 @@ export function NewsPanel({ token }: NewsPanelProps) {
     () => listNews(token)
   );
 
+  const sortedNews = data
+    ?.slice()
+    .sort((a, b) => {
+      const dateA = a.published_at ? new Date(a.published_at).getTime() : 0;
+      const dateB = b.published_at ? new Date(b.published_at).getTime() : 0;
+      return dateB - dateA;
+    });
+
   return (
     <Card className="flex flex-col">
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-3">
@@ -29,23 +37,18 @@ export function NewsPanel({ token }: NewsPanelProps) {
       </CardHeader>
       <CardContent className="space-y-3">
         {isLoading && <p className="text-sm text-muted-foreground">Cargando noticias...</p>}
-        {error && (
-          <p className="text-sm text-destructive">
-            No se pudieron cargar las noticias: {error.message}
-          </p>
+        {(error || (!isLoading && !sortedNews?.length)) && (
+          <p className="text-sm text-muted-foreground">No hay noticias disponibles.</p>
         )}
-        {!isLoading && !error && !data?.length && (
-          <p className="text-sm text-muted-foreground">
-            No hay noticias disponibles en este momento.
-          </p>
-        )}
-        {data?.slice(0, 6).map((item) => (
+        {sortedNews?.slice(0, 6).map((item) => (
           <article key={item.id} className="space-y-1 rounded-lg border p-3">
             <h3 className="text-sm font-semibold">{item.title}</h3>
             {item.summary && <p className="text-xs text-muted-foreground">{item.summary}</p>}
             <div className="flex items-center justify-between text-xs text-muted-foreground">
               <span>{item.source ?? "Fuente desconocida"}</span>
-              {item.published_at && <span>{new Date(item.published_at).toLocaleString()}</span>}
+              {item.published_at && (
+                <span>{new Date(item.published_at).toLocaleString("es-ES", { hour12: false })}</span>
+              )}
             </div>
             <Link
               href={item.url}


### PR DESCRIPTION
## Summary
- add unified API helpers for market quotes and resilient news fetching over the backend endpoints
- wire the market sidebar to live data per asset with realtime status and sparkline preview
- update dashboard session handling and news panel messaging to respect authentication and backend fallbacks

## Testing
- `pnpm lint` *(fails: next lint currently passes deprecated CLI options in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5c68aee1883219ff0872943678f87