### PR TITLE
Add portfolio management feature

### DIFF
--- a/backend/alembic/versions/0008_create_portfolio_table.py
+++ b/backend/alembic/versions/0008_create_portfolio_table.py
@@ -1,0 +1,57 @@
+"""Create portfolio_items table"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision = "0008_create_portfolio_table"
+down_revision = "0007_add_title_active_to_alerts"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "portfolio_items",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            server_default=sa.text("gen_random_uuid()"),
+            primary_key=True,
+        ),
+        sa.Column(
+            "user_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("symbol", sa.String(length=20), nullable=False),
+        sa.Column("amount", sa.Numeric(20, 8), nullable=False),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(),
+            server_default=sa.func.now(),
+            onupdate=sa.func.now(),
+            nullable=False,
+        ),
+    )
+    op.create_index(
+        op.f("ix_portfolio_items_user_id"),
+        "portfolio_items",
+        ["user_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_portfolio_items_symbol"),
+        "portfolio_items",
+        ["symbol"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_portfolio_items_symbol"), table_name="portfolio_items")
+    op.drop_index(op.f("ix_portfolio_items_user_id"), table_name="portfolio_items")
+    op.drop_table("portfolio_items")

--- a/backend/main.py
+++ b/backend/main.py
@@ -10,7 +10,7 @@ from backend.core.logging_config import get_logger
 from backend.core.http_logging import RequestLogMiddleware
 
 # Routers de la app
-from backend.routers import alerts, markets, news, auth, ai
+from backend.routers import alerts, markets, news, auth, ai, portfolio
 from backend.routers import health  # nuevo router de salud
 from backend.services.integration_reporter import log_api_integration_report
 
@@ -102,3 +102,4 @@ app.include_router(markets.router, prefix="/api/markets", tags=["markets"])
 app.include_router(news.router, prefix="/api/news", tags=["news"])
 app.include_router(auth.router)
 app.include_router(ai.router, prefix="/api/ai", tags=["ai"])
+app.include_router(portfolio.router, prefix="/api/portfolio", tags=["portfolio"])

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -3,5 +3,6 @@ from .base import Base
 from .session import Session
 from .user import User
 from .refresh_token import RefreshToken
+from .portfolio import PortfolioItem
 
-__all__ = ["Alert", "Base", "Session", "User", "RefreshToken"]
+__all__ = ["Alert", "Base", "Session", "User", "RefreshToken", "PortfolioItem"]

--- a/backend/models/portfolio.py
+++ b/backend/models/portfolio.py
@@ -1,0 +1,54 @@
+"""Portfolio item model."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from decimal import Decimal
+from typing import TYPE_CHECKING
+
+from sqlalchemy import DateTime, ForeignKey, Numeric, String
+from sqlalchemy.dialects.postgresql import UUID as PGUUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+try:  # pragma: no cover - import resolution for different entrypoints
+    from .base import Base
+except ImportError:  # pragma: no cover
+    from backend.models.base import Base  # type: ignore[no-redef]
+
+if TYPE_CHECKING:  # pragma: no cover - typing helpers
+    from .user import User
+
+
+class PortfolioItem(Base):
+    """Represents a single asset held by a user portfolio."""
+
+    __tablename__ = "portfolio_items"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        PGUUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        PGUUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), index=True
+    )
+    symbol: Mapped[str] = mapped_column(String(20), nullable=False, index=True)
+    amount: Mapped[Decimal] = mapped_column(Numeric(20, 8), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, default=datetime.utcnow, nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False
+    )
+
+    user: Mapped["User"] = relationship(
+        "User", back_populates="portfolio_items", lazy="joined"
+    )
+
+    def __repr__(self) -> str:  # pragma: no cover - debugging helper
+        return (
+            f"PortfolioItem(id={self.id!s}, symbol={self.symbol!r}, "
+            f"amount={self.amount!s})"
+        )
+
+
+__all__ = ["PortfolioItem"]

--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 if TYPE_CHECKING:
     from .refresh_token import RefreshToken
+    from .portfolio import PortfolioItem
 
 try:  # pragma: no cover
     from .base import Base
@@ -56,6 +57,11 @@ class User(Base):
     )
     refresh_tokens: Mapped[list["RefreshToken"]] = relationship(
         "RefreshToken",
+        back_populates="user",
+        cascade="all, delete-orphan",
+    )
+    portfolio_items: Mapped[list["PortfolioItem"]] = relationship(
+        "PortfolioItem",
         back_populates="user",
         cascade="all, delete-orphan",
     )

--- a/backend/routers/portfolio.py
+++ b/backend/routers/portfolio.py
@@ -1,0 +1,130 @@
+"""Routes for managing user portfolio holdings."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Optional
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+
+USER_SERVICE_ERROR: Optional[Exception] = None
+
+try:  # pragma: no cover - allow running from different entrypoints
+    from backend.models import User
+except ImportError:  # pragma: no cover
+    from backend.models import User  # type: ignore
+
+try:  # pragma: no cover
+    from backend.services.user_service import (
+        InvalidTokenError,
+        UserNotFoundError,
+        user_service,
+    )
+except RuntimeError as exc:  # pragma: no cover - missing configuration
+    user_service = None  # type: ignore[assignment]
+    InvalidTokenError = RuntimeError  # type: ignore[assignment]
+    UserNotFoundError = RuntimeError  # type: ignore[assignment]
+    USER_SERVICE_ERROR = exc
+except ImportError:  # pragma: no cover
+    from services.user_service import (  # type: ignore
+        InvalidTokenError,
+        UserNotFoundError,
+        user_service,
+    )
+
+try:  # pragma: no cover
+    from backend.services.portfolio_service import portfolio_service
+except ImportError:  # pragma: no cover
+    from services.portfolio_service import portfolio_service  # type: ignore
+
+from backend.schemas.portfolio import (
+    PortfolioCreate,
+    PortfolioItemResponse,
+    PortfolioSummaryResponse,
+)
+
+router = APIRouter(tags=["portfolio"])
+security = HTTPBearer()
+
+
+def _ensure_user_service_available() -> None:
+    if user_service is None:
+        detail = "Servicio de usuarios no disponible"
+        if USER_SERVICE_ERROR is not None:
+            detail = f"{detail}. {USER_SERVICE_ERROR}"
+        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=detail)
+
+
+async def get_current_user(
+    credentials: HTTPAuthorizationCredentials = Depends(security),
+) -> User:
+    _ensure_user_service_available()
+    try:
+        return await asyncio.to_thread(
+            user_service.get_current_user, credentials.credentials
+        )
+    except InvalidTokenError as exc:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=str(exc)) from exc
+
+
+@router.get("", response_model=PortfolioSummaryResponse)
+async def list_portfolio(
+    current_user: User = Depends(get_current_user),
+) -> PortfolioSummaryResponse:
+    summary = await portfolio_service.get_portfolio_overview(current_user.id)
+    items = [
+        PortfolioItemResponse(
+            id=item["id"],
+            symbol=item["symbol"],
+            amount=float(item["amount"]),
+            price=item.get("price"),
+            value=item.get("value"),
+        )
+        for item in summary["items"]
+    ]
+    return PortfolioSummaryResponse(items=items, total_value=summary["total_value"])
+
+
+@router.post("", response_model=PortfolioItemResponse, status_code=status.HTTP_201_CREATED)
+async def create_portfolio_item(
+    payload: PortfolioCreate,
+    current_user: User = Depends(get_current_user),
+) -> PortfolioItemResponse:
+    try:
+        item = await asyncio.to_thread(
+            portfolio_service.create_item,
+            current_user.id,
+            symbol=payload.symbol,
+            amount=payload.amount,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    except UserNotFoundError as exc:  # pragma: no cover - defensive
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+
+    return PortfolioItemResponse(
+        id=item.id,
+        symbol=item.symbol,
+        amount=float(item.amount),
+        price=None,
+        value=None,
+    )
+
+
+@router.delete("/{item_id}", status_code=status.HTTP_200_OK)
+async def delete_portfolio_item(
+    item_id: UUID,
+    current_user: User = Depends(get_current_user),
+) -> dict:
+    deleted = await asyncio.to_thread(
+        portfolio_service.delete_item, current_user.id, item_id
+    )
+    if not deleted:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Activo no encontrado en el portafolio",
+        )
+
+    return {"message": "Activo eliminado", "id": str(item_id)}

--- a/backend/schemas/portfolio.py
+++ b/backend/schemas/portfolio.py
@@ -1,0 +1,45 @@
+"""Pydantic schemas for portfolio endpoints."""
+
+from __future__ import annotations
+
+from typing import List, Optional
+from uuid import UUID
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class PortfolioCreate(BaseModel):
+    symbol: str = Field(..., min_length=1, max_length=20)
+    amount: float = Field(..., gt=0)
+
+    @field_validator("symbol")
+    @classmethod
+    def _normalize_symbol(cls, value: str) -> str:
+        cleaned = value.strip()
+        if not cleaned:
+            raise ValueError("El símbolo es obligatorio")
+        return cleaned.upper()
+
+
+class PortfolioItemResponse(BaseModel):
+    id: UUID
+    symbol: str
+    amount: float
+    price: Optional[float] = None
+    value: Optional[float] = None
+
+    model_config = {
+        "from_attributes": True,
+    }
+
+
+class PortfolioSummaryResponse(BaseModel):
+    items: List[PortfolioItemResponse]
+    total_value: float
+
+
+__all__ = [
+    "PortfolioCreate",
+    "PortfolioItemResponse",
+    "PortfolioSummaryResponse",
+]

--- a/backend/services/__init__.py
+++ b/backend/services/__init__.py
@@ -4,14 +4,17 @@ from .alert_service import AlertService, alert_service
 from .forex_service import ForexService, forex_service
 from .news_service import NewsService, news_service
 from .sentiment_service import SentimentService, sentiment_service
+from .portfolio_service import PortfolioService, portfolio_service
 
 __all__ = [
     "AlertService",
     "ForexService",
     "NewsService",
     "SentimentService",
+    "PortfolioService",
     "alert_service",
     "forex_service",
     "news_service",
     "sentiment_service",
+    "portfolio_service",
 ]

--- a/backend/services/portfolio_service.py
+++ b/backend/services/portfolio_service.py
@@ -1,0 +1,173 @@
+"""Service layer for user portfolio management."""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import contextmanager
+from decimal import Decimal
+from typing import Any, Dict, Iterable, List, Optional
+from uuid import UUID
+
+from sqlalchemy import delete, select
+from sqlalchemy.orm import Session, sessionmaker
+
+from backend.database import SessionLocal
+from backend.models.portfolio import PortfolioItem
+
+try:  # pragma: no cover - compatibility with different entrypoints
+    from backend.services.market_service import market_service
+except ImportError:  # pragma: no cover
+    from services.market_service import market_service  # type: ignore
+
+try:  # pragma: no cover
+    from backend.services.forex_service import forex_service
+except ImportError:  # pragma: no cover
+    from services.forex_service import forex_service  # type: ignore
+
+
+class PortfolioItemNotFoundError(Exception):
+    """Raised when attempting to delete a non-existent portfolio entry."""
+
+
+class PortfolioService:
+    """High level operations for managing user portfolios."""
+
+    def __init__(self, session_factory: sessionmaker = SessionLocal) -> None:
+        self._session_factory = session_factory
+
+    @contextmanager
+    def _session_scope(self) -> Iterable[Session]:
+        session = self._session_factory()
+        try:
+            yield session
+            session.commit()
+        except Exception:
+            session.rollback()
+            raise
+        finally:
+            session.close()
+
+    # ------------------------------
+    # CRUD helpers
+    # ------------------------------
+    def list_items(self, user_id: UUID) -> List[PortfolioItem]:
+        with self._session_scope() as session:
+            records = (
+                session.scalars(
+                    select(PortfolioItem).where(PortfolioItem.user_id == user_id)
+                )
+                .unique()
+                .all()
+            )
+            for record in records:
+                session.expunge(record)
+            return records
+
+    def create_item(self, user_id: UUID, *, symbol: str, amount: float) -> PortfolioItem:
+        normalized_symbol = symbol.strip().upper()
+        if not normalized_symbol:
+            raise ValueError("El símbolo es obligatorio")
+        try:
+            normalized_amount = float(amount)
+        except (TypeError, ValueError) as exc:  # pragma: no cover - defensive
+            raise ValueError("La cantidad debe ser numérica") from exc
+        if normalized_amount <= 0:
+            raise ValueError("La cantidad debe ser mayor que cero")
+
+        with self._session_scope() as session:
+            item = PortfolioItem(
+                user_id=user_id,
+                symbol=normalized_symbol,
+                amount=Decimal(str(normalized_amount)),
+            )
+            session.add(item)
+            session.flush()
+            session.refresh(item)
+            session.expunge(item)
+            return item
+
+    def delete_item(self, user_id: UUID, item_id: UUID) -> bool:
+        with self._session_scope() as session:
+            stmt = (
+                delete(PortfolioItem)
+                .where(PortfolioItem.user_id == user_id)
+                .where(PortfolioItem.id == item_id)
+            )
+            result = session.execute(stmt)
+            return result.rowcount > 0
+
+    # ------------------------------
+    # Valuation helpers
+    # ------------------------------
+    async def get_portfolio_overview(self, user_id: UUID) -> Dict[str, Any]:
+        items = self.list_items(user_id)
+        if not items:
+            return {"items": [], "total_value": 0.0}
+
+        prices = await asyncio.gather(
+            *[self._resolve_price(item.symbol) for item in items]
+        )
+
+        overview_items: List[Dict[str, Any]] = []
+        total_value = 0.0
+        for item, price in zip(items, prices):
+            amount_float = float(item.amount)
+            value = price * amount_float if price is not None else None
+            if value is not None:
+                total_value += value
+            overview_items.append(
+                {
+                    "id": item.id,
+                    "symbol": item.symbol,
+                    "amount": amount_float,
+                    "price": price,
+                    "value": value,
+                }
+            )
+
+        return {
+            "items": overview_items,
+            "total_value": round(total_value, 2),
+        }
+
+    async def _resolve_price(self, symbol: str) -> Optional[float]:
+        normalized = symbol.strip().upper()
+        # Try crypto first
+        if market_service is not None:
+            try:
+                crypto = await market_service.get_crypto_price(normalized)
+            except Exception:  # pragma: no cover - defensive logging happens upstream
+                crypto = None
+            if crypto and crypto.get("price") is not None:
+                try:
+                    return float(crypto["price"])
+                except (TypeError, ValueError):
+                    pass
+
+            try:
+                stock = await market_service.get_stock_price(normalized)
+            except Exception:  # pragma: no cover
+                stock = None
+            if stock and stock.get("price") is not None:
+                try:
+                    return float(stock["price"])
+                except (TypeError, ValueError):
+                    pass
+
+        if forex_service is not None:
+            try:
+                fx = await forex_service.get_quote(normalized)
+            except Exception:  # pragma: no cover
+                fx = None
+            if fx and fx.get("price") is not None:
+                try:
+                    return float(fx["price"])
+                except (TypeError, ValueError):
+                    pass
+
+        return None
+
+
+portfolio_service = PortfolioService()
+
+__all__ = ["PortfolioService", "portfolio_service", "PortfolioItemNotFoundError"]

--- a/backend/tests/test_portfolio_endpoints.py
+++ b/backend/tests/test_portfolio_endpoints.py
@@ -1,0 +1,135 @@
+import uuid
+import uuid
+from dataclasses import dataclass
+from typing import Optional
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from backend.tests._dependency_stubs import ensure as ensure_test_dependencies
+
+ensure_test_dependencies()
+
+from backend.main import app
+from backend.models import Base, User, PortfolioItem  # noqa: F401 - ensure table registration
+from backend.routers import portfolio as portfolio_router
+from backend.services.portfolio_service import PortfolioService
+
+
+@dataclass
+class DummyUser:
+    id: uuid.UUID
+    email: str
+
+
+class DummyUserService:
+    class InvalidTokenError(Exception):
+        pass
+
+    def __init__(self, user: DummyUser) -> None:
+        self._user = user
+
+    def get_current_user(self, token: str) -> DummyUser:
+        if token != "valid-token":
+            raise self.InvalidTokenError("Token inválido")
+        return self._user
+
+
+@pytest.fixture()
+def sqlite_session_factory() -> sessionmaker:
+    engine = create_engine(
+        "sqlite+pysqlite:///:memory:",
+        future=True,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine, future=True)
+
+
+@pytest.fixture()
+def persisted_user(sqlite_session_factory: sessionmaker) -> DummyUser:
+    with sqlite_session_factory() as session:
+        user = User(email="user@example.com", password_hash="hashed")
+        session.add(user)
+        session.commit()
+        session.refresh(user)
+        session.expunge(user)
+        return DummyUser(id=user.id, email=user.email)
+
+
+class StubPortfolioService(PortfolioService):
+    def __init__(self, session_factory: sessionmaker) -> None:
+        super().__init__(session_factory=session_factory)
+        self._prices = {"BTCUSDT": 50000.0, "AAPL": 180.0, "EURUSD": 1.1}
+
+    async def _resolve_price(self, symbol: str) -> Optional[float]:
+        return self._prices.get(symbol.strip().upper())
+
+
+@pytest.fixture()
+def configured_service(sqlite_session_factory: sessionmaker) -> PortfolioService:
+    return StubPortfolioService(session_factory=sqlite_session_factory)
+
+
+@pytest_asyncio.fixture()
+async def client(
+    configured_service: PortfolioService,
+    persisted_user: DummyUser,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    dummy_user_service = DummyUserService(persisted_user)
+    monkeypatch.setattr(portfolio_router, "user_service", dummy_user_service)
+    monkeypatch.setattr(
+        portfolio_router, "InvalidTokenError", DummyUserService.InvalidTokenError
+    )
+    monkeypatch.setattr(portfolio_router, "USER_SERVICE_ERROR", None)
+    monkeypatch.setattr(portfolio_router, "portfolio_service", configured_service)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+        yield client
+
+
+@pytest.mark.asyncio()
+async def test_portfolio_crud_and_summary(
+    client: AsyncClient,
+):
+    headers = {"Authorization": "Bearer valid-token"}
+
+    create_one = await client.post(
+        "/api/portfolio", json={"symbol": "btcUSDT", "amount": 0.5}, headers=headers
+    )
+    assert create_one.status_code == 201
+    first_id = create_one.json()["id"]
+
+    create_two = await client.post(
+        "/api/portfolio", json={"symbol": "AAPL", "amount": 10}, headers=headers
+    )
+    assert create_two.status_code == 201
+
+    response = await client.get("/api/portfolio", headers=headers)
+    assert response.status_code == 200
+    payload = response.json()
+
+    assert pytest.approx(payload["total_value"], rel=1e-3) == 26800.0
+    assert len(payload["items"]) == 2
+
+    btc_entry = next(item for item in payload["items"] if item["symbol"] == "BTCUSDT")
+    assert btc_entry["price"] == 50000.0
+    assert pytest.approx(btc_entry["value"], rel=1e-6) == 25000.0
+
+    delete_resp = await client.delete(f"/api/portfolio/{first_id}", headers=headers)
+    assert delete_resp.status_code == 200
+    assert delete_resp.json()["id"] == first_id
+
+    updated = await client.get("/api/portfolio", headers=headers)
+    assert updated.status_code == 200
+    remaining = updated.json()
+    assert len(remaining["items"]) == 1
+    assert remaining["items"][0]["symbol"] == "AAPL"
+    assert pytest.approx(remaining["total_value"], rel=1e-3) == 1800.0

--- a/frontend/src/components/portfolio/PortfolioPanel.tsx
+++ b/frontend/src/components/portfolio/PortfolioPanel.tsx
@@ -1,0 +1,199 @@
+"use client";
+
+import { useCallback, useMemo, useState } from "react";
+import useSWR from "swr";
+import { PlusCircle, Trash2 } from "lucide-react";
+
+import {
+  PortfolioItem,
+  PortfolioSummary,
+  createPortfolioItem,
+  deletePortfolioItem,
+  listPortfolio,
+} from "@/lib/api";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Badge } from "@/components/ui/badge";
+
+const currencyFormatter = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+});
+
+interface PortfolioPanelProps {
+  token?: string;
+}
+
+export function PortfolioPanel({ token }: PortfolioPanelProps) {
+  const { data, error, mutate, isLoading } = useSWR<PortfolioSummary>(
+    token ? ["portfolio", token] : null,
+    () => listPortfolio(token!)
+  );
+
+  const [symbol, setSymbol] = useState("");
+  const [amount, setAmount] = useState<string>("");
+  const [formError, setFormError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const totalValue = data?.total_value ?? 0;
+  const formattedTotal = useMemo(() => currencyFormatter.format(totalValue), [totalValue]);
+
+  const handleSubmit = useCallback(
+    async (event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      if (!token) return;
+
+      const trimmedSymbol = symbol.trim();
+      if (!trimmedSymbol) {
+        setFormError("Debes indicar el símbolo del activo.");
+        return;
+      }
+
+      if (amount.trim().length === 0) {
+        setFormError("Debes indicar la cantidad del activo.");
+        return;
+      }
+
+      const numericAmount = Number(amount);
+      if (Number.isNaN(numericAmount) || numericAmount <= 0) {
+        setFormError("La cantidad debe ser mayor que cero.");
+        return;
+      }
+
+      setSubmitting(true);
+      setFormError(null);
+      try {
+        await createPortfolioItem(token, {
+          symbol: trimmedSymbol.toUpperCase(),
+          amount: numericAmount,
+        });
+        setSymbol("");
+        setAmount("");
+        await mutate();
+      } catch (err) {
+        console.error(err);
+        setFormError(
+          err instanceof Error
+            ? err.message
+            : "No se pudo agregar el activo al portafolio."
+        );
+      } finally {
+        setSubmitting(false);
+      }
+    },
+    [amount, mutate, symbol, token]
+  );
+
+  const handleDelete = useCallback(
+    async (item: PortfolioItem) => {
+      if (!token) return;
+      try {
+        await deletePortfolioItem(token, String(item.id));
+        await mutate();
+      } catch (err) {
+        console.error(err);
+        setFormError(
+          err instanceof Error
+            ? err.message
+            : "No se pudo eliminar el activo del portafolio."
+        );
+      }
+    },
+    [mutate, token]
+  );
+
+  return (
+    <Card className="flex flex-col">
+      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-3">
+        <div>
+          <CardTitle className="text-lg font-medium">Portafolio</CardTitle>
+          <p className="text-sm text-muted-foreground">
+            Administra tus posiciones y consulta su valoración estimada.
+          </p>
+        </div>
+        <Badge variant="secondary">Total: {formattedTotal}</Badge>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <form onSubmit={handleSubmit} className="space-y-3">
+          <div className="grid gap-2 md:grid-cols-2">
+            <Input
+              placeholder="Activo (ej. BTCUSDT, AAPL, EURUSD)"
+              value={symbol}
+              onChange={(event) => setSymbol(event.target.value)}
+              disabled={!token || submitting}
+            />
+            <Input
+              placeholder="Cantidad"
+              value={amount}
+              onChange={(event) => setAmount(event.target.value)}
+              disabled={!token || submitting}
+              inputMode="decimal"
+            />
+          </div>
+          {formError && <p className="text-sm text-destructive">{formError}</p>}
+          <Button type="submit" disabled={!token || submitting} className="w-full">
+            <PlusCircle className="mr-2 h-4 w-4" />
+            {submitting ? "Agregando..." : "Agregar activo"}
+          </Button>
+        </form>
+
+        <div className="space-y-3">
+          {isLoading && (
+            <p className="text-sm text-muted-foreground">Cargando portafolio...</p>
+          )}
+          {error && (
+            <p className="text-sm text-destructive">
+              Error al cargar el portafolio:{" "}
+              {error instanceof Error ? error.message : "Desconocido"}
+            </p>
+          )}
+          {!isLoading && !error && (!data || data.items.length === 0) && (
+            <p className="text-sm text-muted-foreground">
+              Todavía no tienes activos registrados. Agrega uno para ver su valoración.
+            </p>
+          )}
+
+          {data?.items.map((item) => {
+            const priceLabel =
+              typeof item.price === "number"
+                ? currencyFormatter.format(item.price)
+                : "Sin datos";
+            const valueLabel =
+              typeof item.value === "number"
+                ? currencyFormatter.format(item.value)
+                : "-";
+
+            return (
+              <div
+                key={item.id}
+                className="flex flex-col gap-2 rounded-lg border p-3 md:flex-row md:items-center md:justify-between"
+              >
+                <div>
+                  <p className="font-medium">{item.symbol}</p>
+                  <p className="text-xs text-muted-foreground">
+                    Cantidad: {item.amount.toLocaleString("en-US")}
+                  </p>
+                  <p className="text-xs text-muted-foreground">Precio: {priceLabel}</p>
+                </div>
+                <div className="flex items-center gap-3">
+                  <p className="text-sm font-semibold">{valueLabel}</p>
+                  <Button
+                    type="button"
+                    variant="destructive"
+                    size="icon"
+                    disabled={!token}
+                    aria-label={`Eliminar ${item.symbol}`}
+                    onClick={() => handleDelete(item)}
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </Button>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/components/portfolio/__tests__/PortfolioPanel.test.tsx
+++ b/frontend/src/components/portfolio/__tests__/PortfolioPanel.test.tsx
@@ -1,0 +1,263 @@
+import { act, customRender, screen, waitFor } from "@/tests/utils/renderWithProviders";
+import userEvent from "@testing-library/user-event";
+import useSWR from "swr";
+
+import {
+  PortfolioPanel
+} from "../PortfolioPanel";
+import {
+  createPortfolioItem,
+  deletePortfolioItem,
+  listPortfolio,
+} from "@/lib/api";
+
+jest.mock("swr", () => {
+  const actual = jest.requireActual("swr");
+  return {
+    __esModule: true,
+    ...actual,
+    default: jest.fn(),
+    SWRConfig: actual.SWRConfig,
+  };
+});
+
+jest.mock("@/lib/api", () => ({
+  createPortfolioItem: jest.fn(),
+  deletePortfolioItem: jest.fn(),
+  listPortfolio: jest.fn(),
+}));
+
+const mockedUseSWR = useSWR as jest.MockedFunction<typeof useSWR>;
+const mockedCreatePortfolioItem =
+  createPortfolioItem as jest.MockedFunction<typeof createPortfolioItem>;
+const mockedDeletePortfolioItem =
+  deletePortfolioItem as jest.MockedFunction<typeof deletePortfolioItem>;
+const mockedListPortfolio = listPortfolio as jest.MockedFunction<typeof listPortfolio>;
+
+describe("PortfolioPanel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedUseSWR.mockReturnValue({
+      data: undefined,
+      error: undefined,
+      mutate: jest.fn().mockResolvedValue(undefined),
+      isLoading: false,
+    } as any);
+  });
+
+  it("no consulta el portafolio cuando falta el token", () => {
+    customRender(<PortfolioPanel token={undefined} />);
+
+    expect(mockedUseSWR).toHaveBeenCalledWith(null, expect.any(Function));
+    expect(mockedListPortfolio).not.toHaveBeenCalled();
+  });
+
+  it("renderiza el total y los activos cuando hay datos", () => {
+    mockedUseSWR.mockReturnValue({
+      data: {
+        total_value: 26800,
+        items: [
+          { id: "1", symbol: "BTCUSDT", amount: 0.5, price: 50000, value: 25000 },
+          { id: "2", symbol: "AAPL", amount: 10, price: 180, value: 1800 },
+        ],
+      },
+      error: undefined,
+      mutate: jest.fn(),
+      isLoading: false,
+    } as any);
+
+    customRender(<PortfolioPanel token="demo" />);
+
+    expect(screen.getByText(/Total:\s+\$26,800\.00/)).toBeInTheDocument();
+    expect(screen.getByText("BTCUSDT")).toBeInTheDocument();
+    expect(screen.getByText("AAPL")).toBeInTheDocument();
+    expect(screen.getByText(/Precio:\s+\$50,000\.00/)).toBeInTheDocument();
+    expect(screen.getByText("$1,800.00")).toBeInTheDocument();
+  });
+
+  it("muestra mensajes de carga y error según corresponda", () => {
+    mockedUseSWR
+      .mockReturnValueOnce({
+        data: undefined,
+        error: undefined,
+        mutate: jest.fn(),
+        isLoading: true,
+      } as any)
+      .mockReturnValueOnce({
+        data: undefined,
+        error: new Error("Fallo"),
+        mutate: jest.fn(),
+        isLoading: false,
+      } as any);
+
+    const { rerender } = customRender(<PortfolioPanel token="demo" />);
+    expect(screen.getByText(/Cargando portafolio/i)).toBeInTheDocument();
+
+    rerender(<PortfolioPanel token="demo" />);
+    expect(screen.getByText(/Error al cargar el portafolio/i)).toBeInTheDocument();
+  });
+
+  it("permite agregar un nuevo activo", async () => {
+    const mutate = jest.fn().mockResolvedValue(undefined);
+    mockedUseSWR.mockReturnValue({
+      data: {
+        total_value: 0,
+        items: [],
+      },
+      error: undefined,
+      mutate,
+      isLoading: false,
+    } as any);
+
+    mockedCreatePortfolioItem.mockResolvedValue({
+      id: "1",
+      symbol: "BTCUSDT",
+      amount: 0.5,
+    } as any);
+
+    const user = userEvent.setup();
+    customRender(<PortfolioPanel token="secure" />);
+
+    await act(async () => {
+      await user.type(
+        screen.getByPlaceholderText("Activo (ej. BTCUSDT, AAPL, EURUSD)"),
+        " btcusdt "
+      );
+      await user.type(screen.getByPlaceholderText("Cantidad"), "0.5");
+      await user.click(screen.getByRole("button", { name: /agregar activo/i }));
+    });
+
+    await waitFor(() => {
+      expect(mockedCreatePortfolioItem).toHaveBeenCalledWith("secure", {
+        symbol: "BTCUSDT",
+        amount: 0.5,
+      });
+    });
+
+    expect(mutate).toHaveBeenCalled();
+  });
+
+  it("muestra un mensaje de error cuando crear el activo falla", async () => {
+    const mutate = jest.fn().mockResolvedValue(undefined);
+    mockedUseSWR.mockReturnValue({
+      data: { total_value: 0, items: [] },
+      error: undefined,
+      mutate,
+      isLoading: false,
+    } as any);
+
+    mockedCreatePortfolioItem.mockRejectedValueOnce(new Error("API down"));
+    const consoleSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    const user = userEvent.setup();
+
+    try {
+      customRender(<PortfolioPanel token="secure" />);
+
+      await act(async () => {
+        await user.type(
+          screen.getByPlaceholderText("Activo (ej. BTCUSDT, AAPL, EURUSD)"),
+          "AAPL"
+        );
+        await user.type(screen.getByPlaceholderText("Cantidad"), "2");
+        await user.click(screen.getByRole("button", { name: /agregar activo/i }));
+      });
+
+      expect(await screen.findByText("API down")).toBeInTheDocument();
+    } finally {
+      consoleSpy.mockRestore();
+    }
+  });
+
+  it("muestra un error de validación si la cantidad es inválida", async () => {
+    const user = userEvent.setup();
+    customRender(<PortfolioPanel token="secure" />);
+
+    await act(async () => {
+      await user.type(
+        screen.getByPlaceholderText("Activo (ej. BTCUSDT, AAPL, EURUSD)"),
+        "AAPL"
+      );
+      await user.type(screen.getByPlaceholderText("Cantidad"), "0");
+      await user.click(screen.getByRole("button", { name: /agregar activo/i }));
+    });
+
+    expect(
+      screen.getByText("La cantidad debe ser mayor que cero.")
+    ).toBeInTheDocument();
+    expect(mockedCreatePortfolioItem).not.toHaveBeenCalled();
+  });
+
+  it("elimina un activo y actualiza el portafolio", async () => {
+    const mutate = jest.fn().mockResolvedValue(undefined);
+    mockedUseSWR.mockReturnValue({
+      data: {
+        total_value: 1000,
+        items: [{ id: "1", symbol: "AAPL", amount: 10, price: 180, value: 1800 }],
+      },
+      error: undefined,
+      mutate,
+      isLoading: false,
+    } as any);
+
+    mockedDeletePortfolioItem.mockResolvedValue(undefined);
+
+    const user = userEvent.setup();
+    customRender(<PortfolioPanel token="secure" />);
+
+    await act(async () => {
+      await user.click(screen.getByRole("button", { name: /eliminar aapl/i }));
+    });
+
+    await waitFor(() => {
+      expect(mockedDeletePortfolioItem).toHaveBeenCalledWith("secure", "1");
+    });
+    expect(mutate).toHaveBeenCalled();
+  });
+
+  it("muestra un mensaje cuando faltan precios para un activo", () => {
+    mockedUseSWR.mockReturnValue({
+      data: {
+        total_value: 0,
+        items: [{ id: "x", symbol: "EURUSD", amount: 1000, price: null, value: null }],
+      },
+      error: undefined,
+      mutate: jest.fn(),
+      isLoading: false,
+    } as any);
+
+    customRender(<PortfolioPanel token="demo" />);
+
+    expect(screen.getByText(/EURUSD/)).toBeInTheDocument();
+    expect(screen.getByText(/Precio:\s+Sin datos/i)).toBeInTheDocument();
+    expect(screen.getByText(/^\s*-\s*$/)).toBeInTheDocument();
+  });
+
+  it("informa un error cuando eliminar un activo falla", async () => {
+    const mutate = jest.fn().mockResolvedValue(undefined);
+    mockedUseSWR.mockReturnValue({
+      data: {
+        total_value: 1000,
+        items: [{ id: "1", symbol: "AAPL", amount: 10, price: 180, value: 1800 }],
+      },
+      error: undefined,
+      mutate,
+      isLoading: false,
+    } as any);
+
+    mockedDeletePortfolioItem.mockRejectedValueOnce(new Error("No se pudo"));
+    const consoleSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    const user = userEvent.setup();
+
+    try {
+      customRender(<PortfolioPanel token="secure" />);
+
+      await act(async () => {
+        await user.click(screen.getByRole("button", { name: /eliminar aapl/i }));
+      });
+
+      expect(await screen.findByText("No se pudo")).toBeInTheDocument();
+    } finally {
+      consoleSpy.mockRestore();
+    }
+  });
+});

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -66,6 +66,19 @@ export interface Alert {
   [key: string]: unknown;
 }
 
+export interface PortfolioItem {
+  id: string;
+  symbol: string;
+  amount: number;
+  price?: number | null;
+  value?: number | null;
+}
+
+export interface PortfolioSummary {
+  items: PortfolioItem[];
+  total_value: number;
+}
+
 export interface NewsItem {
   id: string | number;
   title: string;
@@ -351,6 +364,38 @@ export function suggestAlertCondition(
     {
       method: "POST",
       body: JSON.stringify(payload),
+    },
+    token
+  );
+}
+
+/* ===========
+   PORTFOLIO
+   =========== */
+
+export function listPortfolio(token: string) {
+  return request<PortfolioSummary>("/api/portfolio", { method: "GET" }, token);
+}
+
+export function createPortfolioItem(
+  token: string,
+  payload: { symbol: string; amount: number }
+) {
+  return request<PortfolioItem>(
+    "/api/portfolio",
+    {
+      method: "POST",
+      body: JSON.stringify(payload),
+    },
+    token
+  );
+}
+
+export function deletePortfolioItem(token: string, id: string | number) {
+  return request<void>(
+    `/api/portfolio/${id}`,
+    {
+      method: "DELETE",
     },
     token
   );


### PR DESCRIPTION
## Summary
- add database support for user portfolio holdings and expose CRUD endpoints with valuation logic
- provide backend tests for portfolio API along with service integration
- implement portfolio panel UI with SWR integration, client-side validation, and accompanying tests

## Testing
- pytest backend/tests/test_portfolio_endpoints.py
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68db333b62bc8321b47860a5c120da71