### PR TITLE
Refine alerts condition entry helpers

### DIFF
--- a/frontend/src/components/alerts/__tests__/alerts-panel.test.tsx
+++ b/frontend/src/components/alerts/__tests__/alerts-panel.test.tsx
@@ -1,0 +1,84 @@
+import { act, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import useSWR from "swr";
+
+import { AlertsPanel } from "../alerts-panel";
+
+jest.mock("swr");
+
+const mockedUseSWR = useSWR as jest.MockedFunction<typeof useSWR>;
+
+const mutateMock = jest.fn();
+
+jest.mock("@/lib/api", () => ({
+  listAlerts: jest.fn(),
+  createAlert: jest.fn(),
+  deleteAlert: jest.fn(),
+  sendAlertNotification: jest.fn(),
+  suggestAlertCondition: jest.fn(),
+  updateAlert: jest.fn(),
+}));
+
+describe("AlertsPanel condition helpers", () => {
+  beforeEach(() => {
+    mutateMock.mockReset();
+    mockedUseSWR.mockReturnValue({
+      data: [],
+      error: undefined,
+      mutate: mutateMock,
+      isLoading: false,
+    } as never);
+  });
+
+  it("prefills a quick condition only when the textarea is empty", async () => {
+    const user = userEvent.setup();
+    render(<AlertsPanel token="demo-token" />);
+
+    const textarea = screen.getByPlaceholderText(/condición/i) as HTMLTextAreaElement;
+    const helperButton = screen.getByRole("button", { name: /menor que/i });
+
+    expect(textarea).toHaveValue("");
+    expect(helperButton).toBeEnabled();
+
+    await act(async () => {
+      await user.click(helperButton);
+    });
+
+    expect(textarea).toHaveValue("<");
+    expect(helperButton).toBeDisabled();
+  });
+
+  it("keeps custom expressions in the textarea as the source of truth", async () => {
+    const user = userEvent.setup();
+    render(<AlertsPanel token="demo-token" />);
+
+    const textarea = screen.getByPlaceholderText(/condición/i) as HTMLTextAreaElement;
+    const helperButton = screen.getByRole("button", { name: /menor que/i });
+
+    await act(async () => {
+      await user.type(textarea, "Precio cruza 30k");
+    });
+
+    expect(textarea).toHaveValue("Precio cruza 30k");
+    expect(helperButton).toBeDisabled();
+
+    await act(async () => {
+      await user.click(helperButton);
+    });
+
+    expect(textarea).toHaveValue("Precio cruza 30k");
+
+    await act(async () => {
+      await user.clear(textarea);
+    });
+
+    expect(textarea).toHaveValue("");
+    expect(helperButton).toBeEnabled();
+
+    await act(async () => {
+      await user.click(helperButton);
+    });
+
+    expect(textarea).toHaveValue("<");
+  });
+});

--- a/frontend/src/components/alerts/alerts-panel.tsx
+++ b/frontend/src/components/alerts/alerts-panel.tsx
@@ -45,6 +45,16 @@ export function AlertsPanel({ token }: AlertsPanelProps) {
   const [suggestError, setSuggestError] = useState<string | null>(null); // [Codex] nuevo
   const [suggestNote, setSuggestNote] = useState<string | null>(null); // [Codex] nuevo
 
+  const quickConditionPresets: { label: string; value: string }[] = [
+    { label: "Menor que", value: "<" },
+    { label: "Mayor que", value: ">" },
+    { label: "Igual a", value: "==" },
+  ];
+
+  const handleQuickCondition = useCallback((presetValue: string) => {
+    setCondition((prev) => (prev.trim().length === 0 ? presetValue : prev));
+  }, []);
+
   // Crear alerta nueva
   const handleCreate = useCallback(
     async (event: React.FormEvent<HTMLFormElement>) => {
@@ -244,17 +254,22 @@ export function AlertsPanel({ token }: AlertsPanelProps) {
             onChange={(event) => setCondition(event.target.value)}
             disabled={!token || submitting}
           />
-          <select
-            value={condition}
-            onChange={(event) => setCondition(event.target.value as "<" | ">" | "==")}
-            disabled={!token || submitting}
-            className="w-full rounded-md border bg-background px-3 py-2 text-sm"
-          >
-            <option value="">Selecciona condición</option>
-            <option value="<">Menor que (&lt;)</option>
-            <option value=">">Mayor que (&gt;)</option>
-            <option value="==">Igual a (==)</option>
-          </select>
+          <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+            <span>Atajos:</span>
+            {quickConditionPresets.map((preset) => (
+              <Button
+                key={preset.value}
+                type="button"
+                size="sm"
+                variant="outline"
+                disabled={!token || submitting || Boolean(condition.trim())}
+                onClick={() => handleQuickCondition(preset.value)}
+              >
+                {preset.label}
+                <span className="ml-1 font-mono">{preset.value}</span>
+              </Button>
+            ))}
+          </div>
           <Input
             type="number"
             placeholder="Valor (ej. 30)"


### PR DESCRIPTION
## Summary
- replace the alerts condition dropdown with quick helper buttons that only prefill when the textarea is empty
- keep the textarea as the single source of truth for alert conditions so custom expressions persist
- add AlertsPanel component tests covering the quick-fill helpers and free-form editing behavior

## Testing
- pnpm test -- alerts-panel *(fails: Jest coverage thresholds are configured for the full suite and are not met when running only the AlertsPanel tests)*
- pnpm test *(fails: existing Dashboard accessibility suite cannot find the mocked sidebar text)*

------
https://chatgpt.com/codex/tasks/task_e_68d8550a6a888321b40c00d44d873d2d