### PR TITLE
Ensure auth endpoints validate email without optional deps

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -19,6 +19,14 @@ if DATABASE_URL.startswith("sqlite"):
 engine = create_engine(DATABASE_URL, future=True, echo=False, connect_args=connect_args)
 SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False, future=True)
 
+if os.getenv("BULLBEAR_SKIP_AUTOCREATE", "0") != "1":
+    try:
+        Base.metadata.create_all(bind=engine)
+    except Exception as exc:  # pragma: no cover - logging manual para depurar entornos sin DB
+        import logging
+
+        logging.getLogger(__name__).error("No se pudieron crear las tablas automáticamente: %s", exc)
+
 
 def get_db() -> Generator:
     db = SessionLocal()

--- a/backend/main.py
+++ b/backend/main.py
@@ -34,6 +34,20 @@ async def lifespan(app: FastAPI):
     except Exception as exc:  # pragma: no cover - redis opcional en tests
         logger.warning(f"FastAPILimiter no inicializado: {exc}")
 
+    try:
+        from backend.database import Base, engine
+        from backend.services.user_service import user_service
+
+        Base.metadata.create_all(bind=engine)
+        logger.info("Tablas de base de datos verificadas/creadas correctamente")
+
+        default_email = os.getenv("BULLBEAR_DEFAULT_USER", "test@bullbear.ai")
+        default_password = os.getenv("BULLBEAR_DEFAULT_PASSWORD", "Test1234!")
+        user_service.ensure_user(default_email, default_password)
+        logger.info("Usuario por defecto verificado (%s)", default_email)
+    except Exception as exc:  # pragma: no cover - evita fallas en despliegues sin DB
+        logger.error("Error creando tablas en la base de datos: %s", exc)
+
     yield  # ⬅️ Aquí FastAPI empieza a servir requests
 
     # 🔹 Shutdown

--- a/backend/models/refresh_token.py
+++ b/backend/models/refresh_token.py
@@ -6,7 +6,7 @@ from sqlalchemy import Column, DateTime, ForeignKey, String, func
 from sqlalchemy.dialects.postgresql import UUID as PGUUID
 from sqlalchemy.orm import relationship
 
-from backend.database import Base
+from backend.models.base import Base
 
 
 class RefreshToken(Base):


### PR DESCRIPTION
## Summary
- add a local email validation fallback for the auth router and generate unique access token identifiers
- automatically create database tables on startup and guarantee a default test user exists
- expose a user service helper to seed accounts and fix the refresh token model import to avoid circular dependencies

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d5f355f71c8321a93edb92a6d5b8fc