### PR TITLE
Update dashboard accessibility test to use sidebar heading

### DIFF
--- a/frontend/src/components/dashboard/__tests__/dashboard-accessibility.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/dashboard-accessibility.test.tsx
@@ -15,7 +15,11 @@ jest.mock("next/navigation", () => ({
 }));
 
 jest.mock("@/components/sidebar/market-sidebar", () => ({
-  MarketSidebar: () => <aside>sidebar</aside>,
+  MarketSidebar: () => (
+    <aside>
+      <h2>BullBearBroker</h2>
+    </aside>
+  ),
 }));
 
 jest.mock("@/components/news/news-panel", () => ({
@@ -54,7 +58,7 @@ describe("DashboardPage accesibilidad", () => {
 
     await act(async () => {
       utils = render(<DashboardPage />);
-      await screen.findByText("sidebar");
+      await screen.findByRole("heading", { name: /BullBearBroker/i });
     });
 
     const { container } = utils!;


### PR DESCRIPTION
## Summary
- mock the market sidebar with the actual BullBearBroker heading
- wait for the sidebar heading to render before running the accessibility audit

## Testing
- pnpm test -- dashboard-accessibility *(fails: Unable to find role="heading" and name `/BullBearBroker/i`)*

------
https://chatgpt.com/codex/tasks/task_e_68da88a394688321a7962b0e2cc48b64