### PR TITLE
Ensure scrollIntoView is defined in chat panel tests

### DIFF
--- a/frontend/src/components/chat/__tests__/chat-panel.test.tsx
+++ b/frontend/src/components/chat/__tests__/chat-panel.test.tsx
@@ -18,6 +18,12 @@ describe("ChatPanel", () => {
     sendChatMessage as jest.MockedFunction<typeof sendChatMessage>;
 
   beforeAll(() => {
+    if (!window.HTMLElement.prototype.scrollIntoView) {
+      Object.defineProperty(window.HTMLElement.prototype, "scrollIntoView", {
+        value: jest.fn(),
+        configurable: true,
+      });
+    }
     scrollSpy = jest
       .spyOn(window.HTMLElement.prototype, "scrollIntoView")
       .mockImplementation(() => {});


### PR DESCRIPTION
## Summary
- ensure the chat panel test defines `scrollIntoView` on `HTMLElement` before spying on it to avoid undefined errors

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db014b232083219f211ab6f733064f