### PR TITLE
Adjust RootLayout test to render provider subtree

### DIFF
--- a/frontend/src/app/__tests__/layout.test.tsx
+++ b/frontend/src/app/__tests__/layout.test.tsx
@@ -26,14 +26,14 @@ import RootLayout from "../layout";
 
 describe("RootLayout", () => {
   it("envuelve el contenido con proveedores globales", () => {
-    render(
-      <RootLayout>
-        <span>Contenido</span>
-      </RootLayout>
-    );
+    const layout = RootLayout({ children: <span>Contenido</span> });
 
-    const html = document.querySelector("html");
-    expect(html).toHaveAttribute("lang", "es");
+    expect(layout.props.lang).toBe("es");
+
+    const body = layout.props.children as React.ReactElement;
+
+    render(body.props.children);
+
     expect(screen.getByTestId("theme-provider")).toBeInTheDocument();
     expect(screen.getByTestId("auth-provider")).toBeInTheDocument();
     expect(screen.getByTestId("app-chrome")).toHaveTextContent("Contenido");


### PR DESCRIPTION
## Summary
- instantiate the root layout directly to assert the lang attribute without mounting an html element
- render only the body provider subtree so existing provider assertions continue to pass

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da850561288321bfc7355c22716ed5