### PR TITLE
Use CommonJS Babel config for Jest

### DIFF
--- a/frontend/babel.config.cjs
+++ b/frontend/babel.config.cjs
@@ -1,0 +1,9 @@
+module.exports = {
+  presets: [
+    "next/babel",
+    "@babel/preset-env",
+    "@babel/preset-react",
+    "@babel/preset-typescript",
+  ],
+  plugins: [],
+};

--- a/frontend/jest.config.ts
+++ b/frontend/jest.config.ts
@@ -31,7 +31,7 @@ const config: Config = {
     "^.+\\.(t|j)sx?$": [
       "babel-jest",
       {
-        configFile: "<rootDir>/babel.config.js",
+        configFile: "<rootDir>/babel.config.cjs",
       },
     ],
   },


### PR DESCRIPTION
## Summary
- point Jest's Babel transform at the CommonJS configuration file
- add a CommonJS `babel.config.cjs` that mirrors the existing ESM config for Babel-Jest

## Testing
- npm run test:alerts *(fails: Jest/babel-jest still reports it cannot resolve `<rootDir>/babel.config.cjs` even though the file now exists)*

------
https://chatgpt.com/codex/tasks/task_e_68d8994d6a688321a896f393b8df9784