### PR TITLE
Remove deprecated version declaration from docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 x-backend-base: &backend-base
   build:
     context: ./backend


### PR DESCRIPTION
## Summary
- remove the deprecated version declaration from docker-compose.yml to avoid warnings with Docker Compose v2

## Testing
- not run (docker is not available in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68dc0f01e84083219a2953c0e32f6801