### PR TITLE
Increase dashboard accessibility test timeout

### DIFF
--- a/frontend/src/components/dashboard/__tests__/dashboard-accessibility.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/dashboard-accessibility.test.tsx
@@ -76,5 +76,5 @@ describe("DashboardPage accesibilidad", () => {
     });
     const { container } = utils!;
     expect(await axe(container)).toHaveNoViolations();
-  });
+  }, 15000);
 });


### PR DESCRIPTION
## Summary
- extend the dashboard accessibility test timeout to 15 seconds to reduce flakiness

## Testing
- npx --yes eslint --config frontend/eslint.config.js frontend/src/components/dashboard/__tests__/dashboard-accessibility.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68daddc0f0888321a084406eb941c85c