### PR TITLE
Add tests for IndicatorsChart insights and fallbacks

### DIFF
--- a/frontend/src/components/indicators/__tests__/IndicatorsChart.test.tsx
+++ b/frontend/src/components/indicators/__tests__/IndicatorsChart.test.tsx
@@ -1,104 +1,91 @@
-import { act, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
+
 import { IndicatorsChart } from "../IndicatorsChart";
 
 jest.mock("recharts", () => {
-  const MockLeaf = ({ "data-testid": dataTestId }: any) => (
-    <div data-testid={dataTestId ?? "recharts-node"} />
-  );
+  const Passthrough = ({ children }: any) => <div>{children}</div>;
 
   return {
-    ResponsiveContainer: ({ children }: any) => (
-      <div data-testid="responsive-container">{children}</div>
-    ),
-    LineChart: ({ children }: any) => (
-      <div data-testid="line-chart">{children}</div>
-    ),
-    CartesianGrid: MockLeaf,
-    XAxis: MockLeaf,
-    YAxis: MockLeaf,
-    Tooltip: MockLeaf,
-    Legend: MockLeaf,
-    Line: MockLeaf,
-    ReferenceLine: MockLeaf,
-    BarChart: ({ children }: any) => (
-      <div data-testid="bar-chart">{children}</div>
-    ),
-    Bar: MockLeaf,
+    ResponsiveContainer: Passthrough,
+    LineChart: Passthrough,
+    Line: Passthrough,
+    XAxis: Passthrough,
+    YAxis: Passthrough,
+    Tooltip: Passthrough,
+    Legend: Passthrough,
+    CartesianGrid: Passthrough,
+    ReferenceLine: Passthrough,
+    BarChart: Passthrough,
+    Bar: Passthrough,
   };
 });
 
 describe("IndicatorsChart", () => {
-  it("muestra encabezado, secciones condicionales y textos de insights", async () => {
-    const indicators = {
-      last_close: 145.67,
-      ema: [
-        { period: 20, value: 144.32 },
-        { period: 50, value: 140.11 },
-      ],
-      bollinger: {
-        upper: 150.2,
-        lower: 140.4,
-        middle: 145.3,
-      },
-      rsi: {
-        period: 14,
-        value: 55.6,
-      },
-      macd: {
-        macd: 1.2,
-        signal: 0.9,
-        hist: 0.3,
-      },
-      atr: {
-        period: 14,
-        value: 2.5,
-      },
-      stochastic_rsi: {
-        "%K": 65,
-        "%D": 60,
-      },
-      ichimoku: {
-        tenkan_sen: 150.1,
-        kijun_sen: 148.4,
-        senkou_span_a: 149.2,
-        senkou_span_b: 151.6,
-      },
-      vwap: {
-        value: 147.8,
-      },
-    };
+  const baseIndicators = {
+    last_close: 145.67,
+    ema: [
+      { period: 20, value: 144.32 },
+      { period: 50, value: 140.11 },
+    ],
+    bollinger: {
+      upper: 150.2,
+      lower: 140.4,
+      middle: 145.3,
+    },
+    rsi: {
+      period: 14,
+      value: 55.6,
+    },
+    macd: {
+      macd: 1.2,
+      signal: 0.9,
+      hist: 0.3,
+    },
+    atr: {
+      period: 14,
+      value: 2.5,
+    },
+    stochastic_rsi: {
+      "%K": 65,
+      "%D": 60,
+    },
+    ichimoku: {
+      tenkan_sen: 150.1,
+      kijun_sen: 148.4,
+      senkou_span_a: 149.2,
+      senkou_span_b: 151.6,
+    },
+    vwap: {
+      value: 147.8,
+    },
+  };
 
-    const series = {
-      closes: [145.6, 146.2, 147.5],
-    };
+  it("renders the header, indicator summaries, and insight list", () => {
+    const insights = [
+      "Tendencia alcista moderada",
+      "Vigilar posibles divergencias",
+      "Considerar stop-loss ajustado",
+    ].join("\n");
 
-    const insights = "Tendencia alcista moderada\nVigilar posibles divergencias";
-
-    await act(async () => {
-      render(
-        <IndicatorsChart
-          symbol="AAPL"
-          interval="1d"
-          indicators={indicators}
-          series={series}
-          insights={insights}
-        />
-      );
-    });
+    render(
+      <IndicatorsChart
+        symbol="AAPL"
+        interval="1d"
+        indicators={baseIndicators}
+        series={{ closes: [145.6, 146.2, 147.5] }}
+        insights={insights}
+      />
+    );
 
     expect(
       screen.getByRole("heading", { name: "AAPL · 1D" })
     ).toBeInTheDocument();
-    expect(
-      screen.getByText("Último cierre: 145.67")
-    ).toBeInTheDocument();
+    expect(screen.getByText("Último cierre: 145.67")).toBeInTheDocument();
 
-    expect(screen.getByText("RSI (Periodo 14)")).toBeInTheDocument();
-    expect(screen.getByText("MACD")).toBeInTheDocument();
     expect(screen.getByText("ATR (Periodo 14)")).toBeInTheDocument();
+    expect(screen.getByText("2.5")).toBeInTheDocument();
     expect(screen.getByText("Stochastic RSI")).toBeInTheDocument();
-    expect(screen.getByText("Ichimoku")).toBeInTheDocument();
-    expect(screen.getByText("VWAP")).toBeInTheDocument();
+    expect(screen.getByText("%K 65 · %D 60")).toBeInTheDocument();
 
     expect(screen.getByText("🧠 Insights de la IA")).toBeInTheDocument();
     expect(
@@ -107,5 +94,34 @@ describe("IndicatorsChart", () => {
     expect(
       screen.getByText("Vigilar posibles divergencias")
     ).toBeInTheDocument();
+    expect(
+      screen.getByText("Considerar stop-loss ajustado")
+    ).toBeInTheDocument();
+  });
+
+  it("shows fallback messages when loading or error states are provided", () => {
+    const { rerender } = render(
+      <IndicatorsChart
+        symbol="AAPL"
+        interval="1d"
+        indicators={baseIndicators}
+        loading
+      />
+    );
+
+    expect(
+      screen.getByText("Analizando indicadores...")
+    ).toBeInTheDocument();
+
+    rerender(
+      <IndicatorsChart
+        symbol="AAPL"
+        interval="1d"
+        indicators={baseIndicators}
+        error="No se pudo obtener datos"
+      />
+    );
+
+    expect(screen.getByText("No se pudo obtener datos")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- mock recharts components with simple passthroughs for the IndicatorsChart test suite
- verify the chart renders indicator summaries, insights, and header content for synthetic data
- cover loading and error fallback messages to ensure insight panel messaging works

## Testing
- pnpm test -- --runTestsByPath src/components/indicators/__tests__/IndicatorsChart.test.tsx --collectCoverage=false

------
https://chatgpt.com/codex/tasks/task_e_68dad163d5108321a6a2855148cc65dd