### PR TITLE
Align docker-compose and environment tooling with env-file workflows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,27 +1,40 @@
 COMPOSE ?= docker compose
+ENV_FILE ?= .env.local
 
-.PHONY: up down logs build clean test up-staging down-staging
+.PHONY: up up-local up-supabase down down-v logs build clean test up-staging down-staging migrate
 
 up:
-        $(COMPOSE) up -d
+	ENV_FILE=$(ENV_FILE) $(COMPOSE) up -d
+
+up-local:
+	ENV_FILE=.env.local $(COMPOSE) up -d
+
+up-supabase:
+	ENV_FILE=.env.supabase $(COMPOSE) up -d
 
 up-staging:
-        APP_ENV=staging $(COMPOSE) --profile staging up -d
+	APP_ENV=staging ENV_FILE=$(ENV_FILE) $(COMPOSE) --profile staging up -d
 
 build:
-	$(COMPOSE) up --build
+	ENV_FILE=$(ENV_FILE) $(COMPOSE) up --build
 
 down:
-        $(COMPOSE) down
+	ENV_FILE=$(ENV_FILE) $(COMPOSE) down
+
+down-v:
+	ENV_FILE=$(ENV_FILE) $(COMPOSE) down -v
 
 down-staging:
-        $(COMPOSE) --profile staging down
+	APP_ENV=staging ENV_FILE=$(ENV_FILE) $(COMPOSE) --profile staging down
 
 clean:
-	$(COMPOSE) down -v --remove-orphans
+	ENV_FILE=$(ENV_FILE) $(COMPOSE) down -v --remove-orphans
 
 logs:
-	$(COMPOSE) logs -f
+	ENV_FILE=$(ENV_FILE) $(COMPOSE) logs -f
+
+migrate:
+	ENV_FILE=$(ENV_FILE) bash -c 'set -a; if [ -f "$$ENV_FILE" ]; then . "$$ENV_FILE"; fi; alembic upgrade head'
 
 test:
 	python -m pytest backend/tests

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Campos destacados:
   Docker Compose (`postgresql+psycopg2://bullbear:bullbear@db:5432/bullbear`).
 - **REDIS_URL**: requerido para rate limiting y futuras colas de tareas.
 - **BULLBEAR_DEFAULT_USER / PASSWORD**: credenciales sembradas automáticamente para pruebas.
-- **NEXT_PUBLIC_API_BASE_URL**: URL base que consume el frontend (en Docker se
+- **NEXT_PUBLIC_API_URL**: URL base que consume el frontend (en Docker se
   resuelve a `http://backend:8000`).
 - **PUSH_VAPID_PUBLIC_KEY / PUSH_VAPID_PRIVATE_KEY**: claves VAPID usadas para
   firmar notificaciones web push desde el backend. Genera un par con

--- a/backend/core/security.py
+++ b/backend/core/security.py
@@ -9,11 +9,15 @@ from typing import Any, Dict, Optional
 import jwt
 
 JWT_ALG = "HS256"
-ACCESS_MIN = int(os.getenv("ACCESS_TOKEN_EXPIRE_MINUTES", "15"))
-REFRESH_DAYS = int(os.getenv("REFRESH_TOKEN_EXPIRE_DAYS", "7"))
+ACCESS_MIN = int(os.environ.get("ACCESS_TOKEN_EXPIRE_MINUTES", "15"))
+REFRESH_DAYS = int(os.environ.get("REFRESH_TOKEN_EXPIRE_DAYS", "7"))
 
-ACCESS_SECRET = os.getenv("ACCESS_TOKEN_SECRET", os.getenv("SECRET_KEY", "change-me"))
-REFRESH_SECRET = os.getenv("REFRESH_TOKEN_SECRET", os.getenv("SECRET_KEY", "change-me"))
+ACCESS_SECRET = os.environ.get(
+    "ACCESS_TOKEN_SECRET", os.environ.get("SECRET_KEY", "change-me")
+)
+REFRESH_SECRET = os.environ.get(
+    "REFRESH_TOKEN_SECRET", os.environ.get("SECRET_KEY", "change-me")
+)
 
 
 def _now() -> datetime:

--- a/backend/database.py
+++ b/backend/database.py
@@ -10,7 +10,7 @@ from sqlalchemy.orm import sessionmaker
 
 from backend.models.base import Base
 
-DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./bullbearbroker.db")
+DATABASE_URL = os.environ.get("DATABASE_URL", "sqlite:///./bullbearbroker.db")
 
 connect_args = {}
 if DATABASE_URL.startswith("sqlite"):
@@ -19,7 +19,7 @@ if DATABASE_URL.startswith("sqlite"):
 engine = create_engine(DATABASE_URL, future=True, echo=False, connect_args=connect_args)
 SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False, future=True)
 
-if os.getenv("BULLBEAR_SKIP_AUTOCREATE", "0") != "1":
+if os.environ.get("BULLBEAR_SKIP_AUTOCREATE", "0") != "1":
     try:
         Base.metadata.create_all(bind=engine)
         inspector = inspect(engine)  # [Codex] nuevo - verificación de columnas adicionales

--- a/backend/main.py
+++ b/backend/main.py
@@ -34,7 +34,7 @@ logger.info("backend_started")
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     # 🔹 Startup
-    redis_url = os.getenv("REDIS_URL", "redis://localhost:6379")
+    redis_url = os.environ.get("REDIS_URL", "redis://localhost:6379")
     redis_client = None
     try:
         redis_client = await redis.from_url(
@@ -60,8 +60,8 @@ async def lifespan(app: FastAPI):
         Base.metadata.create_all(bind=engine)
         logger.info("database_ready")
 
-        default_email = os.getenv("BULLBEAR_DEFAULT_USER", "test@bullbear.ai")
-        default_password = os.getenv("BULLBEAR_DEFAULT_PASSWORD", "Test1234!")
+        default_email = os.environ.get("BULLBEAR_DEFAULT_USER", "test@bullbear.ai")
+        default_password = os.environ.get("BULLBEAR_DEFAULT_PASSWORD", "Test1234!")
         user_service.ensure_user(default_email, default_password)
         logger.info("default_user_ready", email=default_email)
     except Exception as exc:  # pragma: no cover - evita fallas en despliegues sin DB
@@ -95,8 +95,9 @@ app = FastAPI(
     lifespan=lifespan,
 )
 
-# Configuración de CORS (para el frontend en localhost:3000)
-origins = ["http://localhost:3000"]
+# Configuración de CORS (controlada por variables de entorno)
+raw_origins = os.environ.get("CORS_ALLOW_ORIGINS", "http://localhost:3000")
+origins = [origin.strip() for origin in raw_origins.split(",") if origin.strip()]
 
 app.add_middleware(
     CORSMiddleware,

--- a/backend/utils/config.py
+++ b/backend/utils/config.py
@@ -12,9 +12,9 @@ LOGGER = logging.getLogger(__name__)
 
 
 def _get_env(name: str, default: Optional[str] = None) -> Optional[str]:
-    """Wrapper around :func:`os.getenv` that trims whitespace."""
+    """Wrapper around :func:`os.environ.get` that trims whitespace."""
 
-    value = os.getenv(name, default)
+    value = os.environ.get(name, default)
     if isinstance(value, str):
         value = value.strip() or None
     return value

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ x-backend-base: &backend-base
     context: .
     dockerfile: Dockerfile
   env_file:
-    - .env
+    - ${ENV_FILE:-.env.local}
   environment:
     DATABASE_URL: ${DATABASE_URL:-postgresql+psycopg2://bullbear:bullbear@db:5432/bullbear}
     REDIS_URL: ${REDIS_URL:-redis://redis:6379/0}
@@ -15,14 +15,14 @@ x-backend-base: &backend-base
     db:
       condition: service_healthy
     redis:
-      condition: service_started
+      condition: service_healthy
 
 x-frontend-base: &frontend-base
   build:
     context: ./frontend
     dockerfile: Dockerfile
   env_file:
-    - .env
+    - ${ENV_FILE:-.env.local}
 
 services:
   db:
@@ -47,6 +47,11 @@ services:
     image: redis:7-alpine
     ports:
       - "6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
   backend:
     <<: *backend-base
@@ -69,10 +74,10 @@ services:
     profiles: ["default"]
     command: npm run dev -- --hostname 0.0.0.0 --port 3000
     environment:
-      NEXT_PUBLIC_API_BASE_URL: ${NEXT_PUBLIC_API_BASE_URL:-http://backend:8000}
+      NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-http://backend:8000}
     depends_on:
       backend:
-        condition: service_started
+        condition: service_healthy
     ports:
       - "3000:3000"
 
@@ -81,10 +86,10 @@ services:
     profiles: ["staging"]
     command: npm start
     environment:
-      NEXT_PUBLIC_API_BASE_URL: ${NEXT_PUBLIC_API_BASE_URL:-http://backend-staging:8000}
+      NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-http://backend-staging:8000}
     depends_on:
       backend-staging:
-        condition: service_started
+        condition: service_healthy
     ports:
       - "3000:3000"
 

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -10,8 +10,7 @@ const nextConfig = {
   },
   env: {
     // 👇 aseguramos compatibilidad con ESLint flat config: process como global
-    NEXT_PUBLIC_API_BASE_URL:
-      process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:8000",
+    NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL,
   },
 };
 

--- a/frontend/src/hooks/__tests__/useAlertsWebSocket.test.ts
+++ b/frontend/src/hooks/__tests__/useAlertsWebSocket.test.ts
@@ -1,9 +1,12 @@
 import { act, renderHook } from "@testing-library/react";
 
+process.env.NEXT_PUBLIC_API_URL =
+  process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
+
 import { useAlertsWebSocket } from "../useAlertsWebSocket";
 import * as api from "@/lib/api";
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL;
 
 class MockWebSocket {
   static instances: MockWebSocket[] = [];
@@ -64,7 +67,7 @@ declare global {
 
 describe("useAlertsWebSocket", () => {
   beforeEach(() => {
-    process.env.NEXT_PUBLIC_API_BASE_URL = "http://localhost:8000";
+    process.env.NEXT_PUBLIC_API_URL = "http://localhost:8000";
     (global as any).WebSocket = MockWebSocket as unknown as typeof WebSocket;
     jest.useFakeTimers();
     MockWebSocket.reset();
@@ -74,7 +77,7 @@ describe("useAlertsWebSocket", () => {
     jest.runOnlyPendingTimers();
     jest.useRealTimers();
     MockWebSocket.reset();
-    process.env.NEXT_PUBLIC_API_BASE_URL = API_BASE_URL;
+    process.env.NEXT_PUBLIC_API_URL = API_BASE_URL;
   });
 
   it("establece la conexión y procesa mensajes de alerta", () => {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,5 +1,11 @@
-export const API_BASE_URL =
-  process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:8000";
+const envApiUrl =
+  process.env.NEXT_PUBLIC_API_URL ?? process.env.NEXT_PUBLIC_API_BASE_URL;
+
+if (!envApiUrl) {
+  throw new Error("NEXT_PUBLIC_API_URL is not defined");
+}
+
+export const API_BASE_URL = envApiUrl.replace(/\/$/, "");
 
 export function resolveWebSocketUrl(path: string): string {
   const base = new URL(API_BASE_URL);


### PR DESCRIPTION
## Summary
- allow docker services to load either .env.local or .env.supabase, add Redis healthcheck, and expose NEXT_PUBLIC_API_URL to frontend containers
- extend the Makefile with local/supabase helpers, volume teardown, migration shortcut, and ensure docker-compose commands respect the selected env file
- update backend configuration to rely on os.environ.get and frontend clients to consume NEXT_PUBLIC_API_URL instead of hard-coded localhost values

## Testing
- python -m pytest backend/tests
- NEXT_PUBLIC_API_URL=http://localhost:8000 npm --prefix frontend test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68dbf578c8988321a4f3d134900e9e71