### PR TITLE
feat: persist chat history and add push notification support

### DIFF
--- a/backend/alembic/versions/0009_create_chat_and_push_tables.py
+++ b/backend/alembic/versions/0009_create_chat_and_push_tables.py
@@ -1,0 +1,84 @@
+"""create chat and push notification tables"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision = "0009_create_chat_and_push_tables"
+down_revision = "0008_create_portfolio_table"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "chat_sessions",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            server_default=sa.text("gen_random_uuid()"),
+            primary_key=True,
+        ),
+        sa.Column(
+            "user_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+    )
+
+    op.create_table(
+        "chat_messages",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            server_default=sa.text("gen_random_uuid()"),
+            primary_key=True,
+        ),
+        sa.Column(
+            "session_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("chat_sessions.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("role", sa.String(length=20), nullable=False),
+        sa.Column("content", sa.Text(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+    )
+    op.create_index(
+        "ix_chat_messages_session_created",
+        "chat_messages",
+        ["session_id", "created_at"],
+    )
+
+    op.create_table(
+        "push_subscriptions",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            server_default=sa.text("gen_random_uuid()"),
+            primary_key=True,
+        ),
+        sa.Column(
+            "user_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("endpoint", sa.String(length=500), nullable=False),
+        sa.Column("auth", sa.String(length=255), nullable=False),
+        sa.Column("p256dh", sa.String(length=255), nullable=False),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.UniqueConstraint("endpoint", name="uq_push_subscriptions_endpoint"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("push_subscriptions")
+    op.drop_index("ix_chat_messages_session_created", table_name="chat_messages")
+    op.drop_table("chat_messages")
+    op.drop_table("chat_sessions")

--- a/backend/dev-requirements.txt
+++ b/backend/dev-requirements.txt
@@ -15,6 +15,7 @@ mypy==1.11.2
 # Herramientas adicionales
 httpx==0.27.0        # útil para pruebas de API
 coverage==7.6.1      # control detallado de cobertura
+pywebpush==1.14.0    # pruebas de notificaciones push
 
 # Extras dev
 email-validator==2.2.0   # ✅ asegurar compatibilidad de tests en dev

--- a/backend/main.py
+++ b/backend/main.py
@@ -12,7 +12,7 @@ from backend.core.logging_config import get_logger
 from backend.core.http_logging import RequestLogMiddleware
 
 # Routers de la app
-from backend.routers import alerts, markets, news, auth, ai, portfolio
+from backend.routers import alerts, markets, news, auth, ai, portfolio, push
 from backend.routers import health  # nuevo router de salud
 from backend.services.integration_reporter import log_api_integration_report
 from backend.services.alert_service import alert_service
@@ -119,6 +119,7 @@ app.include_router(markets.router, prefix="/api/markets", tags=["markets"])
 app.include_router(news.router, prefix="/api/news", tags=["news"])
 app.include_router(auth.router)
 app.include_router(ai.router, prefix="/api/ai", tags=["ai"])
+app.include_router(push.router, prefix="/api/push", tags=["push"])
 app.include_router(portfolio.router, prefix="/api/portfolio", tags=["portfolio"])
 
 

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -4,5 +4,17 @@ from .session import Session
 from .user import User
 from .refresh_token import RefreshToken
 from .portfolio import PortfolioItem
+from .chat import ChatSession, ChatMessage
+from .push_subscription import PushSubscription
 
-__all__ = ["Alert", "Base", "Session", "User", "RefreshToken", "PortfolioItem"]
+__all__ = [
+    "Alert",
+    "Base",
+    "Session",
+    "User",
+    "RefreshToken",
+    "PortfolioItem",
+    "ChatSession",
+    "ChatMessage",
+    "PushSubscription",
+]

--- a/backend/models/chat.py
+++ b/backend/models/chat.py
@@ -1,0 +1,57 @@
+"""Database models for AI chat sessions and messages."""
+
+from __future__ import annotations
+
+from datetime import datetime
+import uuid
+
+from sqlalchemy import DateTime, ForeignKey, String, Text
+from sqlalchemy.dialects.postgresql import UUID as PGUUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+try:  # pragma: no cover - support running from different entrypoints
+    from .base import Base
+except ImportError:  # pragma: no cover
+    from backend.models.base import Base  # type: ignore[no-redef]
+
+
+class ChatSession(Base):
+    """Represents a persisted conversation between a user and the AI assistant."""
+
+    __tablename__ = "chat_sessions"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        PGUUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        PGUUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, default=datetime.utcnow, nullable=False
+    )
+
+    messages: Mapped[list["ChatMessage"]] = relationship(
+        "ChatMessage", back_populates="session", cascade="all, delete-orphan"
+    )
+    user: Mapped["User"] = relationship("User", back_populates="chat_sessions")
+
+
+class ChatMessage(Base):
+    """Represents a single turn in a chat session."""
+
+    __tablename__ = "chat_messages"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        PGUUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    session_id: Mapped[uuid.UUID] = mapped_column(
+        PGUUID(as_uuid=True), ForeignKey("chat_sessions.id", ondelete="CASCADE"), nullable=False
+    )
+    role: Mapped[str] = mapped_column(String(20), nullable=False)
+    content: Mapped[str] = mapped_column(Text, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, default=datetime.utcnow, nullable=False
+    )
+
+    session: Mapped[ChatSession] = relationship("ChatSession", back_populates="messages")
+

--- a/backend/models/push_subscription.py
+++ b/backend/models/push_subscription.py
@@ -1,0 +1,40 @@
+"""Model definition for browser push notification subscriptions."""
+
+from __future__ import annotations
+
+from datetime import datetime
+import uuid
+
+from sqlalchemy import DateTime, ForeignKey, String, UniqueConstraint
+from sqlalchemy.dialects.postgresql import UUID as PGUUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+try:  # pragma: no cover - compatibility with different import paths
+    from .base import Base
+except ImportError:  # pragma: no cover
+    from backend.models.base import Base  # type: ignore[no-redef]
+
+
+class PushSubscription(Base):
+    """Stores a Web Push subscription for a user."""
+
+    __tablename__ = "push_subscriptions"
+    __table_args__ = (
+        UniqueConstraint("endpoint", name="uq_push_subscriptions_endpoint"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        PGUUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        PGUUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+    )
+    endpoint: Mapped[str] = mapped_column(String(500), nullable=False)
+    auth: Mapped[str] = mapped_column(String(255), nullable=False)
+    p256dh: Mapped[str] = mapped_column(String(255), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, default=datetime.utcnow, nullable=False
+    )
+
+    user: Mapped["User"] = relationship("User", back_populates="push_subscriptions")
+

--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -12,6 +12,8 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 if TYPE_CHECKING:
     from .refresh_token import RefreshToken
     from .portfolio import PortfolioItem
+    from .chat import ChatSession
+    from .push_subscription import PushSubscription
 
 try:  # pragma: no cover
     from .base import Base
@@ -64,6 +66,12 @@ class User(Base):
         "PortfolioItem",
         back_populates="user",
         cascade="all, delete-orphan",
+    )
+    chat_sessions: Mapped[list["ChatSession"]] = relationship(
+        "ChatSession", back_populates="user", cascade="all, delete-orphan"
+    )
+    push_subscriptions: Mapped[list["PushSubscription"]] = relationship(
+        "PushSubscription", back_populates="user", cascade="all, delete-orphan"
     )
 
     def verify_password(self, password: str) -> bool:

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -24,6 +24,7 @@ aioredis==2.0.1
 celery==5.4.0
 APScheduler==3.10.4
 redis==5.0.1
+pywebpush==1.14.0
 
 # Modelado y validación
 pydantic==2.9.2

--- a/backend/routers/ai.py
+++ b/backend/routers/ai.py
@@ -1,23 +1,37 @@
-"""AI chat endpoints."""
+"""AI chat endpoints with persistent history."""
 
 from __future__ import annotations
 
+import asyncio
 import logging
-from typing import Any, Dict, Optional, List  # [Codex] cambiado
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+from uuid import UUID
 
-from fastapi import APIRouter, HTTPException
-from pydantic import BaseModel, Field
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from pydantic import BaseModel, ConfigDict, Field
+from sqlalchemy.orm import Session
+
+from backend.database import get_db
+from backend.models import ChatMessage as ChatMessageModel, ChatSession as ChatSessionModel, User
+from backend.utils.config import Config
 
 try:  # pragma: no cover - allow running from different entrypoints
-    from backend.services.ai_service import ai_service
+    from backend.services.ai_service import ai_service, AIResponsePayload
 except ImportError:  # pragma: no cover
-    from services.ai_service import ai_service  # type: ignore
+    from services.ai_service import ai_service, AIResponsePayload  # type: ignore
 
-from backend.utils.config import Config
+try:  # pragma: no cover - optional when running without user_service
+    from backend.services.user_service import InvalidTokenError, user_service
+except Exception:  # pragma: no cover
+    user_service = None  # type: ignore[assignment]
+    InvalidTokenError = Exception  # type: ignore[assignment]
 
 
 LOGGER = logging.getLogger(__name__)
 router = APIRouter(tags=["AI"])
+security = HTTPBearer()
 
 
 class ChatRequest(BaseModel):
@@ -25,50 +39,202 @@ class ChatRequest(BaseModel):
     context: Optional[Dict[str, Any]] = Field(
         default=None, description="Contexto adicional opcional"
     )
+    session_id: Optional[UUID] = Field(
+        default=None,
+        description="Identificador de la sesión persistida",
+    )
 
 
 class ChatResponse(BaseModel):
     response: str
     provider: Optional[str] = None
-    used_data: bool = False  # [Codex] nuevo - informa si se usaron datos reales
-    sources: List[str] = Field(default_factory=list)  # [Codex] nuevo - fuentes de datos
+    used_data: bool = False
+    sources: List[str] = Field(default_factory=list)
+    session_id: UUID
+
+
+class PersistedMessage(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    role: str
+    content: str
+    created_at: datetime
+
+
+class ChatHistoryResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    session_id: UUID
+    created_at: datetime
+    messages: List[PersistedMessage]
 
 
 def _ensure_provider_available() -> None:
     if not (Config.MISTRAL_API_KEY or Config.HUGGINGFACE_API_KEY):
         LOGGER.error("No AI providers configured. Check MISTRAL_API_KEY or HUGGINGFACE_API_KEY")
         raise HTTPException(
-            status_code=500,
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="No hay proveedores de IA configurados en el servidor.",
         )
 
 
+def _ensure_user_service_available() -> None:
+    if user_service is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Servicio de usuarios no disponible",
+        )
+
+
+async def get_current_user(
+    credentials: HTTPAuthorizationCredentials = Depends(security),
+) -> User:
+    _ensure_user_service_available()
+
+    try:
+        return await asyncio.to_thread(
+            user_service.get_current_user, credentials.credentials
+        )
+    except InvalidTokenError as exc:  # pragma: no cover - defensive
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=str(exc)) from exc
+
+
+def _fetch_session(
+    db: Session, user_id: UUID, session_id: Optional[UUID]
+) -> ChatSessionModel:
+    if session_id is None:
+        session = ChatSessionModel(user_id=user_id)
+        db.add(session)
+        db.flush()
+        return session
+
+    session = (
+        db.query(ChatSessionModel)
+        .filter(ChatSessionModel.id == session_id, ChatSessionModel.user_id == user_id)
+        .one_or_none()
+    )
+    if session is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Sesión no encontrada")
+    return session
+
+
+def _load_history(db: Session, session: ChatSessionModel) -> List[ChatMessageModel]:
+    return (
+        db.query(ChatMessageModel)
+        .filter(ChatMessageModel.session_id == session.id)
+        .order_by(ChatMessageModel.created_at.asc())
+        .all()
+    )
+
+
+def _prepare_context(
+    base_context: Optional[Dict[str, Any]],
+    history: List[ChatMessageModel],
+) -> Dict[str, Any]:
+    context: Dict[str, Any] = dict(base_context or {})
+    serialized_history = [
+        {"role": message.role, "content": message.content}
+        for message in history
+        if message.content
+    ]
+    if serialized_history:
+        existing_history = list(context.get("history") or [])
+        context["history"] = serialized_history + existing_history
+    return context
+
+
+def _persist_message(
+    db: Session,
+    session: ChatSessionModel,
+    role: str,
+    content: str,
+) -> ChatMessageModel:
+    message = ChatMessageModel(session_id=session.id, role=role, content=content)
+    db.add(message)
+    return message
+
+
 @router.post("/chat", response_model=ChatResponse)
-async def chat_endpoint(payload: ChatRequest) -> ChatResponse:
-    """Procesa una consulta mediante los proveedores de IA configurados."""
+async def chat_endpoint(
+    payload: ChatRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> ChatResponse:
+    """Procesa una consulta mediante los proveedores de IA configurados y la persiste."""
 
     _ensure_provider_available()
 
+    prompt = payload.prompt.strip()
+    if not prompt:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="El mensaje no puede estar vacío")
+
+    session = _fetch_session(db, current_user.id, payload.session_id)
+    history = _load_history(db, session)
+    context = _prepare_context(payload.context, history)
+
+    user_message = _persist_message(db, session, "user", prompt)
+
     try:
-        reply = await ai_service.process_message(payload.prompt, payload.context)
+        reply: AIResponsePayload = await ai_service.process_message(prompt, context)
     except Exception as exc:  # pragma: no cover - errores inesperados
         LOGGER.exception("AIService failed to process prompt")
+        db.rollback()
         raise HTTPException(status_code=502, detail=str(exc)) from exc
 
     if not reply:
+        db.rollback()
         raise HTTPException(
             status_code=502, detail="El servicio de IA no devolvió ninguna respuesta"
         )
 
-    # [Codex] cambiado - la respuesta ahora transporta metadatos del middleware
     text = getattr(reply, "text", str(reply))
     provider = getattr(reply, "provider", None) or "auto"
     used_data = bool(getattr(reply, "used_data", False))
     sources = list(getattr(reply, "sources", []) or [])
+
+    assistant_message = _persist_message(db, session, "assistant", text)
+
+    try:
+        db.commit()
+    except Exception as exc:  # pragma: no cover - unexpected db error
+        LOGGER.exception("Failed to persist chat messages")
+        db.rollback()
+        raise HTTPException(status_code=500, detail="No se pudo guardar la conversación") from exc
+
+    db.refresh(user_message)
+    db.refresh(assistant_message)
+    db.refresh(session)
 
     return ChatResponse(
         response=text,
         provider=provider,
         used_data=used_data,
         sources=sources,
+        session_id=session.id,
+    )
+
+
+@router.get("/history/{session_id}", response_model=ChatHistoryResponse)
+async def get_history(
+    session_id: UUID,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> ChatHistoryResponse:
+    _ensure_user_service_available()
+
+    session = (
+        db.query(ChatSessionModel)
+        .filter(ChatSessionModel.id == session_id, ChatSessionModel.user_id == current_user.id)
+        .one_or_none()
+    )
+    if session is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Sesión no encontrada")
+
+    messages = _load_history(db, session)
+
+    return ChatHistoryResponse(
+        session_id=session.id,
+        created_at=session.created_at,
+        messages=[PersistedMessage.model_validate(message) for message in messages],
     )

--- a/backend/routers/push.py
+++ b/backend/routers/push.py
@@ -1,0 +1,112 @@
+"""Endpoints for Web Push subscriptions."""
+
+from __future__ import annotations
+
+import asyncio
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from pydantic import BaseModel, Field
+from sqlalchemy.orm import Session
+
+from backend.database import get_db
+from backend.models import PushSubscription, User
+from backend.services.push_service import push_service
+
+try:  # pragma: no cover - optional when running tests without user_service
+    from backend.services.user_service import InvalidTokenError, user_service
+except Exception:  # pragma: no cover - fallback when user_service is unavailable
+    user_service = None  # type: ignore[assignment]
+    InvalidTokenError = Exception  # type: ignore[assignment]
+
+
+router = APIRouter(tags=["push"])
+security = HTTPBearer()
+
+
+class SubscriptionKeys(BaseModel):
+    auth: str = Field(..., min_length=4)
+    p256dh: str = Field(..., min_length=4)
+
+
+class PushSubscriptionPayload(BaseModel):
+    endpoint: str = Field(..., min_length=10)
+    keys: SubscriptionKeys
+
+
+class PushSubscriptionResponse(BaseModel):
+    id: UUID
+
+
+async def get_current_user(
+    credentials: HTTPAuthorizationCredentials = Depends(security),
+) -> User:
+    if user_service is None:
+        raise HTTPException(status_code=503, detail="Servicio de usuarios no disponible")
+
+    try:
+        return await asyncio.to_thread(
+            user_service.get_current_user, credentials.credentials
+        )
+    except InvalidTokenError as exc:  # pragma: no cover - defensive
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=str(exc)) from exc
+
+
+@router.post("/subscribe", response_model=PushSubscriptionResponse, status_code=status.HTTP_201_CREATED)
+async def subscribe_push(
+    payload: PushSubscriptionPayload,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> PushSubscriptionResponse:
+    if user_service is None:
+        raise HTTPException(status_code=503, detail="Servicio de usuarios no disponible")
+
+    subscription = (
+        db.query(PushSubscription)
+        .filter(PushSubscription.endpoint == payload.endpoint)
+        .one_or_none()
+    )
+
+    if subscription:
+        subscription.auth = payload.keys.auth
+        subscription.p256dh = payload.keys.p256dh
+        subscription.user_id = current_user.id
+    else:
+        subscription = PushSubscription(
+            endpoint=payload.endpoint,
+            auth=payload.keys.auth,
+            p256dh=payload.keys.p256dh,
+            user_id=current_user.id,
+        )
+        db.add(subscription)
+
+    db.commit()
+    db.refresh(subscription)
+
+    return PushSubscriptionResponse(id=subscription.id)
+
+
+@router.post("/send-test", status_code=status.HTTP_202_ACCEPTED)
+async def send_test_notification(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> dict:
+    subscriptions = (
+        db.query(PushSubscription)
+        .filter(PushSubscription.user_id == current_user.id)
+        .all()
+    )
+    if not subscriptions:
+        raise HTTPException(status_code=404, detail="No hay suscripciones registradas")
+
+    payload = {
+        "title": "BullBearBroker",
+        "body": "Notificación de prueba",
+    }
+
+    delivered = push_service.broadcast(subscriptions, payload)
+    if delivered == 0:
+        raise HTTPException(status_code=502, detail="No se pudieron enviar notificaciones")
+
+    return {"delivered": delivered}

--- a/backend/services/push_service.py
+++ b/backend/services/push_service.py
@@ -1,0 +1,85 @@
+"""Utilities to register and deliver Web Push notifications."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Dict, Iterable, Optional
+
+try:  # pragma: no cover - optional dependency in some environments
+    from pywebpush import WebPushException, webpush
+except ImportError:  # pragma: no cover - provide graceful fallback for tests
+    class WebPushException(Exception):
+        """Raised when pywebpush is unavailable."""
+
+    def webpush(**_: Any) -> None:  # type: ignore
+        raise WebPushException("pywebpush package is not installed")
+
+from backend.models.push_subscription import PushSubscription
+from backend.utils.config import Config
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+class PushService:
+    """Encapsulates Web Push subscription handling and delivery."""
+
+    def __init__(
+        self,
+        *,
+        vapid_private_key: Optional[str] = None,
+        vapid_public_key: Optional[str] = None,
+        contact_email: Optional[str] = None,
+    ) -> None:
+        self._vapid_private_key = vapid_private_key or Config.PUSH_VAPID_PRIVATE_KEY
+        self._vapid_public_key = vapid_public_key or Config.PUSH_VAPID_PUBLIC_KEY
+        self._contact_email = contact_email or Config.PUSH_CONTACT_EMAIL
+
+    @property
+    def is_configured(self) -> bool:
+        return bool(self._vapid_private_key and self._vapid_public_key)
+
+    def _build_claims(self) -> Dict[str, str]:
+        contact = self._contact_email or "support@bullbear.ai"
+        if not contact.startswith("mailto:"):
+            contact = f"mailto:{contact}"
+        return {"sub": contact}
+
+    def send_notification(
+        self, subscription: PushSubscription, payload: Dict[str, Any]
+    ) -> None:
+        if not self.is_configured:
+            raise RuntimeError("Web Push configuration missing VAPID keys")
+
+        subscription_info = {
+            "endpoint": subscription.endpoint,
+            "keys": {"auth": subscription.auth, "p256dh": subscription.p256dh},
+        }
+
+        try:
+            webpush(
+                subscription_info=subscription_info,
+                data=json.dumps(payload),
+                vapid_private_key=self._vapid_private_key,
+                vapid_public_key=self._vapid_public_key,
+                vapid_claims=self._build_claims(),
+            )
+        except WebPushException as exc:  # pragma: no cover - defensive logging
+            LOGGER.warning("Web push delivery failed: %s", exc)
+            raise RuntimeError("Failed to deliver push notification") from exc
+
+    def broadcast(
+        self, subscriptions: Iterable[PushSubscription], payload: Dict[str, Any]
+    ) -> int:
+        delivered = 0
+        for subscription in subscriptions:
+            try:
+                self.send_notification(subscription, payload)
+            except RuntimeError:
+                continue
+            delivered += 1
+        return delivered
+
+
+push_service = PushService()

--- a/backend/tests/test_chat_history.py
+++ b/backend/tests/test_chat_history.py
@@ -1,0 +1,106 @@
+import uuid
+
+import pytest
+from httpx import AsyncClient, ASGITransport
+
+from backend.database import SessionLocal
+from backend.main import app
+from backend.models import ChatMessage
+from backend.services.ai_service import AIResponsePayload, ai_service
+from backend.utils.config import Config
+
+
+@pytest.mark.asyncio
+async def test_chat_persists_history(monkeypatch):
+    monkeypatch.setattr(Config, "MISTRAL_API_KEY", "test-key", raising=False)
+
+    async def fake_process(message: str, context: dict | None) -> AIResponsePayload:
+        return AIResponsePayload(text=f"Respuesta a: {message}", provider="test", used_data=True, sources=["prices"])
+
+    monkeypatch.setattr(ai_service, "process_message", fake_process)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        email = f"chat_{uuid.uuid4().hex}@test.com"
+        register = await client.post(
+            "/api/auth/register",
+            json={"email": email, "password": "chat1234"},
+        )
+        assert register.status_code in (200, 201)
+
+        login = await client.post(
+            "/api/auth/login",
+            json={"email": email, "password": "chat1234"},
+        )
+        assert login.status_code == 200
+        token = login.json()["access_token"]
+
+        chat_response = await client.post(
+            "/api/ai/chat",
+            headers={"Authorization": f"Bearer {token}"},
+            json={"prompt": "Hola"},
+        )
+        assert chat_response.status_code == 200, chat_response.text
+        data = chat_response.json()
+        session_id = uuid.UUID(data["session_id"])
+        assert data["response"].startswith("Respuesta a")
+
+        with SessionLocal() as db:
+            rows = (
+                db.query(ChatMessage)
+                .filter(ChatMessage.session_id == session_id)
+                .order_by(ChatMessage.created_at)
+                .all()
+            )
+            assert len(rows) == 2
+            assert [row.role for row in rows] == ["user", "assistant"]
+
+        history = await client.get(
+            f"/api/ai/history/{session_id}",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert history.status_code == 200, history.text
+        history_data = history.json()
+        assert history_data["session_id"] == str(session_id)
+        assert len(history_data["messages"]) == 2
+        assert history_data["messages"][0]["role"] == "user"
+        assert history_data["messages"][1]["role"] == "assistant"
+
+        # Reuse session
+        second = await client.post(
+            "/api/ai/chat",
+            headers={"Authorization": f"Bearer {token}"},
+            json={"prompt": "Seguimos", "session_id": str(session_id)},
+        )
+        assert second.status_code == 200
+
+        with SessionLocal() as db:
+            total = (
+                db.query(ChatMessage)
+                .filter(ChatMessage.session_id == session_id)
+                .order_by(ChatMessage.created_at)
+                .all()
+            )
+            assert len(total) == 4
+
+
+@pytest.mark.asyncio
+async def test_history_requires_valid_session(monkeypatch):
+    monkeypatch.setattr(Config, "MISTRAL_API_KEY", "test-key", raising=False)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        email = f"history_{uuid.uuid4().hex}@test.com"
+        await client.post(
+            "/api/auth/register",
+            json={"email": email, "password": "chat1234"},
+        )
+        login = await client.post(
+            "/api/auth/login",
+            json={"email": email, "password": "chat1234"},
+        )
+        token = login.json()["access_token"]
+
+        missing = await client.get(
+            f"/api/ai/history/{uuid.uuid4()}",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert missing.status_code == 404

--- a/backend/tests/test_push_notifications.py
+++ b/backend/tests/test_push_notifications.py
@@ -1,0 +1,64 @@
+import uuid
+
+import pytest
+from httpx import AsyncClient, ASGITransport
+
+from backend.database import SessionLocal
+from backend.main import app
+from backend.models import PushSubscription
+from backend.services.push_service import push_service
+
+
+@pytest.mark.asyncio
+async def test_push_subscription_and_send(monkeypatch):
+    push_service._vapid_private_key = "test-private"  # type: ignore[attr-defined]
+    push_service._vapid_public_key = "test-public"  # type: ignore[attr-defined]
+
+    webpush_calls: list[dict] = []
+
+    def fake_webpush(**kwargs):
+        webpush_calls.append(kwargs)
+        return None
+
+    monkeypatch.setattr("backend.services.push_service.webpush", fake_webpush)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        email = f"push_{uuid.uuid4().hex}@test.com"
+        register = await client.post(
+            "/api/auth/register",
+            json={"email": email, "password": "push1234"},
+        )
+        assert register.status_code in (200, 201)
+
+        login = await client.post(
+            "/api/auth/login",
+            json={"email": email, "password": "push1234"},
+        )
+        token = login.json()["access_token"]
+
+        payload = {
+            "endpoint": "https://example.com/push/1",
+            "keys": {"auth": "auth-key", "p256dh": "p256dh-key"},
+        }
+
+        subscribe = await client.post(
+            "/api/push/subscribe",
+            headers={"Authorization": f"Bearer {token}"},
+            json=payload,
+        )
+        assert subscribe.status_code == 201, subscribe.text
+        sub_id = subscribe.json()["id"]
+
+        with SessionLocal() as db:
+            record = db.query(PushSubscription).filter(PushSubscription.id == uuid.UUID(sub_id)).one()
+            assert record.endpoint == payload["endpoint"]
+            assert record.auth == payload["keys"]["auth"]
+            assert record.p256dh == payload["keys"]["p256dh"]
+
+        send = await client.post(
+            "/api/push/send-test",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert send.status_code == 202, send.text
+        assert send.json()["delivered"] == 1
+        assert len(webpush_calls) == 1

--- a/backend/utils/config.py
+++ b/backend/utils/config.py
@@ -73,6 +73,9 @@ class Config:
     TELEGRAM_DEFAULT_CHAT_ID = _get_env("TELEGRAM_DEFAULT_CHAT_ID")
     DISCORD_BOT_TOKEN = _get_env("DISCORD_BOT_TOKEN")
     DISCORD_APPLICATION_ID = _get_env("DISCORD_APPLICATION_ID")
+    PUSH_VAPID_PUBLIC_KEY = _get_env("PUSH_VAPID_PUBLIC_KEY")
+    PUSH_VAPID_PRIVATE_KEY = _get_env("PUSH_VAPID_PRIVATE_KEY")
+    PUSH_CONTACT_EMAIL = _get_env("PUSH_CONTACT_EMAIL", "support@bullbear.ai")
 
     API_BASE_URL = _get_env("BULLBEAR_API_URL", "http://localhost:8000")  # [Codex] nuevo
 

--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -1,0 +1,41 @@
+self.addEventListener("install", (event) => {
+  self.skipWaiting();
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(self.clients.claim());
+});
+
+self.addEventListener("push", (event) => {
+  const data = event.data ? event.data.json() : {};
+  const title = data.title || "BullBearBroker";
+  const options = {
+    body: data.body || "Tienes una nueva alerta",
+    icon: data.icon || "/icons/icon-192x192.png",
+    badge: data.badge || "/icons/icon-96x96.png",
+    data,
+  };
+
+  event.waitUntil(self.registration.showNotification(title, options));
+});
+
+self.addEventListener("notificationclick", (event) => {
+  const notification = event.notification;
+  const targetUrl = notification.data?.url || "/";
+
+  event.waitUntil(
+    self.clients.matchAll({ type: "window" }).then((clientList) => {
+      for (const client of clientList) {
+        if (client.url === targetUrl && "focus" in client) {
+          return client.focus();
+        }
+      }
+      if (self.clients.openWindow) {
+        return self.clients.openWindow(targetUrl);
+      }
+      return undefined;
+    })
+  );
+
+  notification.close();
+});

--- a/frontend/src/components/dashboard/dashboard-page.tsx
+++ b/frontend/src/components/dashboard/dashboard-page.tsx
@@ -13,13 +13,17 @@ import { ThemeToggle } from "@/components/dashboard/theme-toggle";
 import { IndicatorsChart } from "@/components/indicators/IndicatorsChart"; // [Codex] nuevo
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
 import { getIndicators, sendChatMessage } from "@/lib/api"; // [Codex] nuevo
+import { usePushNotifications } from "@/hooks/usePushNotifications";
 
 export function DashboardPage() {
   const { user, loading, token, logout } = useAuth();
   const router = useRouter();
 
   const sidebarToken = useMemo(() => token ?? undefined, [token]);
+
+  const { enabled: pushEnabled, error: pushError } = usePushNotifications(token ?? undefined);
 
   const [indicatorData, setIndicatorData] = useState<any | null>(null); // [Codex] nuevo
   const [indicatorInsights, setIndicatorInsights] = useState<string | null>(null); // [Codex] nuevo
@@ -132,12 +136,20 @@ export function DashboardPage() {
             <h1 className="text-2xl font-semibold">{user.name || user.email}</h1>
           </div>
           <div className="flex items-center gap-3">
+            <Badge variant={pushEnabled ? "outline" : "secondary"} className="hidden md:inline-flex">
+              {pushEnabled ? "Push activo" : "Push inactivo"}
+            </Badge>
             <ThemeToggle />
             <Button variant="outline" onClick={logout}>
               Cerrar sesión
             </Button>
           </div>
         </header>
+        {pushError && (
+          <div className="rounded-lg border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive">
+            {pushError}
+          </div>
+        )}
         <section className="grid flex-1 gap-6 lg:grid-cols-2 xl:grid-cols-[2fr_1fr]">
           <div className="grid auto-rows-min gap-6">
             <PortfolioPanel token={token ?? undefined} />

--- a/frontend/src/hooks/__tests__/usePushNotifications.test.ts
+++ b/frontend/src/hooks/__tests__/usePushNotifications.test.ts
@@ -1,0 +1,111 @@
+import { act, renderHook, waitFor } from "@/tests/utils/renderWithProviders";
+
+import { subscribePush } from "@/lib/api";
+import { usePushNotifications } from "../usePushNotifications";
+
+jest.mock("@/lib/api", () => ({
+  subscribePush: jest.fn().mockResolvedValue({ id: "sub" }),
+}));
+
+describe("usePushNotifications", () => {
+  const originalNotification = window.Notification;
+  const originalServiceWorker = navigator.serviceWorker;
+  const originalPushManager = (window as any).PushManager;
+  const originalAtob = (global as any).atob;
+  const mockedSubscribePush = subscribePush as jest.MockedFunction<typeof subscribePush>;
+
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_PUSH_VAPID_PUBLIC_KEY = "dGVzdA==";
+
+    (global as any).atob = (value: string) => Buffer.from(value, "base64").toString("binary");
+
+    const registration = {
+      pushManager: {
+        getSubscription: jest.fn().mockResolvedValue(null),
+        subscribe: jest.fn().mockResolvedValue({
+          endpoint: "https://example.com/push",
+          toJSON: () => ({ keys: { auth: "auth", p256dh: "p256dh" } }),
+        }),
+      },
+    } as unknown as ServiceWorkerRegistration;
+
+    Object.defineProperty(navigator, "serviceWorker", {
+      configurable: true,
+      value: {
+        register: jest.fn().mockResolvedValue(registration),
+      },
+    });
+
+    Object.defineProperty(window, "PushManager", {
+      configurable: true,
+      value: function PushManager() {},
+    });
+
+    class MockNotification {
+      static permission: NotificationPermission = "default";
+      static async requestPermission(): Promise<NotificationPermission> {
+        MockNotification.permission = "granted";
+        return MockNotification.permission;
+      }
+    }
+
+    Object.defineProperty(window, "Notification", {
+      configurable: true,
+      value: MockNotification,
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, "Notification", {
+      configurable: true,
+      value: originalNotification,
+    });
+    Object.defineProperty(navigator, "serviceWorker", {
+      configurable: true,
+      value: originalServiceWorker,
+    });
+    if (originalPushManager) {
+      Object.defineProperty(window, "PushManager", {
+        configurable: true,
+        value: originalPushManager,
+      });
+    } else {
+      delete (window as any).PushManager;
+    }
+    if (originalAtob) {
+      (global as any).atob = originalAtob;
+    } else {
+      delete (global as any).atob;
+    }
+    mockedSubscribePush.mockClear();
+  });
+
+  it("registra la suscripción cuando el navegador soporta push", async () => {
+    const { result } = renderHook(() => usePushNotifications("token"));
+
+    await waitFor(() => expect(result.current.enabled).toBe(true));
+
+    expect(mockedSubscribePush).toHaveBeenCalledWith(
+      {
+        endpoint: "https://example.com/push",
+        keys: { auth: "auth", p256dh: "p256dh" },
+      },
+      "token"
+    );
+    expect(result.current.error).toBeNull();
+  });
+
+  it("reporta error cuando falta la clave VAPID", async () => {
+    process.env.NEXT_PUBLIC_PUSH_VAPID_PUBLIC_KEY = "";
+
+    const { result } = renderHook(() => usePushNotifications("token"));
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(result.current.enabled).toBe(false);
+    expect(result.current.error).toMatch(/clave pública VAPID/i);
+    expect(mockedSubscribePush).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/hooks/usePushNotifications.ts
+++ b/frontend/src/hooks/usePushNotifications.ts
@@ -1,0 +1,114 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+import { subscribePush } from "@/lib/api";
+
+function urlBase64ToUint8Array(base64String: string): Uint8Array {
+  const padding = "=".repeat((4 - (base64String.length % 4)) % 4);
+  const base64 = (base64String + padding).replace(/-/g, "+").replace(/_/g, "/");
+
+  const rawData = atob(base64);
+  const outputArray = new Uint8Array(rawData.length);
+
+  for (let i = 0; i < rawData.length; ++i) {
+    outputArray[i] = rawData.charCodeAt(i);
+  }
+  return outputArray;
+}
+
+interface PushNotificationsState {
+  enabled: boolean;
+  error: string | null;
+  permission: NotificationPermission | "unsupported";
+  loading: boolean;
+}
+
+export function usePushNotifications(token?: string | null): PushNotificationsState {
+  const [enabled, setEnabled] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const permission: NotificationPermission | "unsupported" = useMemo(() => {
+    if (typeof window === "undefined" || !("Notification" in window)) {
+      return "unsupported";
+    }
+    return Notification.permission;
+  }, []);
+
+  useEffect(() => {
+    if (!token) return;
+    if (typeof window === "undefined") return;
+    if (!("serviceWorker" in navigator) || !("PushManager" in window)) {
+      setError("Las notificaciones push no están soportadas en este navegador.");
+      return;
+    }
+
+    let active = true;
+    const vapidKey = process.env.NEXT_PUBLIC_PUSH_VAPID_PUBLIC_KEY;
+    if (!vapidKey) {
+      setError("Falta configurar la clave pública VAPID.");
+      return;
+    }
+
+    const register = async () => {
+      setLoading(true);
+      try {
+        const registration = await navigator.serviceWorker.register("/sw.js");
+        let permissionState = Notification.permission;
+        if (permissionState !== "granted") {
+          permissionState = await Notification.requestPermission();
+        }
+        if (permissionState !== "granted") {
+          if (active) {
+            setError("Debes habilitar las notificaciones para recibir alertas.");
+          }
+          return;
+        }
+
+        let subscription = await registration.pushManager.getSubscription();
+        if (!subscription) {
+          subscription = await registration.pushManager.subscribe({
+            userVisibleOnly: true,
+            applicationServerKey: urlBase64ToUint8Array(vapidKey),
+          });
+        }
+
+        const json = subscription.toJSON();
+        const auth = json.keys?.auth ?? "";
+        const p256dh = json.keys?.p256dh ?? "";
+
+        await subscribePush(
+          {
+            endpoint: subscription.endpoint,
+            keys: { auth, p256dh },
+          },
+          token
+        );
+
+        if (active) {
+          setEnabled(true);
+          setError(null);
+        }
+      } catch (err) {
+        if (!active) return;
+        console.error("No se pudo registrar la suscripción push", err);
+        const message =
+          err instanceof Error ? err.message : "No se pudo registrar la suscripción push.";
+        setError(message);
+        setEnabled(false);
+      } finally {
+        if (active) {
+          setLoading(false);
+        }
+      }
+    };
+
+    register();
+
+    return () => {
+      active = false;
+    };
+  }, [token]);
+
+  return { enabled, error, permission, loading };
+}

--- a/frontend/src/lib/__tests__/api.test.ts
+++ b/frontend/src/lib/__tests__/api.test.ts
@@ -269,6 +269,7 @@ describe("API wrappers", () => {
           provider: "openai",
           used_data: true,
           sources: ["prices"],
+          session_id: "chat-1",
         })
       );
     const onChunk = jest.fn();
@@ -286,6 +287,7 @@ describe("API wrappers", () => {
     expect(onChunk).toHaveBeenCalledWith("Respuesta final");
     expect(result.messages).toHaveLength(2);
     expect(result.sources).toEqual(["prices"]);
+    expect(result.sessionId).toBe("chat-1");
   });
 
   it("continúa aunque getIndicators falle", async () => {
@@ -301,7 +303,7 @@ describe("API wrappers", () => {
       ],
       undefined,
       undefined,
-      { symbol: "ETH" }
+      { symbol: "ETH", sessionId: "persisted" }
     );
 
     expect(warnSpy).toHaveBeenCalled();
@@ -309,6 +311,7 @@ describe("API wrappers", () => {
       `${API_BASE_URL}/api/ai/chat`
     );
     expect(result.messages[result.messages.length - 1].content).toBe("Ok");
+    expect(result.sessionId).toBe("persisted");
     warnSpy.mockRestore();
   });
 


### PR DESCRIPTION
## Summary
- add chat session and message models with persistence and expose history endpoint
- implement push subscription storage and minimal delivery service with API endpoints
- update frontend chat panel to load history, register service workers, and surface push status

## Testing
- pytest backend/tests/test_chat_history.py backend/tests/test_push_notifications.py
- pnpm test -- --runTestsByPath src/components/chat/__tests__/chat-panel.test.tsx (fails due to global coverage thresholds when run in isolation)
- pnpm test -- --runTestsByPath src/hooks/__tests__/usePushNotifications.test.ts (fails due to global coverage thresholds when run in isolation)


------
https://chatgpt.com/codex/tasks/task_e_68dbbcf269688321bc1c68edc8c9c9a6