### PR TITLE
test: expand coverage for alert, news and ai services

### DIFF
--- a/backend/tests/test_alert_service_extended.py
+++ b/backend/tests/test_alert_service_extended.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+from importlib import import_module
 from uuid import uuid4
 from unittest.mock import AsyncMock
 
@@ -8,6 +9,7 @@ from sqlalchemy.orm import sessionmaker
 
 from backend.models.alert import Alert
 from backend.models.base import Base
+alert_service_module = import_module("backend.services.alert_service")
 from backend.services.alert_service import AlertService
 
 
@@ -31,6 +33,14 @@ def service(in_memory_factory) -> AlertService:
 @pytest.fixture
 def anyio_backend() -> str:
     return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_suggest_alert_condition_rejects_incomplete_payload(
+    service: AlertService,
+) -> None:
+    with pytest.raises(ValueError):
+        await service.suggest_alert_condition(" ", interval="1h")
 
 
 def test_fetch_alert_persists_valid_records(service: AlertService, in_memory_factory) -> None:
@@ -240,3 +250,159 @@ async def test_send_external_alert_handles_delivery_exceptions(
     assert "telegram down" in results["telegram"]["error"]
     assert results["discord"]["status"] == "error"
     assert "discord down" in results["discord"]["error"]
+
+
+@pytest.mark.anyio
+async def test_send_external_alert_requires_target(service: AlertService) -> None:
+    with pytest.raises(ValueError):
+        await service.send_external_alert(message="Test without targets")
+
+
+@pytest.mark.anyio
+async def test_evaluate_alerts_skips_expired_alerts(
+    service: AlertService, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    class _ExpiringAlert:
+        def __init__(self) -> None:
+            self.asset = "BTCUSDT"
+            self.value = 30000.0
+            self.condition = ">"
+            self.expires_at = datetime.utcnow() - timedelta(minutes=5)
+
+        @property
+        def active(self) -> bool:  # pragma: no cover - simple property
+            return self.expires_at > datetime.utcnow()
+
+    alert = _ExpiringAlert()
+
+    monkeypatch.setattr(service, "_fetch_alerts", lambda: [alert])
+
+    async def fail_resolve(symbol: str) -> float:  # noqa: ANN001
+        raise AssertionError("Expired alerts should not trigger price resolution")
+
+    monkeypatch.setattr(service, "_resolve_price", fail_resolve)
+    notifier = AsyncMock()
+    monkeypatch.setattr(service, "_notify", notifier)
+
+    await service.evaluate_alerts()
+
+    notifier.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_evaluate_alerts_triggers_after_reactivation(
+    service: AlertService, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    alert = Alert(
+        user_id=uuid4(),
+        title="Swing",
+        asset="AAPL",
+        condition=">",
+        value=150.0,
+        active=True,
+    )
+
+    def fetch_alerts() -> list[Alert]:
+        return [alert] if getattr(alert, "active", True) else []
+
+    monkeypatch.setattr(service, "_fetch_alerts", fetch_alerts)
+    price_resolver = AsyncMock(return_value=180.0)
+    monkeypatch.setattr(service, "_resolve_price", price_resolver)
+    notifier = AsyncMock()
+    monkeypatch.setattr(service, "_notify", notifier)
+
+    # Desactivar temporalmente la alerta
+    alert.active = False
+    await service.evaluate_alerts()
+    notifier.assert_not_awaited()
+    price_resolver.assert_not_awaited()
+
+    # Reactivar y comprobar notificación
+    alert.active = True
+    await service.evaluate_alerts()
+    notifier.assert_awaited_once()
+    price_resolver.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_send_external_alert_reports_invalid_target(
+    service: AlertService, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    async def failing_telegram(chat_id: str, message: str) -> None:  # noqa: ANN001
+        raise RuntimeError(f"invalid target {chat_id}")
+
+    monkeypatch.setattr(service, "_send_telegram_message", failing_telegram)
+
+    results = await service.send_external_alert(
+        message="Payload",
+        telegram_chat_id="bad-target",
+    )
+
+    assert results["telegram"]["status"] == "error"
+    assert "bad-target" in results["telegram"]["error"]
+
+
+def test_should_trigger_equal_condition(service: AlertService) -> None:
+    alert = Alert(
+        user_id=uuid4(),
+        title="Equality",
+        asset="BTCUSDT",
+        condition="==",
+        value=100.0,
+        active=True,
+    )
+
+    assert service._should_trigger(alert, 100.0000004)
+    assert service._should_trigger(alert, 99.9999997)
+    assert service._should_trigger(alert, 100.01) is False
+
+
+@pytest.mark.anyio
+async def test_notify_handles_websocket_errors_and_telegram(
+    service: AlertService, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    class _Manager:
+        async def broadcast(self, payload):  # noqa: ANN001
+            raise RuntimeError("websocket down")
+
+    service.register_websocket_manager(_Manager())
+
+    calls: list[str] = []
+
+    async def fake_notify(alert: Alert, message: str) -> None:  # noqa: ANN001
+        calls.append(message)
+
+    monkeypatch.setattr(service, "_notify_telegram", fake_notify)
+
+    alert = Alert(
+        user_id=uuid4(),
+        title="Breakout",
+        asset="ETHUSDT",
+        condition=">",
+        value=2000.0,
+        active=True,
+    )
+
+    await service._notify(alert, 2100.0)
+
+    assert calls and "2100.00" in calls[0]
+
+
+@pytest.mark.anyio
+async def test_suggest_alert_condition_fallback_on_ai_error(
+    service: AlertService, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    fake_call = AsyncMock(side_effect=RuntimeError("AI offline"))
+
+    monkeypatch.setattr(
+        alert_service_module.ai_service,
+        "process_message",
+        fake_call,
+        raising=False,
+    )
+
+    suggestion = await service.suggest_alert_condition("btc", interval="4h")
+
+    fake_call.assert_awaited_once()
+    assert "Sugerencia" in suggestion["notes"] or "Sugerencia" in suggestion["suggestion"]
+    assert suggestion["suggestion"].upper().startswith("BTC")


### PR DESCRIPTION
## Summary
- add async regression tests around invalid payloads, expired/reactivated alerts, and notification error reporting for the alert service
- expand news service tests to cover deduplication, corrupted source payloads, and recency ordering across feeds
- extend AI service suite with long prompt fallback, streaming accumulation, cascading failure, and provider retry scenarios to drive coverage above 60%

## Testing
- pytest backend/tests/test_alert_service_extended.py backend/tests/test_news_service_extended.py backend/tests/test_ai_service_extended.py --cov=backend.services.alert_service --cov=backend.services.news_service --cov=backend.services.ai_service --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68dcaa480f888321b1845df0b0a764c6