### PR TITLE
Wrap useMarketData refresh call in act

### DIFF
--- a/frontend/src/hooks/__tests__/useMarketData.test.tsx
+++ b/frontend/src/hooks/__tests__/useMarketData.test.tsx
@@ -1,4 +1,4 @@
-import { renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { SWRConfig } from "swr";
 import { http, HttpResponse } from "msw";
 
@@ -72,7 +72,9 @@ describe("useMarketData", () => {
     await waitFor(() => expect(result.current.data?.price).toBe(50_000));
 
     server.use(makeMarketQuoteHandler("crypto", { price: 51_000 }));
-    await result.current.refresh();
+    await act(async () => {
+      await result.current.refresh();
+    });
 
     await waitFor(() => expect(result.current.data?.price).toBe(51_000));
   });


### PR DESCRIPTION
## Summary
- wrap the manual refresh invocation in `useMarketData` tests with `act` to comply with React Testing Library expectations

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dac93d4d50832194ca6da0916ee3b8