### PR TITLE
Add global scrollIntoView mock for chat tests

### DIFF
--- a/frontend/jest.setup.ts
+++ b/frontend/jest.setup.ts
@@ -44,6 +44,21 @@ if (!globalThis.BroadcastChannel) {
   globalThis.BroadcastChannel = MockBroadcastChannel;
 }
 
+if (typeof window !== "undefined" && window.HTMLElement) {
+  const descriptor = Object.getOwnPropertyDescriptor(
+    window.HTMLElement.prototype,
+    "scrollIntoView"
+  );
+
+  if (!descriptor || descriptor.value === undefined) {
+    Object.defineProperty(window.HTMLElement.prototype, "scrollIntoView", {
+      configurable: true,
+      writable: true,
+      value: jest.fn(),
+    });
+  }
+}
+
 // Mock global de next/link para tests
 jest.mock("next/link", () => {
   const React = require("react");

--- a/frontend/src/components/chat/__tests__/chat-panel.test.tsx
+++ b/frontend/src/components/chat/__tests__/chat-panel.test.tsx
@@ -18,13 +18,6 @@ describe("ChatPanel", () => {
     sendChatMessage as jest.MockedFunction<typeof sendChatMessage>;
 
   beforeAll(() => {
-    if (!window.HTMLElement.prototype.scrollIntoView) {
-      Object.defineProperty(window.HTMLElement.prototype, "scrollIntoView", {
-        value: () => {},
-        configurable: true,
-      });
-    }
-
     scrollSpy = jest
       .spyOn(window.HTMLElement.prototype, "scrollIntoView")
       .mockImplementation(() => {});


### PR DESCRIPTION
## Summary
- define a global scrollIntoView mock in the Jest setup with a guard to avoid overriding custom definitions
- simplify the chat panel tests by relying on the shared setup mock while keeping the spy behavior

## Testing
- ./node_modules/.bin/jest -c jest.config.cjs src/components/chat/__tests__/chat-panel.test.tsx *(fails: Node binary not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68daf3af28c48321bfe43d3688d0a2dd