### PR TITLE
test: mock Radix ScrollArea in chat panel tests

### DIFF
--- a/frontend/src/components/chat/__tests__/chat-panel.test.tsx
+++ b/frontend/src/components/chat/__tests__/chat-panel.test.tsx
@@ -4,6 +4,21 @@ import { act, render, screen } from "@testing-library/react";
 import { ChatPanel } from "../chat-panel";
 import { sendChatMessage } from "@/lib/api";
 
+// Mock de Radix ScrollArea porque JSDOM no implementa addEventListener como espera la lib
+jest.mock("@radix-ui/react-scroll-area", () => {
+  const React = require("react");
+  return {
+    __esModule: true,
+    Root: ({ children, ...props }: any) =>
+      React.createElement("div", props, children),
+    Viewport: ({ children, ...props }: any) =>
+      React.createElement("div", props, children),
+    Scrollbar: ({ children, ...props }: any) =>
+      React.createElement("div", props, children),
+    Thumb: (props: any) => React.createElement("div", props),
+  };
+});
+
 jest.mock("@/lib/api", () => ({
   sendChatMessage: jest.fn().mockResolvedValue({
     messages: [],


### PR DESCRIPTION
## Summary
- add a mock implementation of @radix-ui/react-scroll-area to the chat panel tests to avoid reliance on DOM APIs that JSDOM does not support

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db0ac55fc4832192d8348172b2d85d