### PR TITLE
Update dashboard accessibility test to await logout button

### DIFF
--- a/frontend/src/components/dashboard/__tests__/dashboard-accessibility.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/dashboard-accessibility.test.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 
-import { act, render, screen, within } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import { axe } from "jest-axe";
 
 jest.mock("@/components/providers/auth-provider", () => ({
@@ -64,17 +64,30 @@ import { DashboardPage } from "../dashboard-page";
 
 describe("DashboardPage accesibilidad", () => {
   it("no tiene violaciones básicas", async () => {
-    let utils: ReturnType<typeof render> | undefined;
+    const originalConsoleError = console.error;
+    const consoleErrorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation((...args) => {
+        if (
+          typeof args[0] === "string" &&
+          args[0].includes("not wrapped in act")
+        ) {
+          return;
+        }
+        originalConsoleError(...(args as Parameters<typeof console.error>));
+      });
 
-    await act(async () => {
-      utils = render(<DashboardPage />);
-    });
-
-    const sidebarHeading = await screen.findByText(/BullBearBroker/i);
-    within(sidebarHeading.parentElement as HTMLElement).getByRole("button", {
-      name: /Cerrar sesión/i,
-    });
-    const { container } = utils!;
-    expect(await axe(container)).toHaveNoViolations();
-  }, 15000);
+    try {
+      const utils = render(<DashboardPage />);
+      const sidebarHeading = await screen.findByText(/BullBearBroker/i);
+      await within(sidebarHeading.parentElement as HTMLElement).findByRole(
+        "button",
+        { name: /Cerrar sesión/i },
+      );
+      const { container } = utils;
+      expect(await axe(container)).toHaveNoViolations();
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
+  }, 30000);
 });


### PR DESCRIPTION
## Summary
- wait for the sidebar logout control with an asynchronous role query
- silence the expected React act warnings while keeping the accessibility assertion intact

## Testing
- pnpm test -- frontend/src/components/dashboard/__tests__/dashboard-accessibility.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68daf466877883219ac0c0c5ea96647b