### PR TITLE
Fix docker-compose.yml services block and validation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,5 @@
+version: "3.9"
+
 x-backend-base: &backend-base
   build:
     context: .
@@ -25,7 +27,9 @@ x-frontend-base: &frontend-base
 services:
   db:
     container_name: bullbear-db
-    profiles: ["default", "staging"]
+    profiles:
+      - default
+      - staging
     image: postgres:15-alpine
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-bullbear}
@@ -43,7 +47,9 @@ services:
 
   redis:
     container_name: bullbear-redis
-    profiles: ["default", "staging"]
+    profiles:
+      - default
+      - staging
     image: redis:7-alpine
     ports:
       - "6379:6379"
@@ -56,7 +62,8 @@ services:
   backend:
     container_name: bullbear-backend
     <<: *backend-base
-    profiles: ["default"]
+    profiles:
+      - default
     command: uvicorn backend.main:app --reload --host 0.0.0.0 --port 8000
     ports:
       - "8000:8000"
@@ -71,7 +78,8 @@ services:
   backend-staging:
     container_name: bullbear-backend-staging
     <<: *backend-base
-    profiles: ["staging"]
+    profiles:
+      - staging
     command: uvicorn backend.main:app --host 0.0.0.0 --port 8000
     ports:
       - "8000:8000"
@@ -84,7 +92,8 @@ services:
   frontend:
     container_name: bullbear-frontend
     <<: *frontend-base
-    profiles: ["default"]
+    profiles:
+      - default
     command: npm run dev -- --hostname 0.0.0.0 --port 3000
     environment:
       NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-http://backend:8000}
@@ -97,7 +106,8 @@ services:
   frontend-staging:
     container_name: bullbear-frontend-staging
     <<: *frontend-base
-    profiles: ["staging"]
+    profiles:
+      - staging
     command: npm start
     environment:
       NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-http://backend-staging:8000}


### PR DESCRIPTION
## Summary
- ensure the docker-compose services block stays at the root level with an explicit schema version
- keep service definitions intact while normalizing profile declarations so Compose recognizes db, redis, backend, and frontend

## Testing
- `docker compose -f docker-compose.yml config` *(fails: docker command is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc00150b748321a2a516320c6ee5fb