### PR TITLE
Fix Jest using Babel config for TS/TSX tests

### DIFF
--- a/frontend/babel.config.cjs
+++ b/frontend/babel.config.cjs
@@ -1,8 +1,18 @@
-module.exports = {
-  presets: [
-    "next/babel",
-    ["@babel/preset-env", { targets: { node: "current" } }],
-    "@babel/preset-react",
-    "@babel/preset-typescript",
-  ],
+module.exports = function (api) {
+  const isTest = api.env("test");
+
+  return {
+    presets: [
+      [
+        "next/babel",
+        {
+          "preset-env": {
+            targets: isTest ? { node: "current" } : undefined,
+            modules: isTest ? "commonjs" : false,
+          },
+        },
+      ],
+      isTest && "@babel/preset-typescript",
+    ].filter(Boolean),
+  };
 };


### PR DESCRIPTION
## Summary
- make the frontend Babel config environment aware so Jest transpiles ES module syntax to CommonJS during tests
- ensure TypeScript preset remains enabled for tests while preserving Next.js defaults for other environments

## Testing
- npm test -- src/__tests__/hello.test.tsx --coverage=false

------
https://chatgpt.com/codex/tasks/task_e_68d9cfcc500883219bf600e0722aad88