### PR TITLE
feat: add real-time alerts websocket integration

### DIFF
--- a/backend/routers/health.py
+++ b/backend/routers/health.py
@@ -1,4 +1,5 @@
 import os
+import os
 import time
 from collections import defaultdict
 

--- a/backend/services/websocket_manager.py
+++ b/backend/services/websocket_manager.py
@@ -1,0 +1,60 @@
+"""Simple connection manager for alert WebSocket clients."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import List, Set
+
+from fastapi import WebSocket
+
+LOGGER = logging.getLogger(__name__)
+
+
+class AlertWebSocketManager:
+    """Stores active WebSocket connections and broadcasts alert payloads."""
+
+    def __init__(self) -> None:
+        self._connections: Set[WebSocket] = set()
+        self._lock = asyncio.Lock()
+
+    async def connect(self, websocket: WebSocket) -> None:
+        await websocket.accept()
+        async with self._lock:
+            self._connections.add(websocket)
+
+    async def disconnect(self, websocket: WebSocket) -> None:
+        async with self._lock:
+            self._connections.discard(websocket)
+
+    async def _snapshot(self) -> List[WebSocket]:
+        async with self._lock:
+            return list(self._connections)
+
+    async def broadcast(self, payload: dict) -> None:
+        recipients = await self._snapshot()
+        if not recipients:
+            return
+
+        for connection in recipients:
+            try:
+                await connection.send_json(payload)
+            except Exception as exc:  # pragma: no cover - defensive logging
+                LOGGER.debug("Removing websocket connection after send error: %s", exc)
+                await self.disconnect(connection)
+
+    async def close(self) -> None:
+        """Close all active connections (used during shutdown/tests)."""
+        recipients = await self._snapshot()
+        for connection in recipients:
+            try:
+                await connection.close()
+            except Exception:  # pragma: no cover - best effort cleanup
+                pass
+
+    async def count(self) -> int:
+        async with self._lock:
+            return len(self._connections)
+
+
+__all__ = ["AlertWebSocketManager"]

--- a/backend/tests/test_alerts_websocket.py
+++ b/backend/tests/test_alerts_websocket.py
@@ -1,0 +1,29 @@
+from fastapi.testclient import TestClient
+
+from backend.main import app
+
+
+def test_alerts_websocket_ping_and_broadcast() -> None:
+    with TestClient(app) as client:
+        with client.websocket_connect("/ws/alerts") as connection:
+            hello = connection.receive_json()
+            assert hello["type"] == "system"
+
+            connection.send_json({"type": "ping"})
+            pong = connection.receive_json()
+            assert pong == {"type": "pong"}
+
+            connection.send_json({"type": "custom", "value": 42})
+            ack = connection.receive_json()
+            assert ack["type"] == "ack"
+            assert ack["received"] == "custom"
+
+            payload = {
+                "type": "alert",
+                "symbol": "BTCUSDT",
+                "price": 42000.0,
+            }
+
+            client.portal.call(client.app.state.alerts_ws_manager.broadcast, payload)
+            broadcast = connection.receive_json()
+            assert broadcast == payload

--- a/backend/tests/test_api_endpoints.py
+++ b/backend/tests/test_api_endpoints.py
@@ -34,6 +34,7 @@ os.environ.setdefault("DATABASE_URL", "postgresql+psycopg://user:pass@localhost/
 from backend.main import app  # noqa: E402  (import after path setup)
 from backend.routers import alerts as alerts_router  # noqa: E402
 from backend.routers import auth as auth_router  # noqa: E402
+from backend.routers import markets as markets_router  # noqa: E402
 from backend.services.alert_service import alert_service  # noqa: E402
 from backend.services.market_service import market_service  # noqa: E402
 from backend.services.news_service import news_service  # noqa: E402
@@ -834,3 +835,138 @@ async def test_alerts_list_returns_created_alert(
     assert alerts[0]["active"] is True
     assert "updated_at" in alerts[0]
     assert alerts[0]["updated_at"]
+
+
+@pytest.mark.asyncio
+async def test_indicators_endpoint_exposes_requested_signals(
+    client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    closes = [100 + idx * 0.5 for idx in range(120)]
+    highs = [price + 1 for price in closes]
+    lows = [price - 1 for price in closes]
+    volumes = [1000 + idx for idx in range(120)]
+    meta = {
+        "source": "stub",
+        "note": "fixtures",
+        "highs": highs,
+        "lows": lows,
+        "volumes": volumes,
+    }
+
+    monkeypatch.setattr(
+        markets_router,
+        "get_closes",
+        AsyncMock(return_value=(closes, meta)),
+    )
+    monkeypatch.setattr(markets_router, "rsi", lambda values, period: 55.5)
+    monkeypatch.setattr(
+        markets_router,
+        "ema",
+        lambda values, period: round(120 + period * 0.1, 2),
+    )
+    monkeypatch.setattr(
+        markets_router,
+        "macd",
+        lambda values, fast, slow, signal: {
+            "macd": 1.23,
+            "signal": 1.1,
+            "hist": 0.13,
+        },
+    )
+    monkeypatch.setattr(
+        markets_router,
+        "bollinger",
+        lambda values, period, mult: {
+            "middle": 123.4,
+            "upper": 130.0,
+            "lower": 117.0,
+            "bandwidth": 0.1,
+        },
+    )
+    monkeypatch.setattr(
+        markets_router,
+        "average_true_range",
+        lambda highs_, lows_, closes_, period: 2.5,
+    )
+    monkeypatch.setattr(
+        markets_router,
+        "stochastic_rsi",
+        lambda closes_, period, smooth_k, smooth_d: {"%K": 40.0, "%D": 35.0},
+    )
+    monkeypatch.setattr(
+        markets_router,
+        "ichimoku_cloud",
+        lambda highs_, lows_, closes_, conversion_period, base_period, span_b_period: {
+            "tenkan_sen": 110.0,
+            "kijun_sen": 115.0,
+            "senkou_span_a": 112.5,
+            "senkou_span_b": 118.0,
+            "chikou_span": 111.0,
+        },
+    )
+    monkeypatch.setattr(
+        markets_router,
+        "volume_weighted_average_price",
+        lambda highs_, lows_, closes_, volumes_: 125.55,
+    )
+
+    response = await client.get(
+        "/api/markets/indicators",
+        params={
+            "type": "crypto",
+            "symbol": "BTCUSDT",
+            "interval": "1h",
+            "limit": 200,
+            "ema_periods": "20,50",
+            "include_atr": True,
+            "include_stoch_rsi": True,
+            "include_ichimoku": True,
+            "include_vwap": True,
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["symbol"] == "BTCUSDT"
+    assert payload["indicators"]["rsi"]["value"] == 55.5
+    assert payload["indicators"]["ema"] == [
+        {"period": 20, "value": 122.0},
+        {"period": 50, "value": 125.0},
+    ]
+    assert payload["indicators"]["macd"]["hist"] == 0.13
+    assert payload["indicators"]["bollinger"]["upper"] == 130.0
+    assert payload["indicators"]["atr"]["value"] == 2.5
+    assert payload["indicators"]["stochastic_rsi"]["%K"] == 40.0
+    assert payload["indicators"]["ichimoku"]["tenkan_sen"] == 110.0
+    assert payload["indicators"]["vwap"]["value"] == 125.55
+    assert payload["series"]["closes"] == closes
+    assert payload["series"]["highs"] == highs
+    assert payload["series"]["lows"] == lows
+    assert payload["series"]["volumes"] == volumes
+
+
+@pytest.mark.asyncio
+async def test_indicators_endpoint_validates_minimum_history(
+    client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    short_series = [100.0] * 10
+    meta = {"source": "stub", "highs": [], "lows": [], "volumes": []}
+
+    monkeypatch.setattr(
+        markets_router,
+        "get_closes",
+        AsyncMock(return_value=(short_series, meta)),
+    )
+
+    response = await client.get(
+        "/api/markets/indicators",
+        params={
+            "type": "crypto",
+            "symbol": "BTCUSDT",
+            "interval": "1h",
+            "limit": 60,
+        },
+    )
+
+    assert response.status_code == 400
+    assert "No hay suficientes datos" in response.json()["detail"]

--- a/frontend/src/components/dashboard/__tests__/dashboard-integration.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/dashboard-integration.test.tsx
@@ -27,6 +27,17 @@ jest.mock("@/components/providers/theme-provider", () => ({
   ThemeProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
 
+jest.mock("@/hooks/useAlertsWebSocket", () => ({
+  __esModule: true,
+  useAlertsWebSocket: jest.fn(() => ({
+    status: "closed",
+    lastMessage: null,
+    error: null,
+    reconnect: jest.fn(),
+    disconnect: jest.fn(),
+  })),
+}));
+
 jest.mock("next/navigation", () => ({
   useRouter: jest.fn(),
 }));

--- a/frontend/src/hooks/__tests__/useAlertsWebSocket.test.ts
+++ b/frontend/src/hooks/__tests__/useAlertsWebSocket.test.ts
@@ -1,0 +1,249 @@
+import { act, renderHook } from "@testing-library/react";
+
+import { useAlertsWebSocket } from "../useAlertsWebSocket";
+import * as api from "@/lib/api";
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
+
+class MockWebSocket {
+  static instances: MockWebSocket[] = [];
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+
+  readyState = MockWebSocket.CONNECTING;
+  url: string;
+  onopen: (() => void) | null = null;
+  onclose: ((event?: any) => void) | null = null;
+  onmessage: ((event: { data: string }) => void) | null = null;
+  onerror: ((event?: any) => void) | null = null;
+
+  constructor(url: string) {
+    this.url = url;
+    MockWebSocket.instances.push(this);
+  }
+
+  send(): void {
+    // noop
+  }
+
+  close(): void {
+    this.readyState = MockWebSocket.CLOSED;
+    this.onclose?.({});
+  }
+
+  triggerOpen(): void {
+    this.readyState = MockWebSocket.OPEN;
+    this.onopen?.();
+  }
+
+  triggerMessage(payload: unknown): void {
+    this.onmessage?.({ data: JSON.stringify(payload) });
+  }
+
+  triggerError(): void {
+    this.readyState = MockWebSocket.CLOSED;
+    this.onerror?.(new Event("error"));
+  }
+
+  triggerClose(): void {
+    this.readyState = MockWebSocket.CLOSED;
+    this.onclose?.({});
+  }
+
+  static reset(): void {
+    MockWebSocket.instances = [];
+  }
+}
+
+declare global {
+  // eslint-disable-next-line no-var
+  var WebSocket: typeof MockWebSocket;
+}
+
+describe("useAlertsWebSocket", () => {
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_API_BASE_URL = "http://localhost:8000";
+    (global as any).WebSocket = MockWebSocket as unknown as typeof WebSocket;
+    jest.useFakeTimers();
+    MockWebSocket.reset();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+    MockWebSocket.reset();
+    process.env.NEXT_PUBLIC_API_BASE_URL = API_BASE_URL;
+  });
+
+  it("establece la conexión y procesa mensajes de alerta", () => {
+    const onAlert = jest.fn();
+    const onSystemMessage = jest.fn();
+
+    const { result } = renderHook(() =>
+      useAlertsWebSocket({ token: "token-123", onAlert, onSystemMessage })
+    );
+
+    expect(MockWebSocket.instances).toHaveLength(1);
+    const socket = MockWebSocket.instances[0];
+    expect(socket.url).toBe("ws://localhost:8000/ws/alerts?token=token-123");
+
+    act(() => {
+      socket.triggerOpen();
+    });
+
+    expect(result.current.status).toBe("open");
+
+    act(() => {
+      socket.triggerMessage({ type: "alert", message: "BTC cruzó el objetivo" });
+      socket.triggerMessage({ type: "system", message: "Bienvenido" });
+      // mensaje inválido para cubrir rama de error
+      socket.onmessage?.({ data: "not-json" } as any);
+    });
+
+    expect(onAlert).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "alert", message: "BTC cruzó el objetivo" })
+    );
+    expect(onSystemMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "system", message: "Bienvenido" })
+    );
+    expect(result.current.lastMessage).toMatchObject({ type: "system" });
+    expect(result.current.error).toBe("Mensaje de WebSocket no válido");
+  });
+
+  it("reintenta la conexión ante un cierre inesperado", () => {
+    const { result } = renderHook(() =>
+      useAlertsWebSocket({ token: "token-123", enabled: true })
+    );
+
+    const socket = MockWebSocket.instances[0];
+
+    act(() => {
+      socket.triggerOpen();
+    });
+
+    expect(result.current.status).toBe("open");
+
+    act(() => {
+      socket.triggerClose();
+    });
+
+    expect(result.current.status).toBe("closed");
+    expect(MockWebSocket.instances).toHaveLength(1);
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(MockWebSocket.instances).toHaveLength(2);
+  });
+
+  it("permite cerrar manualmente la conexión", () => {
+    const { result } = renderHook(() =>
+      useAlertsWebSocket({ token: "token-123", enabled: true })
+    );
+
+    const socket = MockWebSocket.instances[0];
+
+    act(() => {
+      socket.triggerOpen();
+    });
+
+    act(() => {
+      result.current.disconnect();
+    });
+
+    expect(result.current.status).toBe("closed");
+
+    act(() => {
+      jest.advanceTimersByTime(2000);
+    });
+
+    // No se crea un nuevo WebSocket tras desconexión manual
+    expect(MockWebSocket.instances).toHaveLength(1);
+  });
+
+  it("no intenta conectar cuando está deshabilitado", () => {
+    const { result, rerender } = renderHook(
+      ({ enabled }) => useAlertsWebSocket({ token: "token-123", enabled }),
+      { initialProps: { enabled: false } }
+    );
+
+    expect(MockWebSocket.instances).toHaveLength(0);
+    expect(result.current.status).toBe("closed");
+
+    rerender({ enabled: true });
+
+    expect(MockWebSocket.instances).toHaveLength(1);
+  });
+
+  it("puede reconectar manualmente después de un cierre", () => {
+    const { result } = renderHook(() =>
+      useAlertsWebSocket({ token: "token-123", enabled: true })
+    );
+
+    const socket = MockWebSocket.instances[0];
+
+    act(() => {
+      socket.triggerOpen();
+    });
+
+    act(() => {
+      socket.triggerClose();
+    });
+
+    act(() => {
+      result.current.reconnect();
+    });
+
+    expect(MockWebSocket.instances).toHaveLength(2);
+  });
+
+  it("no crea conexiones adicionales cuando ya existe una activa", () => {
+    const { result } = renderHook(() =>
+      useAlertsWebSocket({ token: "token-123", enabled: true })
+    );
+
+    expect(MockWebSocket.instances).toHaveLength(1);
+
+    act(() => {
+      result.current.reconnect();
+    });
+
+    expect(MockWebSocket.instances).toHaveLength(1);
+  });
+
+  it("propaga estado de error cuando el socket reporta fallo", () => {
+    const { result } = renderHook(() =>
+      useAlertsWebSocket({ token: "token-123", enabled: true })
+    );
+
+    const socket = MockWebSocket.instances[0];
+
+    act(() => {
+      socket.triggerError();
+    });
+
+    expect(result.current.status).toBe("error");
+    expect(result.current.error).toBe("Ocurrió un error con la conexión en vivo");
+  });
+
+  it("maneja fallos al construir la URL del WebSocket", () => {
+    const spy = jest
+      .spyOn(api, "getAlertsWebSocketUrl")
+      .mockImplementation(() => {
+        throw new Error("boom");
+      });
+
+    const { result } = renderHook(() =>
+      useAlertsWebSocket({ token: "token-123", enabled: true })
+    );
+
+    expect(MockWebSocket.instances).toHaveLength(0);
+    expect(result.current.status).toBe("idle");
+
+    spy.mockRestore();
+  });
+
+});

--- a/frontend/src/hooks/useAlertsWebSocket.ts
+++ b/frontend/src/hooks/useAlertsWebSocket.ts
@@ -1,0 +1,181 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import { getAlertsWebSocketUrl } from "@/lib/api";
+
+export type AlertWebSocketEvent = {
+  type: string;
+  [key: string]: unknown;
+};
+
+export type AlertWebSocketStatus =
+  | "idle"
+  | "connecting"
+  | "open"
+  | "closed"
+  | "error";
+
+interface UseAlertsWebSocketOptions {
+  token?: string | null;
+  enabled?: boolean;
+  onAlert?: (event: AlertWebSocketEvent) => void;
+  onSystemMessage?: (event: AlertWebSocketEvent) => void;
+}
+
+interface UseAlertsWebSocketResult {
+  status: AlertWebSocketStatus;
+  lastMessage: AlertWebSocketEvent | null;
+  error: string | null;
+  reconnect: () => void;
+  disconnect: () => void;
+}
+
+export function useAlertsWebSocket({
+  token,
+  enabled = true,
+  onAlert,
+  onSystemMessage,
+}: UseAlertsWebSocketOptions = {}): UseAlertsWebSocketResult {
+  const [status, setStatus] = useState<AlertWebSocketStatus>("idle");
+  const [lastMessage, setLastMessage] =
+    useState<AlertWebSocketEvent | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const wsRef = useRef<WebSocket | null>(null);
+  const reconnectTimeoutRef = useRef<number | null>(null);
+  const reconnectAttempts = useRef(0);
+  const manualClose = useRef(false);
+
+  const url = useMemo(() => {
+    if (!enabled) {
+      return null;
+    }
+    try {
+      return getAlertsWebSocketUrl(token ?? undefined);
+    } catch (err) {
+      console.error("No se pudo construir la URL del WebSocket", err);
+      return null;
+    }
+  }, [enabled, token]);
+
+  const cleanup = useCallback(() => {
+    if (reconnectTimeoutRef.current) {
+      window.clearTimeout(reconnectTimeoutRef.current);
+      reconnectTimeoutRef.current = null;
+    }
+    if (wsRef.current) {
+      wsRef.current.onopen = null;
+      wsRef.current.onclose = null;
+      wsRef.current.onmessage = null;
+      wsRef.current.onerror = null;
+    }
+  }, []);
+
+  const connect = useCallback(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+    if (!url) {
+      return;
+    }
+    if (
+      wsRef.current &&
+      (wsRef.current.readyState === WebSocket.OPEN ||
+        wsRef.current.readyState === WebSocket.CONNECTING)
+    ) {
+      return;
+    }
+
+    manualClose.current = false;
+    setStatus("connecting");
+    setError(null);
+
+    const socket = new WebSocket(url);
+    wsRef.current = socket;
+
+    socket.onopen = () => {
+      reconnectAttempts.current = 0;
+      setStatus("open");
+    };
+
+    socket.onmessage = (event: MessageEvent) => {
+      try {
+        const data = JSON.parse(event.data) as AlertWebSocketEvent;
+        setLastMessage(data);
+        if (data.type === "alert" && onAlert) {
+          onAlert(data);
+        } else if (data.type === "system" && onSystemMessage) {
+          onSystemMessage(data);
+        }
+      } catch (err) {
+        console.error("Mensaje WS no parseable", err);
+        setError("Mensaje de WebSocket no válido");
+      }
+    };
+
+    socket.onerror = () => {
+      setStatus("error");
+      setError("Ocurrió un error con la conexión en vivo");
+    };
+
+    socket.onclose = () => {
+      setStatus("closed");
+      wsRef.current = null;
+      if (!manualClose.current) {
+        reconnectAttempts.current += 1;
+        const delay = Math.min(
+          1000 * 2 ** (reconnectAttempts.current - 1),
+          15000
+        );
+        if (reconnectTimeoutRef.current) {
+          window.clearTimeout(reconnectTimeoutRef.current);
+        }
+        reconnectTimeoutRef.current = window.setTimeout(() => {
+          reconnectTimeoutRef.current = null;
+          connect();
+        }, delay);
+      }
+    };
+  }, [enabled, onAlert, onSystemMessage, url]);
+
+  const disconnect = useCallback(() => {
+    manualClose.current = true;
+    cleanup();
+    const socket = wsRef.current;
+    if (socket && socket.readyState !== WebSocket.CLOSED) {
+      socket.close();
+    }
+    wsRef.current = null;
+    setStatus("closed");
+  }, [cleanup]);
+
+  useEffect(() => {
+    if (!enabled) {
+      disconnect();
+      return undefined;
+    }
+
+    connect();
+
+    return () => {
+      manualClose.current = true;
+      cleanup();
+      const socket = wsRef.current;
+      if (socket && socket.readyState !== WebSocket.CLOSED) {
+        socket.close();
+      }
+      wsRef.current = null;
+    };
+  }, [connect, cleanup, disconnect, enabled, url]);
+
+  const reconnect = useCallback(() => {
+    manualClose.current = false;
+    cleanup();
+    connect();
+  }, [cleanup, connect]);
+
+  return { status, lastMessage, error, reconnect, disconnect };
+}
+
+export type { UseAlertsWebSocketResult };

--- a/frontend/src/lib/__tests__/api.test.ts
+++ b/frontend/src/lib/__tests__/api.test.ts
@@ -118,6 +118,21 @@ describe("request", () => {
 
     await expect(request("/demo", { method: "GET" })).rejects.toThrow("Mensaje amigable");
   });
+
+  it("serializa el detalle cuando no es un string", async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: false,
+      status: 409,
+      json: jest.fn().mockResolvedValue({ detail: { code: "duplicated" } }),
+      statusText: "Conflict",
+      text: jest.fn(),
+      headers: new Headers(),
+    });
+
+    await expect(request("/demo", { method: "GET" })).rejects.toThrow(
+      '{"code":"duplicated"}'
+    );
+  });
 });
 
 describe("API wrappers", () => {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,6 +1,22 @@
 export const API_BASE_URL =
   process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:8000";
 
+export function resolveWebSocketUrl(path: string): string {
+  const base = new URL(API_BASE_URL);
+  const wsProtocol = base.protocol === "https:" ? "wss:" : "ws:";
+  const wsUrl = new URL(path, base);
+  wsUrl.protocol = wsProtocol;
+  return wsUrl.toString();
+}
+
+export function getAlertsWebSocketUrl(token?: string | null): string {
+  const url = new URL(resolveWebSocketUrl("/ws/alerts"));
+  if (token) {
+    url.searchParams.set("token", token);
+  }
+  return url.toString();
+}
+
 /* ===========
    INTERFACES
    =========== */


### PR DESCRIPTION
## Summary
- add an AlertWebSocketManager and FastAPI /ws/alerts endpoint with broadcast coverage tests
- expose websocket URL helpers and a resilient useAlertsWebSocket hook consumed by the alerts panel and dashboard
- extend alerts, auth form, and API tests to cover validation, websocket UI states, and error fallbacks while keeping coverage thresholds satisfied

## Testing
- pytest
- npm --prefix frontend test -- --coverage

------
https://chatgpt.com/codex/tasks/task_e_68db4c6a82608321a139e2f395d1d4e1