### PR TITLE
Fix auth provider mocks in form tests

### DIFF
--- a/frontend/src/components/forms/__tests__/login-form.test.tsx
+++ b/frontend/src/components/forms/__tests__/login-form.test.tsx
@@ -4,12 +4,22 @@ import { axe } from "jest-axe";
 import { LoginForm } from "../login-form";
 
 // Mock de useAuth
-const loginUserMock = jest.fn().mockResolvedValue(undefined);
-jest.mock("@/components/providers/auth-provider", () => ({
-  useAuth: () => ({
-    loginUser: loginUserMock,
-  }),
-}));
+jest.mock("@/components/providers/auth-provider", () => {
+  const loginUserMock = jest.fn().mockResolvedValue(undefined);
+
+  return {
+    __esModule: true,
+    useAuth: () => ({
+      loginUser: loginUserMock,
+    }),
+    loginUserMock,
+  };
+});
+
+const { loginUserMock } =
+  jest.requireMock("@/components/providers/auth-provider") as {
+    loginUserMock: jest.Mock;
+  };
 
 const pushMock = jest.fn();
 

--- a/frontend/src/components/forms/__tests__/register-form.test.tsx
+++ b/frontend/src/components/forms/__tests__/register-form.test.tsx
@@ -3,12 +3,22 @@ import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { RegisterForm } from "../register-form";
 
 // Mock de useAuth
-const registerUserMock = jest.fn().mockResolvedValue(undefined);
-jest.mock("@/components/providers/auth-provider", () => ({
-  useAuth: () => ({
-    registerUser: registerUserMock,
-  }),
-}));
+jest.mock("@/components/providers/auth-provider", () => {
+  const registerUserMock = jest.fn().mockResolvedValue(undefined);
+
+  return {
+    __esModule: true,
+    useAuth: () => ({
+      registerUser: registerUserMock,
+    }),
+    registerUserMock,
+  };
+});
+
+const { registerUserMock } =
+  jest.requireMock("@/components/providers/auth-provider") as {
+    registerUserMock: jest.Mock;
+  };
 
 const pushMock = jest.fn();
 


### PR DESCRIPTION
## Summary
- create isolated auth-provider mock implementations within the jest.mock factory for the form tests
- re-export the generated mocks so existing expectations can reuse them without violating Jest scoping rules

## Testing
- not run (static analysis only)


------
https://chatgpt.com/codex/tasks/task_e_68d9fc28d0588321947b19ef015ece17