### PR TITLE
Improve backend coverage for time series and AI fallbacks

### DIFF
--- a/backend/tests/test_ai_service_fallbacks.py
+++ b/backend/tests/test_ai_service_fallbacks.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from typing import Callable
+from unittest.mock import AsyncMock
+
+import pytest
+
+from backend.services import ai_service as ai_service_module
+from backend.services.ai_service import AIService
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+def configure_ai_providers(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(ai_service_module.Config, "HUGGINGFACE_API_KEY", "test-token", raising=False)
+    monkeypatch.setattr(ai_service_module.Config, "HUGGINGFACE_MODEL", "test/model", raising=False)
+    monkeypatch.setattr(ai_service_module.Config, "HUGGINGFACE_API_URL", "https://example.com/api", raising=False)
+    monkeypatch.setattr(ai_service_module.Config, "OLLAMA_HOST", "http://localhost:11434", raising=False)
+    monkeypatch.setattr(ai_service_module.Config, "OLLAMA_MODEL", "mock-ollama", raising=False)
+
+
+@pytest.mark.anyio
+async def test_process_message_uses_mocked_provider(monkeypatch: pytest.MonkeyPatch) -> None:
+    service = AIService()
+
+    mistral_mock = AsyncMock(return_value="respuesta simulada")
+    ollama_mock = AsyncMock(side_effect=AssertionError("Ollama no debería ejecutarse"))
+
+    monkeypatch.setattr(ai_service_module.Config, "HUGGINGFACE_API_KEY", "", raising=False)
+    monkeypatch.setattr(AIService, "process_with_mistral", mistral_mock)
+    monkeypatch.setattr(AIService, "_call_ollama", ollama_mock)
+
+    result = await service.process_message("Dame un resumen del mercado")
+
+    assert result.text == "respuesta simulada"
+    assert result.provider == "mistral"
+    assert mistral_mock.await_count == 1
+    ollama_mock.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_call_with_backoff_falls_back_on_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    service = AIService()
+
+    primary = AsyncMock(side_effect=TimeoutError("timeout"))
+    secondary = AsyncMock(return_value="respuesta secundaria")
+    sleep_mock = AsyncMock()
+
+    monkeypatch.setattr(ai_service_module.asyncio, "sleep", sleep_mock)
+
+    result, provider = await service._call_with_backoff([
+        ("primario", lambda: primary()),
+        ("secundario", lambda: secondary()),
+    ])
+
+    assert result == "respuesta secundaria"
+    assert provider == "secundario"
+    assert primary.await_count == 3
+    assert secondary.await_count == 1
+    assert sleep_mock.await_count == 2
+
+
+@pytest.mark.anyio
+async def test_call_with_backoff_raises_on_empty_response(monkeypatch: pytest.MonkeyPatch) -> None:
+    service = AIService()
+
+    failing_provider = AsyncMock(return_value="   ")
+    sleep_mock = AsyncMock()
+
+    monkeypatch.setattr(ai_service_module.asyncio, "sleep", sleep_mock)
+
+    with pytest.raises(ValueError):
+        await service._call_with_backoff([("mock", lambda: failing_provider())])
+
+    assert failing_provider.await_count == 3
+    assert sleep_mock.await_count == 2
+
+
+class _DummyResponse:
+    def __init__(self, status: int, json_data, text_data: str = "") -> None:
+        self.status = status
+        self._json_data = json_data
+        self._text_data = text_data or ""
+
+    async def __aenter__(self) -> "_DummyResponse":
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    async def json(self):
+        if isinstance(self._json_data, Exception):
+            raise self._json_data
+        return self._json_data
+
+    async def text(self) -> str:
+        return self._text_data
+
+
+class _DummySession:
+    def __init__(self, response_factory: Callable[[], _DummyResponse]) -> None:
+        self._response_factory = response_factory
+
+    async def __aenter__(self) -> "_DummySession":
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    def post(self, *args, **kwargs) -> _DummyResponse:
+        return self._response_factory()
+
+
+@pytest.mark.anyio
+async def test_huggingface_invalid_payload_raises_value_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    service = AIService()
+
+    def _response_factory() -> _DummyResponse:
+        return _DummyResponse(status=200, json_data=[{}], text_data="{}")
+
+    monkeypatch.setattr(ai_service_module.aiohttp, "ClientSession", lambda: _DummySession(_response_factory))
+
+    with pytest.raises(ValueError):
+        await service._call_huggingface("", {})

--- a/backend/tests/test_alert_service.py
+++ b/backend/tests/test_alert_service.py
@@ -1,12 +1,29 @@
+from __future__ import annotations
+
 from types import SimpleNamespace
+from uuid import uuid4
 
 import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
 
+from backend.models.alert import Alert
+from backend.models.base import Base
 from backend.services.alert_service import AlertService
 
 
 class DummyAlert(SimpleNamespace):
     pass
+
+
+@pytest.fixture()
+def in_memory_session_factory():
+    engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+    Base.metadata.create_all(engine)
+    factory = sessionmaker(bind=engine, expire_on_commit=False, future=True)
+    yield factory
+    Base.metadata.drop_all(engine)
+    engine.dispose()
 
 
 @pytest.fixture
@@ -85,3 +102,88 @@ async def test_send_external_alert_requires_target(monkeypatch):
 
     with pytest.raises(ValueError):
         await service.send_external_alert(message="Hello")
+
+
+def test_fetch_alerts_returns_persisted_alert(in_memory_session_factory) -> None:
+    service = AlertService(session_factory=in_memory_session_factory)
+    user_id = uuid4()
+
+    with in_memory_session_factory() as session:
+        alert = Alert(
+            user_id=user_id,
+            title="Breakout",
+            asset="AAPL",
+            condition=">",
+            value=150.0,
+            active=True,
+        )
+        session.add(alert)
+        session.commit()
+
+    stored = service._fetch_alerts()
+    assert len(stored) == 1
+    assert stored[0].asset == "AAPL"
+    assert stored[0].active is True
+
+
+def test_validate_condition_expression_rejects_invalid_data() -> None:
+    service = AlertService(session_factory=None)
+
+    with pytest.raises(ValueError):
+        service.validate_condition_expression("")
+    with pytest.raises(ValueError):
+        service.validate_condition_expression("RSI(14) + >")
+
+
+def test_toggle_alert_active_state(in_memory_session_factory) -> None:
+    service = AlertService(session_factory=in_memory_session_factory)
+    user_id = uuid4()
+
+    with in_memory_session_factory() as session:
+        alert = Alert(
+            user_id=user_id,
+            title="Resistance",
+            asset="TSLA",
+            condition="<",
+            value=200.0,
+            active=True,
+        )
+        session.add(alert)
+        session.commit()
+        alert_id = alert.id
+
+    assert [stored.id for stored in service._fetch_alerts()] == [alert_id]
+
+    with in_memory_session_factory() as session:
+        record = session.get(Alert, alert_id)
+        assert record is not None
+        record.active = False
+        session.commit()
+
+    assert service._fetch_alerts() == []
+
+    with in_memory_session_factory() as session:
+        record = session.get(Alert, alert_id)
+        assert record is not None
+        record.active = True
+        session.commit()
+
+    assert [stored.id for stored in service._fetch_alerts()] == [alert_id]
+
+
+@pytest.mark.anyio
+async def test_send_with_result_returns_error_details() -> None:
+    service = AlertService(session_factory=None)
+
+    async def failing_operation():
+        raise RuntimeError("alert not found")
+
+    provider, target, outcome = await service._send_with_result(
+        "websocket",
+        "missing",
+        failing_operation(),
+    )
+
+    assert provider == "websocket"
+    assert target == "missing"
+    assert outcome == "alert not found"

--- a/backend/tests/test_timeseries_service.py
+++ b/backend/tests/test_timeseries_service.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from typing import List, Sequence
+
+import pytest
+
+from backend.services.timeseries_service import resample_series
+
+
+@pytest.mark.parametrize(
+    "interval, series, expected",
+    [
+        (
+            "1h",
+            [
+                {"timestamp": "2024-01-01T00:15:00Z", "close": 10.0, "volume": 1},
+                {"timestamp": "2024-01-01T00:45:00Z", "close": 12.0, "volume": 2},
+                {"timestamp": "2024-01-01T01:10:00Z", "close": 9.0, "volume": 3},
+                {"timestamp": "2024-01-01T02:05:00Z", "close": 11.0, "volume": 1},
+            ],
+            [
+                {
+                    "timestamp": "2024-01-01T00:00:00Z",
+                    "open": 10.0,
+                    "high": 12.0,
+                    "low": 10.0,
+                    "close": 12.0,
+                    "volume": 3.0,
+                },
+                {
+                    "timestamp": "2024-01-01T01:00:00Z",
+                    "open": 9.0,
+                    "high": 9.0,
+                    "low": 9.0,
+                    "close": 9.0,
+                    "volume": 3.0,
+                },
+                {
+                    "timestamp": "2024-01-01T02:00:00Z",
+                    "open": 11.0,
+                    "high": 11.0,
+                    "low": 11.0,
+                    "close": 11.0,
+                    "volume": 1.0,
+                },
+            ],
+        ),
+        (
+            "1d",
+            [
+                {"timestamp": "2024-01-01T10:00:00Z", "close": 100.0},
+                {"timestamp": "2024-01-01T15:30:00Z", "close": 110.0},
+                {"timestamp": "2024-01-02T09:30:00Z", "close": 90.0},
+            ],
+            [
+                {
+                    "timestamp": "2024-01-01T00:00:00Z",
+                    "open": 100.0,
+                    "high": 110.0,
+                    "low": 100.0,
+                    "close": 110.0,
+                },
+                {
+                    "timestamp": "2024-01-02T00:00:00Z",
+                    "open": 90.0,
+                    "high": 90.0,
+                    "low": 90.0,
+                    "close": 90.0,
+                },
+            ],
+        ),
+    ],
+)
+def test_resample_series_returns_expected_buckets(
+    interval: str, series: Sequence[dict], expected: List[dict]
+) -> None:
+    result = resample_series(series, interval)
+    assert result == expected
+
+
+def test_resample_series_handles_empty_input() -> None:
+    assert resample_series([], "1h") == []
+
+
+def test_resample_series_sorts_out_of_order_points() -> None:
+    series = [
+        ("2024-01-01T02:00:00Z", 20.0),
+        ("2024-01-01T00:00:00Z", 10.0),
+        ("2024-01-01T01:00:00Z", 15.0),
+    ]
+    result = resample_series(series, "1h")
+    timestamps = [bucket["timestamp"] for bucket in result]
+    assert timestamps == [
+        "2024-01-01T00:00:00Z",
+        "2024-01-01T01:00:00Z",
+        "2024-01-01T02:00:00Z",
+    ]
+
+
+def test_resample_series_raises_for_invalid_interval() -> None:
+    with pytest.raises(ValueError):
+        resample_series([
+            {"timestamp": "2024-01-01T00:00:00Z", "close": 1.0}
+        ], "15m")


### PR DESCRIPTION
## Summary
- add a reusable resample_series helper to the time series service and cover happy path, ordering, and invalid intervals
- add dedicated async AI fallback tests to exercise timeout recovery, empty responses, and huggingface error handling
- extend alert service and indicator tests with in-memory database scenarios and edge-case signal inputs

## Testing
- pytest backend/tests/test_timeseries_service.py backend/tests/test_ai_service_fallbacks.py backend/tests/test_alert_service.py backend/tests/test_indicators.py -q

------
https://chatgpt.com/codex/tasks/task_e_68dc64b2b3ac832185da7f3cffa799f7