### PR TITLE
Adjust login form tests to use global mocks

### DIFF
--- a/frontend/src/components/forms/__tests__/login-form.test.tsx
+++ b/frontend/src/components/forms/__tests__/login-form.test.tsx
@@ -5,22 +5,22 @@ import { LoginForm } from "../login-form";
 
 // Mock de useAuth
 jest.mock("@/components/providers/auth-provider", () => {
-  (globalThis as any).loginUserMock = jest.fn().mockResolvedValue(undefined);
+  (global as any).loginUserMock = jest.fn().mockResolvedValue(undefined);
 
   return {
     __esModule: true,
     useAuth: () => ({
-      loginUser: (globalThis as any).loginUserMock,
+      loginUser: (global as any).loginUserMock,
     }),
   };
 });
 
 jest.mock("next/navigation", () => {
-  (globalThis as any).pushMock = jest.fn();
+  (global as any).pushMock = jest.fn();
 
   return {
     useRouter: () => ({
-      push: (globalThis as any).pushMock,
+      push: (global as any).pushMock,
       replace: jest.fn(),
       refresh: jest.fn(),
       prefetch: jest.fn(),
@@ -31,8 +31,8 @@ jest.mock("next/navigation", () => {
 
 describe("LoginForm", () => {
   beforeEach(() => {
-    (globalThis as any).loginUserMock.mockClear();
-    (globalThis as any).pushMock.mockClear();
+    (global as any).loginUserMock.mockClear();
+    (global as any).pushMock.mockClear();
   });
 
   it("muestra mensajes de validación cuando el formulario está vacío", async () => {
@@ -43,7 +43,7 @@ describe("LoginForm", () => {
     expect(
       await screen.findByText(/debe ingresar un correo válido/i)
     ).toBeInTheDocument();
-    expect((globalThis as any).loginUserMock).not.toHaveBeenCalled();
+    expect((global as any).loginUserMock).not.toHaveBeenCalled();
   });
 
   it("valida longitud mínima de la contraseña", async () => {
@@ -61,7 +61,7 @@ describe("LoginForm", () => {
     expect(
       await screen.findByText(/la contraseña debe tener al menos 6 caracteres/i)
     ).toBeInTheDocument();
-    expect((globalThis as any).loginUserMock).not.toHaveBeenCalled();
+    expect((global as any).loginUserMock).not.toHaveBeenCalled();
   });
 
   it("envía los datos correctamente", async () => {
@@ -77,12 +77,12 @@ describe("LoginForm", () => {
     fireEvent.click(screen.getByRole("button", { name: /iniciar sesión/i }));
 
     await waitFor(() =>
-      expect((globalThis as any).loginUserMock).toHaveBeenCalledWith(
+      expect((global as any).loginUserMock).toHaveBeenCalledWith(
         "user@example.com",
         "secret123"
       )
     );
-    expect((globalThis as any).pushMock).toHaveBeenCalledWith("/");
+    expect((global as any).pushMock).toHaveBeenCalledWith("/");
 
     // No hay validación de UI en este form; validamos que NO haya mensaje de error inmediato
     expect(
@@ -91,7 +91,7 @@ describe("LoginForm", () => {
   });
 
   it("muestra mensaje de error cuando la autenticación falla", async () => {
-    (globalThis as any).loginUserMock.mockRejectedValueOnce(
+    (global as any).loginUserMock.mockRejectedValueOnce(
       new Error("Credenciales inválidas")
     );
 
@@ -109,7 +109,7 @@ describe("LoginForm", () => {
     expect(
       await screen.findByText(/credenciales inválidas/i)
     ).toBeInTheDocument();
-    expect((globalThis as any).pushMock).not.toHaveBeenCalled();
+    expect((global as any).pushMock).not.toHaveBeenCalled();
   });
 
   it("no presenta violaciones de accesibilidad básicas", async () => {


### PR DESCRIPTION
## Summary
- update the auth-provider mock to expose loginUser via a global mock
- ensure the next/navigation mock stores push on the global object so expectations work
- replace remaining globalThis references with global to use the shared mocks

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68da947242b88321a4faf73bb32c53e4