### PR TITLE
Wrap useNewsFeed refresh call in act

### DIFF
--- a/frontend/src/hooks/__tests__/useNewsFeed.test.tsx
+++ b/frontend/src/hooks/__tests__/useNewsFeed.test.tsx
@@ -1,4 +1,4 @@
-import { renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { SWRConfig } from "swr";
 
 import { useNewsFeed } from "../useNewsFeed";
@@ -81,7 +81,9 @@ describe("useNewsFeed", () => {
       )
     );
 
-    await result.current.refresh();
+    await act(async () => {
+      await result.current.refresh();
+    });
 
     await waitFor(() => expect(result.current.data?.[0]?.title).toBe("Noticia B"));
   });


### PR DESCRIPTION
## Summary
- add testing-library act import to useNewsFeed hook tests
- wrap the manual refresh call in act to satisfy React testing requirements

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dac9c029a48321b3121b0c1422ccdb