### PR TITLE
Fix docker compose anchors and profiles

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,35 @@
+version: "3.9"
+
+x-backend-base: &backend-base
+  build:
+    context: ./backend
+    dockerfile: Dockerfile
+  env_file:
+    - ${ENV_FILE:-.env.local}
+  environment:
+    DATABASE_URL: ${DATABASE_URL:-postgresql+psycopg2://bullbear:bullbear@db:5432/bullbear}
+    REDIS_URL: ${REDIS_URL:-redis://redis:6379/0}
+    BULLBEAR_DEFAULT_USER: ${BULLBEAR_DEFAULT_USER:-test@bullbear.ai}
+    BULLBEAR_DEFAULT_PASSWORD: ${BULLBEAR_DEFAULT_PASSWORD:-Test1234!}
+  depends_on:
+    db:
+      condition: service_healthy
+    redis:
+      condition: service_healthy
+
+x-frontend-base: &frontend-base
+  build:
+    context: ./frontend
+    dockerfile: Dockerfile
+  env_file:
+    - ${ENV_FILE:-.env.local}
+
 services:
   db:
     container_name: bullbear-db
-    profiles: ["default", "staging"]
+    profiles:
+      - default
+      - staging
     image: postgres:15-alpine
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-bullbear}
@@ -19,7 +47,9 @@ services:
 
   redis:
     container_name: bullbear-redis
-    profiles: ["default", "staging"]
+    profiles:
+      - default
+      - staging
     image: redis:7-alpine
     ports:
       - "6379:6379"
@@ -31,21 +61,9 @@ services:
 
   backend:
     container_name: bullbear-backend
-    build:
-      context: ./backend
-      dockerfile: Dockerfile
-    env_file:
-      - ${ENV_FILE:-.env.local}
-    environment:
-      DATABASE_URL: ${DATABASE_URL:-postgresql+psycopg2://bullbear:bullbear@db:5432/bullbear}
-      REDIS_URL: ${REDIS_URL:-redis://redis:6379/0}
-      BULLBEAR_DEFAULT_USER: ${BULLBEAR_DEFAULT_USER:-test@bullbear.ai}
-      BULLBEAR_DEFAULT_PASSWORD: ${BULLBEAR_DEFAULT_PASSWORD:-Test1234!}
-    depends_on:
-      db:
-        condition: service_healthy
-      redis:
-        condition: service_healthy
+    <<: *backend-base
+    profiles:
+      - default
     command: uvicorn backend.main:app --reload --host 0.0.0.0 --port 8000
     ports:
       - "8000:8000"
@@ -59,21 +77,9 @@ services:
 
   backend-staging:
     container_name: bullbear-backend-staging
-    build:
-      context: ./backend
-      dockerfile: Dockerfile
-    env_file:
-      - ${ENV_FILE:-.env.local}
-    environment:
-      DATABASE_URL: ${DATABASE_URL:-postgresql+psycopg2://bullbear:bullbear@db:5432/bullbear}
-      REDIS_URL: ${REDIS_URL:-redis://redis:6379/0}
-      BULLBEAR_DEFAULT_USER: ${BULLBEAR_DEFAULT_USER:-test@bullbear.ai}
-      BULLBEAR_DEFAULT_PASSWORD: ${BULLBEAR_DEFAULT_PASSWORD:-Test1234!}
-    depends_on:
-      db:
-        condition: service_healthy
-      redis:
-        condition: service_healthy
+    <<: *backend-base
+    profiles:
+      - staging
     command: uvicorn backend.main:app --host 0.0.0.0 --port 8000
     ports:
       - "8000:8000"
@@ -85,11 +91,9 @@ services:
 
   frontend:
     container_name: bullbear-frontend
-    build:
-      context: ./frontend
-      dockerfile: Dockerfile
-    env_file:
-      - ${ENV_FILE:-.env.local}
+    <<: *frontend-base
+    profiles:
+      - default
     command: npm run dev -- --hostname 0.0.0.0 --port 3000
     environment:
       NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-http://backend:8000}
@@ -101,11 +105,9 @@ services:
 
   frontend-staging:
     container_name: bullbear-frontend-staging
-    build:
-      context: ./frontend
-      dockerfile: Dockerfile
-    env_file:
-      - ${ENV_FILE:-.env.local}
+    <<: *frontend-base
+    profiles:
+      - staging
     command: npm start
     environment:
       NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-http://backend-staging:8000}


### PR DESCRIPTION
## Summary
- restore backend and frontend service anchors so shared configuration is defined once without duplication
- explicitly scope services to the intended default or staging profiles and add the compose file version header
- retain existing health checks, dependencies, environment variables, and volumes so `docker compose config` renders all services

## Testing
- make up-local *(fails: docker CLI is not available in the execution environment)*
- docker compose ps *(fails: docker CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc0b7d9ec08321b622e6899a0a2563