### PR TITLE
Fix act usage in dashboard accessibility test

### DIFF
--- a/frontend/src/components/dashboard/__tests__/dashboard-accessibility.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/dashboard-accessibility.test.tsx
@@ -66,7 +66,7 @@ describe("DashboardPage accesibilidad", () => {
   it("no tiene violaciones básicas", async () => {
     let utils: ReturnType<typeof render> | undefined;
 
-    act(() => {
+    await act(async () => {
       utils = render(<DashboardPage />);
     });
 
@@ -74,8 +74,6 @@ describe("DashboardPage accesibilidad", () => {
     within(sidebarHeading.parentElement as HTMLElement).getByRole("button", {
       name: /Cerrar sesión/i,
     });
-    await act(async () => {});
-
     const { container } = utils!;
     expect(await axe(container)).toHaveNoViolations();
   });


### PR DESCRIPTION
## Summary
- wrap the dashboard accessibility test render in an async act block for proper handling
- remove the redundant empty act invocation while keeping assertions outside act

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dac7cd9e888321b259aa644b4b5c43