### PR TITLE
Integrate portfolio module into dashboard layout

### DIFF
--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,6 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
 /// <reference types="next/navigation-types/compat/navigation" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/frontend/src/components/dashboard/__tests__/dashboard-integration.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/dashboard-integration.test.tsx
@@ -1,0 +1,231 @@
+import React from "react";
+import {
+  act,
+  customRender,
+  screen,
+  waitFor,
+  within,
+} from "@/tests/utils/renderWithProviders";
+import userEvent from "@testing-library/user-event";
+
+jest.mock("@/components/providers/auth-provider", () => {
+  const actual = jest.requireActual("@/components/providers/auth-provider");
+  return {
+    ...actual,
+    AuthProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    useAuth: jest.fn(),
+  };
+});
+
+const { useAuth: mockUseAuth } = jest.requireMock(
+  "@/components/providers/auth-provider"
+) as {
+  useAuth: jest.Mock;
+};
+
+jest.mock("@/components/providers/theme-provider", () => ({
+  ThemeProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+jest.mock("next/navigation", () => ({
+  useRouter: jest.fn(),
+}));
+
+const { useRouter: mockUseRouter } = jest.requireMock(
+  "next/navigation"
+) as {
+  useRouter: jest.Mock;
+};
+
+const mockedGetIndicators = jest.fn();
+const mockedSendChatMessage = jest.fn();
+const mockedListPortfolio = jest.fn();
+const mockedCreatePortfolioItem = jest.fn();
+const mockedDeletePortfolioItem = jest.fn();
+const mockedListAlerts = jest.fn();
+const mockedCreateAlert = jest.fn();
+const mockedUpdateAlert = jest.fn();
+const mockedDeleteAlert = jest.fn();
+const mockedSendAlertNotification = jest.fn();
+const mockedSuggestAlertCondition = jest.fn();
+const mockedListNews = jest.fn();
+const mockedGetMarketQuote = jest.fn();
+
+jest.mock("@/lib/api", () => {
+  const actual = jest.requireActual("@/lib/api");
+  return {
+    ...actual,
+    getIndicators: (...args: any[]) => mockedGetIndicators(...args),
+    sendChatMessage: (...args: any[]) => mockedSendChatMessage(...args),
+    listPortfolio: (...args: any[]) => mockedListPortfolio(...args),
+    createPortfolioItem: (...args: any[]) => mockedCreatePortfolioItem(...args),
+    deletePortfolioItem: (...args: any[]) => mockedDeletePortfolioItem(...args),
+    listAlerts: (...args: any[]) => mockedListAlerts(...args),
+    createAlert: (...args: any[]) => mockedCreateAlert(...args),
+    updateAlert: (...args: any[]) => mockedUpdateAlert(...args),
+    deleteAlert: (...args: any[]) => mockedDeleteAlert(...args),
+    sendAlertNotification: (...args: any[]) =>
+      mockedSendAlertNotification(...args),
+    suggestAlertCondition: (...args: any[]) =>
+      mockedSuggestAlertCondition(...args),
+    listNews: (...args: any[]) => mockedListNews(...args),
+    getMarketQuote: (...args: any[]) => mockedGetMarketQuote(...args),
+  };
+});
+
+import { DashboardPage } from "../dashboard-page";
+
+const baseAuth = {
+  logout: jest.fn(),
+  token: "token-123",
+  user: { id: "1", email: "user@example.com", name: "Ana" },
+};
+
+const portfolioFixture = {
+  total_value: 12500,
+  items: [
+    {
+      id: "1",
+      symbol: "BTCUSDT",
+      amount: 0.5,
+      price: 25000,
+      value: 12500,
+    },
+  ],
+};
+
+const alertsFixture = [
+  {
+    id: "1",
+    title: "BTC arriba",
+    asset: "BTC",
+    condition: "> 30000",
+    value: 30000,
+    active: true,
+  },
+];
+
+const newsFixture = [
+  {
+    id: "1",
+    title: "Mercados en alza",
+    url: "https://example.com/news",
+    summary: "Resumen de mercado",
+    source: "Reuters",
+    published_at: new Date("2024-01-15T10:00:00Z").toISOString(),
+  },
+];
+
+describe("DashboardPage integration", () => {
+  beforeAll(() => {
+    class ResizeObserverMock {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+
+    // @ts-expect-error - jsdom no expone ResizeObserver por defecto
+    global.ResizeObserver = ResizeObserverMock;
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseAuth.mockReturnValue({ ...baseAuth, loading: false });
+    mockUseRouter.mockReturnValue({ replace: jest.fn() });
+
+    mockedGetIndicators.mockResolvedValue({
+      symbol: "BTCUSDT",
+      interval: "1h",
+      indicators: { last_close: 12345 },
+      series: { closes: [1, 2, 3] },
+    });
+    mockedSendChatMessage.mockResolvedValue({
+      messages: [{ role: "assistant", content: "Análisis" }],
+      sources: ["indicators"],
+      used_data: true,
+    });
+    mockedListPortfolio.mockResolvedValue(portfolioFixture);
+    mockedCreatePortfolioItem.mockResolvedValue({ id: "2" });
+    mockedDeletePortfolioItem.mockResolvedValue(undefined);
+    mockedListAlerts.mockResolvedValue(alertsFixture);
+    mockedCreateAlert.mockResolvedValue({ id: "2" });
+    mockedUpdateAlert.mockResolvedValue(undefined);
+    mockedDeleteAlert.mockResolvedValue(undefined);
+    mockedSendAlertNotification.mockResolvedValue({ ok: true });
+    mockedSuggestAlertCondition.mockResolvedValue({
+      suggestion: "BTC > 32000",
+      notes: "Basado en momentum",
+    });
+    mockedListNews.mockResolvedValue(newsFixture);
+    mockedGetMarketQuote.mockImplementation(
+      async (type: string, symbol: string) => ({
+        symbol,
+        price: type === "forex" ? 1.08 : 30000,
+        raw_change: 1.25,
+        source: "Demo",
+        type,
+      })
+    );
+  });
+
+  it("renders all dashboard modules and keeps portfolio actions accessible", async () => {
+    await act(async () => {
+      customRender(<DashboardPage />);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: /portafolio/i })).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByRole("heading", { name: /indicadores clave \(BTCUSDT\)/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: /chat con ia/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: /alertas personalizadas/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: /noticias/i })
+    ).toBeInTheDocument();
+
+    const portfolioLink = screen.getByRole("link", { name: /ver portafolio/i });
+    expect(portfolioLink).toHaveAttribute("href", "/portfolio");
+
+    expect(
+      await screen.findByRole("button", { name: /eliminar btcusdt/i })
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Total:/i)).toBeInTheDocument();
+
+    const portfolioCard = screen
+      .getByRole("heading", { name: /portafolio/i })
+      .closest("div")!
+      .parentElement!
+      .parentElement! as HTMLElement;
+
+    const symbolInput = within(portfolioCard).getByPlaceholderText(
+      /BTCUSDT, AAPL, EURUSD/i
+    );
+    const amountInput = within(portfolioCard).getByPlaceholderText(/cantidad/i);
+
+    const user = userEvent.setup();
+
+    await act(async () => {
+      await user.type(symbolInput, "eth");
+      await user.type(amountInput, "2");
+      await user.click(
+        screen.getByRole("button", { name: /agregar activo/i })
+      );
+    });
+
+    await waitFor(() => {
+      expect(mockedCreatePortfolioItem).toHaveBeenCalledWith(
+        baseAuth.token,
+        expect.objectContaining({ symbol: "ETH", amount: 2 })
+      );
+    });
+
+    expect(mockedGetIndicators).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/dashboard/__tests__/dashboard-page.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/dashboard-page.test.tsx
@@ -23,6 +23,7 @@ const mockMarketSidebar = jest.fn(() => <aside data-testid="market-sidebar" />);
 const mockAlertsPanel = jest.fn(() => <section data-testid="alerts-panel" />);
 const mockNewsPanel = jest.fn(() => <section data-testid="news-panel" />);
 const mockChatPanel = jest.fn(() => <section data-testid="chat-panel" />);
+const mockPortfolioPanel = jest.fn(() => <section data-testid="portfolio-panel" />);
 const mockIndicatorsChart = jest.fn((props) => (
   <div data-testid="indicators-chart">{props.symbol}</div>
 ));
@@ -41,6 +42,10 @@ jest.mock("@/components/news/news-panel", () => ({
 
 jest.mock("@/components/chat/chat-panel", () => ({
   ChatPanel: (props: any) => mockChatPanel(props),
+}));
+
+jest.mock("@/components/portfolio/PortfolioPanel", () => ({
+  PortfolioPanel: (props: any) => mockPortfolioPanel(props),
 }));
 
 jest.mock("@/components/indicators/IndicatorsChart", () => ({
@@ -90,6 +95,7 @@ describe("DashboardPage", () => {
     mockAlertsPanel.mockClear();
     mockNewsPanel.mockClear();
     mockChatPanel.mockClear();
+    mockPortfolioPanel.mockClear();
   });
 
   it("muestra la pantalla de carga mientras la sesión está verificándose", () => {
@@ -139,6 +145,9 @@ describe("DashboardPage", () => {
     expect(await screen.findByText(/bienvenido de vuelta/i)).toBeInTheDocument();
     expect(screen.getByText(/Ana/i)).toBeInTheDocument();
     expect(mockMarketSidebar).toHaveBeenCalled();
+    expect(mockPortfolioPanel).toHaveBeenCalledWith(
+      expect.objectContaining({ token: baseAuth.token })
+    );
     expect(mockAlertsPanel).toHaveBeenCalled();
     expect(mockNewsPanel).toHaveBeenCalled();
     expect(mockChatPanel).toHaveBeenCalled();

--- a/frontend/src/components/dashboard/dashboard-page.tsx
+++ b/frontend/src/components/dashboard/dashboard-page.tsx
@@ -7,6 +7,7 @@ import { useAuth } from "@/components/providers/auth-provider";
 import { ChatPanel } from "@/components/chat/chat-panel";
 import { AlertsPanel } from "@/components/alerts/alerts-panel";
 import { NewsPanel } from "@/components/news/news-panel";
+import { PortfolioPanel } from "@/components/portfolio/PortfolioPanel";
 import { MarketSidebar } from "@/components/sidebar/market-sidebar";
 import { ThemeToggle } from "@/components/dashboard/theme-toggle";
 import { IndicatorsChart } from "@/components/indicators/IndicatorsChart"; // [Codex] nuevo
@@ -137,10 +138,11 @@ export function DashboardPage() {
             </Button>
           </div>
         </header>
-        <section className="grid flex-1 gap-6 xl:grid-cols-[2fr_1fr]">
-          <div className="flex flex-col gap-6">
+        <section className="grid flex-1 gap-6 lg:grid-cols-2 xl:grid-cols-[2fr_1fr]">
+          <div className="grid auto-rows-min gap-6">
+            <PortfolioPanel token={token ?? undefined} />
             {/* [Codex] nuevo - tarjeta de indicadores con insights AI */}
-            <Card className="flex flex-col">
+            <Card className="flex flex-col" data-testid="dashboard-indicators">
               <CardHeader className="flex items-center justify-between space-y-0 pb-2">
                 <CardTitle className="text-lg font-medium">
                   Indicadores clave (BTCUSDT)
@@ -178,13 +180,13 @@ export function DashboardPage() {
                 )}
               </CardContent>
             </Card>
-            <Card className="flex flex-col">
+            <Card className="flex flex-col" data-testid="dashboard-chat">
               <CardContent className="flex h-full flex-col gap-4 pt-6">
                 <ChatPanel token={token ?? undefined} />
               </CardContent>
             </Card>
           </div>
-          <div className="flex flex-col gap-6">
+          <div className="grid auto-rows-min gap-6">
             <AlertsPanel token={token ?? undefined} />
             <NewsPanel token={token ?? undefined} />
           </div>


### PR DESCRIPTION
## Summary
- integrate the portfolio panel into the dashboard grid alongside indicators, chat, alerts, and news modules
- add an integration test to assert dashboard modules render, sidebar navigation remains accessible, and portfolio actions can be triggered
- update Next.js generated type references after running the development server

## Testing
- npm --prefix frontend test -- --coverage=false --runTestsByPath src/components/dashboard/__tests__/dashboard-page.test.tsx src/components/dashboard/__tests__/dashboard-integration.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68db4213adc88321936ad7592b0aeb40