### PR TITLE
Add portfolio page route and integration coverage

### DIFF
--- a/frontend/src/app/__tests__/portfolio-page.test.tsx
+++ b/frontend/src/app/__tests__/portfolio-page.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { SWRConfig } from "swr";
+
+import PortfolioPage from "../portfolio/page";
+import { createMockPortfolioHandlers } from "@/tests/msw/handlers";
+import { server } from "@/tests/msw/server";
+
+jest.mock("@/components/providers/auth-provider", () => ({
+  useAuth: jest.fn(),
+}));
+
+jest.mock("next/navigation", () => ({
+  useRouter: jest.fn(),
+}));
+
+const { useAuth } = jest.requireMock("@/components/providers/auth-provider");
+const { useRouter } = jest.requireMock("next/navigation");
+
+const mockedUseAuth = useAuth as jest.Mock;
+const mockedUseRouter = useRouter as jest.Mock;
+
+function renderPortfolioPage() {
+  mockedUseRouter.mockReturnValue({ replace: jest.fn() });
+  mockedUseAuth.mockReturnValue({
+    user: { id: "1", email: "trader@example.com", name: "Trader" },
+    token: "secure-token",
+    loading: false,
+  });
+
+  return render(
+    <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
+      <PortfolioPage />
+    </SWRConfig>
+  );
+}
+
+describe("PortfolioPage", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renderiza el panel de portafolio con datos iniciales", async () => {
+    server.use(
+      ...createMockPortfolioHandlers({
+        initialItems: [
+          { symbol: "ETHUSDT", amount: 2 },
+        ],
+      })
+    );
+
+    renderPortfolioPage();
+
+    expect(await screen.findByText(/tu portafolio/i)).toBeInTheDocument();
+    expect(await screen.findByText("ETHUSDT")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText(/Total: \$240.00/)).toBeInTheDocument();
+    });
+  });
+
+  it("permite agregar y eliminar activos desde la interfaz", async () => {
+    server.use(
+      ...createMockPortfolioHandlers({
+        initialItems: [
+          { id: "1", symbol: "BTCUSDT", amount: 0.5, price: 50000, value: 25000 },
+        ],
+        defaultPrice: 100,
+      })
+    );
+
+    const user = userEvent.setup();
+    renderPortfolioPage();
+
+    expect(await screen.findByText("BTCUSDT")).toBeInTheDocument();
+
+    await user.type(
+      screen.getByPlaceholderText(/Activo/),
+      "aapl"
+    );
+    await user.type(screen.getByPlaceholderText(/Cantidad/), "3");
+    await user.click(screen.getByRole("button", { name: /Agregar activo/i }));
+
+    expect(await screen.findByText("AAPL")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText("$300.00")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: /Eliminar AAPL/i }));
+
+    await waitFor(() => {
+      expect(screen.queryByText("AAPL")).not.toBeInTheDocument();
+      expect(screen.getByText("BTCUSDT")).toBeInTheDocument();
+      expect(screen.getByText(/Total: \$25,000.00/)).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/app/portfolio/page.tsx
+++ b/frontend/src/app/portfolio/page.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+
+import { useAuth } from "@/components/providers/auth-provider";
+import { PortfolioPanel } from "@/components/portfolio/PortfolioPanel";
+
+export default function PortfolioPage() {
+  const { user, token, loading } = useAuth();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!loading && !user) {
+      router.replace("/login");
+    }
+  }, [loading, router, user]);
+
+  if (loading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-background">
+        <p className="text-muted-foreground">Cargando portafolio...</p>
+      </div>
+    );
+  }
+
+  if (!user) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-background">
+        <p className="text-muted-foreground">Redirigiendo al acceso...</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex min-h-screen bg-background p-6 text-foreground">
+      <div className="mx-auto flex w-full max-w-5xl flex-col gap-6">
+        <header className="space-y-1">
+          <p className="text-sm text-muted-foreground">Gestiona tus posiciones</p>
+          <h1 className="text-3xl font-semibold">Tu portafolio</h1>
+        </header>
+        <PortfolioPanel token={token ?? undefined} />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/sidebar/market-sidebar.tsx
+++ b/frontend/src/components/sidebar/market-sidebar.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import useSWR from "swr";
 import { useMemo } from "react";
 import { LineChart, Coins, Wallet } from "lucide-react";
@@ -83,9 +84,17 @@ export function MarketSidebar({ token, user, onLogout }: MarketSidebarProps) {
   return (
     <div className="flex h-full flex-col gap-4 p-4">
       <Card className="border-none bg-transparent shadow-none">
-        <CardContent className="p-0">
-          <h2 className="text-xl font-semibold">BullBearBroker</h2>
-          <p className="text-sm text-muted-foreground">{user.email}</p>
+        <CardContent className="space-y-3 p-0">
+          <div>
+            <h2 className="text-xl font-semibold">BullBearBroker</h2>
+            <p className="text-sm text-muted-foreground">{user.email}</p>
+          </div>
+          <Button variant="secondary" size="sm" className="w-full" asChild>
+            <Link href="/portfolio" className="flex items-center justify-center gap-2">
+              <Wallet className="h-4 w-4" />
+              <span>Ver portafolio</span>
+            </Link>
+          </Button>
         </CardContent>
       </Card>
       <ScrollArea className="flex-1">

--- a/frontend/src/tests/msw/__tests__/handlers.test.ts
+++ b/frontend/src/tests/msw/__tests__/handlers.test.ts
@@ -1,0 +1,103 @@
+import {
+  makeMarketRateLimitHandler,
+  createMockPortfolioHandlers,
+  newsTooManyRequestHandler,
+} from "@/tests/msw/handlers";
+
+describe("MSW handler helpers", () => {
+  it("retorna 429 para rate limit en mercados", async () => {
+    const handler = makeMarketRateLimitHandler("crypto");
+    const response = await handler.resolver(
+      { request: new Request("https://example.com/api/markets/crypto/prices") } as any,
+      undefined as any,
+      undefined as any
+    );
+
+    expect(response?.status).toBe(429);
+  });
+
+  it("retorna 429 cuando noticias están limitadas", async () => {
+    const response = await newsTooManyRequestHandler.resolver(
+      { request: new Request("https://example.com/api/news/latest") } as any,
+      undefined as any,
+      undefined as any
+    );
+
+    expect(response?.status).toBe(429);
+  });
+
+  it("gestiona flujo básico de portafolio", async () => {
+    const [getHandler, postHandler, deleteHandler] = createMockPortfolioHandlers({
+      initialItems: [{ symbol: "ETHUSDT", amount: 1.5 }],
+      defaultPrice: 200,
+    });
+
+    const initial = await getHandler.resolver(
+      { request: new Request("https://example.com/api/portfolio") } as any,
+      undefined as any,
+      undefined as any
+    );
+    expect(await initial?.json()).toMatchObject({ total_value: 300 });
+
+    await postHandler.resolver(
+      {
+        request: new Request("https://example.com/api/portfolio", {
+          method: "POST",
+          body: JSON.stringify({ symbol: "aapl", amount: 2 }),
+        }),
+      } as any,
+      undefined as any,
+      undefined as any
+    );
+
+    const afterAdd = await getHandler.resolver(
+      { request: new Request("https://example.com/api/portfolio") } as any,
+      undefined as any,
+      undefined as any
+    );
+    const payload = await afterAdd?.json();
+    expect(payload.items).toHaveLength(2);
+    expect(payload.total_value).toBe(700);
+
+    await deleteHandler.resolver(
+      { params: { id: payload.items[0].id }, request: new Request("https://example.com/api/portfolio/1", { method: "DELETE" }) } as any,
+      undefined as any,
+      undefined as any
+    );
+
+    const afterDelete = await getHandler.resolver(
+      { request: new Request("https://example.com/api/portfolio") } as any,
+      undefined as any,
+      undefined as any
+    );
+    const finalPayload = await afterDelete?.json();
+    expect(finalPayload.items).toHaveLength(1);
+    expect(finalPayload.total_value).toBe(400);
+
+    const [emptyGet, emptyPost, emptyDelete] = createMockPortfolioHandlers();
+
+    const emptyResponse = await emptyGet.resolver(
+      { request: new Request("https://example.com/api/portfolio") } as any,
+      undefined as any,
+      undefined as any
+    );
+    expect(await emptyResponse?.json()).toEqual({ items: [], total_value: 0 });
+
+    await emptyPost.resolver(
+      {
+        request: new Request("https://example.com/api/portfolio", {
+          method: "POST",
+          body: JSON.stringify({ amount: "invalid" }),
+        }),
+      } as any,
+      undefined as any,
+      undefined as any
+    );
+
+    await emptyDelete.resolver(
+      { params: {}, request: new Request("https://example.com/api/portfolio/x", { method: "DELETE" }) } as any,
+      undefined as any,
+      undefined as any
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add a protected /portfolio page that renders the PortfolioPanel component for authenticated users
- surface a "Ver portafolio" entry in the market sidebar and expose reusable MSW handlers for portfolio requests
- cover the new route and handlers with integration tests to exercise CRUD flows end-to-end

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68db3c493578832188373330083c0d67