### PR TITLE
Add alerts panel unit tests

### DIFF
--- a/frontend/src/components/alerts/__tests__/alerts-panel.test.tsx
+++ b/frontend/src/components/alerts/__tests__/alerts-panel.test.tsx
@@ -1,0 +1,166 @@
+import { act, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import useSWR from "swr";
+
+import { createAlert, updateAlert } from "@/lib/api";
+import { AlertsPanel } from "../alerts-panel";
+
+jest.mock("swr", () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+jest.mock("@/lib/api", () => ({
+  __esModule: true,
+  createAlert: jest.fn(),
+  updateAlert: jest.fn(),
+  deleteAlert: jest.fn(),
+  listAlerts: jest.fn(),
+  sendAlertNotification: jest.fn(),
+  suggestAlertCondition: jest.fn(),
+}));
+
+const mockedUseSWR = useSWR as jest.MockedFunction<typeof useSWR>;
+const mockedCreateAlert = createAlert as jest.MockedFunction<typeof createAlert>;
+const mockedUpdateAlert = updateAlert as jest.MockedFunction<typeof updateAlert>;
+
+describe("AlertsPanel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedUseSWR.mockReturnValue({
+      data: [],
+      error: undefined,
+      mutate: jest.fn().mockResolvedValue(undefined),
+      isLoading: false,
+    });
+  });
+
+  it("creates an alert with the expected payload", async () => {
+    const user = userEvent.setup();
+    const mutate = jest.fn().mockResolvedValue(undefined);
+    mockedUseSWR.mockReturnValue({
+      data: [],
+      error: undefined,
+      mutate,
+      isLoading: false,
+    });
+
+    mockedCreateAlert.mockResolvedValue({
+      id: "1",
+      title: "Comprar BTC",
+      asset: "BTCUSDT",
+      condition: "Precio cruza los 50k",
+      value: 50000,
+      active: true,
+    });
+
+    render(<AlertsPanel token="secure-token" />);
+
+    await act(async () => {
+      await user.type(
+        screen.getByPlaceholderText("Título de la alerta"),
+        "  Comprar BTC "
+      );
+      await user.type(
+        screen.getByPlaceholderText("Activo (ej. BTCUSDT, AAPL)"),
+        "btcusdt"
+      );
+      await user.type(
+        screen.getByPlaceholderText("Condición (ej. BTC > 50,000 USD)"),
+        "Precio cruza los 50k"
+      );
+      await user.type(
+        screen.getByPlaceholderText("Valor (ej. 30)"),
+        "50000"
+      );
+    });
+
+    await act(async () => {
+      await user.click(screen.getByRole("button", { name: /crear alerta/i }));
+    });
+
+    await waitFor(() => {
+      expect(mockedCreateAlert).toHaveBeenCalledWith(
+        "secure-token",
+        expect.objectContaining({
+          title: "Comprar BTC",
+          asset: "BTCUSDT",
+          condition: "Precio cruza los 50k",
+          value: 50000,
+          active: true,
+        })
+      );
+    });
+
+    expect(mutate).toHaveBeenCalled();
+  });
+
+  it("shows a validation error when title is missing", async () => {
+    const user = userEvent.setup();
+    render(<AlertsPanel token="secure-token" />);
+
+    await act(async () => {
+      await user.type(
+        screen.getByPlaceholderText("Activo (ej. BTCUSDT, AAPL)"),
+        "ETHUSDT"
+      );
+      await user.type(
+        screen.getByPlaceholderText("Condición (ej. BTC > 50,000 USD)"),
+        "ETH supera los 3000"
+      );
+      await user.type(
+        screen.getByPlaceholderText("Valor (ej. 30)"),
+        "3000"
+      );
+      await user.click(screen.getByRole("button", { name: /crear alerta/i }));
+    });
+
+    expect(
+      await screen.findByText("Debes asignar un título a la alerta.")
+    ).toBeInTheDocument();
+    expect(mockedCreateAlert).not.toHaveBeenCalled();
+  });
+
+  it("toggles an alert to inactive", async () => {
+    const user = userEvent.setup();
+    const mutate = jest.fn().mockResolvedValue(undefined);
+    mockedUseSWR.mockReturnValue({
+      data: [
+        {
+          id: "alert-1",
+          title: "Cruz dorada",
+          asset: "BTCUSDT",
+          condition: "Cruce EMA 50/200",
+          value: 50000,
+          active: true,
+        },
+      ],
+      error: undefined,
+      mutate,
+      isLoading: false,
+    });
+
+    mockedUpdateAlert.mockResolvedValue({
+      id: "alert-1",
+      title: "Cruz dorada",
+      asset: "BTCUSDT",
+      condition: "Cruce EMA 50/200",
+      value: 50000,
+      active: false,
+    });
+
+    render(<AlertsPanel token="secure-token" />);
+
+    await act(async () => {
+      await user.click(screen.getByRole("button", { name: /pausar/i }));
+    });
+
+    await waitFor(() => {
+      expect(mockedUpdateAlert).toHaveBeenCalledWith("secure-token", "alert-1", {
+        active: false,
+      });
+    });
+
+    expect(mutate).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for AlertsPanel covering alert creation, validation errors, and toggling active state
- mock alert API helpers and SWR hook to isolate component behaviour

## Testing
- npm --prefix frontend test -- src/components/alerts/__tests__/alerts-panel.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d85671c4b08321ab2109e6e4c1c9cb