### PR TITLE
Add edge-case test coverage for indicators, stock, and forex services

### DIFF
--- a/backend/tests/test_forex_service_edge_cases.py
+++ b/backend/tests/test_forex_service_edge_cases.py
@@ -1,0 +1,139 @@
+import asyncio
+from typing import Any, Dict
+from unittest.mock import AsyncMock
+
+import pytest
+
+from backend.services.forex_service import ForexService
+from backend.utils.config import Config
+
+
+class DummyCache:
+    def __init__(self) -> None:
+        self.values: Dict[str, Any] = {}
+
+    async def get(self, key: str):
+        return self.values.get(key.lower())
+
+    async def set(self, key: str, value: Any, ttl: Any = None):  # noqa: ARG002
+        self.values[key.lower()] = value
+
+
+class DummySession:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):  # noqa: D401
+        return False
+
+
+@pytest.fixture(autouse=True)
+def restore_config():
+    original_td = Config.TWELVEDATA_API_KEY
+    original_av = Config.ALPHA_VANTAGE_API_KEY
+    yield
+    Config.TWELVEDATA_API_KEY = original_td
+    Config.ALPHA_VANTAGE_API_KEY = original_av
+
+
+@pytest.mark.asyncio
+async def test_get_quote_falls_back_after_timeouts(monkeypatch):
+    Config.TWELVEDATA_API_KEY = "td-key"
+    Config.ALPHA_VANTAGE_API_KEY = "av-key"
+
+    service = ForexService(
+        cache_client=DummyCache(),
+        session_factory=lambda timeout=None: DummySession(),
+    )
+
+    twelvedata_mock = AsyncMock(
+        side_effect=[asyncio.TimeoutError()] * ForexService.RETRY_ATTEMPTS
+    )
+    alpha_mock = AsyncMock(
+        side_effect=[KeyError("bad payload")] * ForexService.RETRY_ATTEMPTS
+    )
+    yahoo_mock = AsyncMock(return_value={"price": 1.5, "change": 0.02})
+
+    monkeypatch.setattr(service, "_fetch_twelvedata", twelvedata_mock)
+    monkeypatch.setattr(service, "_fetch_alpha_vantage", alpha_mock)
+    monkeypatch.setattr(service, "_fetch_yahoo_finance", yahoo_mock)
+    service.apis[0]["callable"] = twelvedata_mock
+    service.apis[1]["callable"] = alpha_mock
+    service.apis[2]["callable"] = yahoo_mock
+    monkeypatch.setattr(asyncio, "sleep", AsyncMock())
+
+    result = await service.get_quote("eurusd")
+
+    assert result == {
+        "symbol": "EUR/USD",
+        "price": 1.5,
+        "change": 0.02,
+        "source": "Yahoo Finance",
+        "sources": ["Twelve Data", "Alpha Vantage", "Yahoo Finance"],
+    }
+
+    assert twelvedata_mock.await_count == service.RETRY_ATTEMPTS
+    assert alpha_mock.await_count == service.RETRY_ATTEMPTS
+    yahoo_mock.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_cached_result_after_fallback(monkeypatch):
+    Config.TWELVEDATA_API_KEY = "td-key"
+    Config.ALPHA_VANTAGE_API_KEY = "av-key"
+
+    service = ForexService(
+        cache_client=DummyCache(),
+        session_factory=lambda timeout=None: DummySession(),
+    )
+
+    twelvedata_mock = AsyncMock(
+        side_effect=[asyncio.TimeoutError()] * ForexService.RETRY_ATTEMPTS
+    )
+    alpha_mock = AsyncMock(return_value={"price": 2.0, "change": None})
+
+    monkeypatch.setattr(service, "_fetch_twelvedata", twelvedata_mock)
+    monkeypatch.setattr(service, "_fetch_alpha_vantage", alpha_mock)
+    service.apis[0]["callable"] = twelvedata_mock
+    service.apis[1]["callable"] = alpha_mock
+    monkeypatch.setattr(asyncio, "sleep", AsyncMock())
+
+    first = await service.get_quote("gbpjpy")
+    second = await service.get_quote("GBPJPY")
+
+    assert first == second
+    assert first["source"] == "Alpha Vantage"
+    assert first["sources"] == ["Twelve Data", "Alpha Vantage"]
+    assert twelvedata_mock.await_count == service.RETRY_ATTEMPTS
+    assert alpha_mock.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_get_quote_returns_none_when_all_fail(monkeypatch):
+    Config.TWELVEDATA_API_KEY = "td-key"
+    Config.ALPHA_VANTAGE_API_KEY = "av-key"
+
+    service = ForexService(
+        cache_client=DummyCache(),
+        session_factory=lambda timeout=None: DummySession(),
+    )
+
+    failure = AsyncMock(return_value=None)
+    monkeypatch.setattr(service, "_call_with_retries", failure)
+
+    result = await service.get_quote("xauusd")
+
+    assert result is None
+    assert failure.await_count == 3
+
+
+@pytest.mark.asyncio
+async def test_fetch_alpha_vantage_invalid_symbol_raises_value_error(monkeypatch):
+    Config.ALPHA_VANTAGE_API_KEY = "av-key"
+    service = ForexService(
+        cache_client=DummyCache(),
+        session_factory=lambda timeout=None: DummySession(),
+    )
+
+    with pytest.raises(ValueError):
+        await service._fetch_alpha_vantage(None, "USD")

--- a/backend/tests/test_indicators_edge_cases.py
+++ b/backend/tests/test_indicators_edge_cases.py
@@ -1,0 +1,126 @@
+import math
+from typing import Sequence
+
+import numpy as np
+import pytest
+
+from backend.utils import indicators
+
+
+@pytest.mark.parametrize(
+    "values, period, expected",
+    [
+        ([], 5, None),
+        ([0.0], 3, None),
+    ],
+)
+def test_indicators_empty_sequences_return_none(values, period, expected):
+    assert indicators.ema(values, period) is expected
+    assert indicators.rsi(values, period) is expected
+
+
+def test_average_true_range_and_vwap_empty_inputs_return_none():
+    assert indicators.average_true_range([], [], [], period=5) is None
+    assert indicators.volume_weighted_average_price([], [], [], []) is None
+
+
+@pytest.mark.parametrize(
+    "func, args",
+    [
+        (indicators.ema, (None, 3)),
+        (indicators.rsi, (None, 14)),
+        (indicators.average_true_range, (None, None, None, 14)),
+        (indicators.volume_weighted_average_price, (None, None, None, None)),
+    ],
+)
+def test_indicators_none_inputs_raise_type_error(func, args):
+    with pytest.raises(TypeError):
+        func(*args)
+
+
+@pytest.mark.parametrize(
+    "values",
+    [
+        [1.0, float("inf"), 10.0, 5.0, 2.0],
+        [1e20, 1e20 + 1, 1e20 + 2, 1e20 + 3, 1e20 + 4],
+    ],
+)
+def test_ema_and_rsi_handle_extreme_values(values: Sequence[float]):
+    ema_result = indicators.ema(list(values), period=3)
+    rsi_result = indicators.rsi(list(values), period=3)
+
+    assert ema_result is None or isinstance(ema_result, float)
+    assert rsi_result is None or isinstance(rsi_result, float)
+
+    if ema_result is not None:
+        assert math.isfinite(ema_result) or math.isinf(ema_result)
+    if rsi_result is not None:
+        assert (
+            math.isfinite(rsi_result)
+            or math.isinf(rsi_result)
+            or math.isnan(rsi_result)
+        )
+
+
+@pytest.mark.parametrize(
+    "highs, lows, closes",
+    [
+        (
+            [1.0, float("inf"), 10.0, 9.0],
+            [0.5, 1.0, 8.5, 8.0],
+            [0.75, 2.0, 9.5, 8.5],
+        ),
+        (
+            [1e10, 1e10 + 5, 1e10 + 2, 1e10 + 8],
+            [1e10 - 5, 1e10 - 1, 1e10 - 2, 1e10 - 3],
+            [1e10 - 1, 1e10 + 1, 1e10 + 3, 1e10 + 2],
+        ),
+    ],
+)
+def test_atr_handles_infinite_and_large_values(highs, lows, closes):
+    result = indicators.average_true_range(highs, lows, closes, period=2)
+    assert result is None or isinstance(result, float)
+    if result is not None:
+        assert math.isfinite(result) or math.isinf(result)
+
+
+@pytest.mark.parametrize(
+    "volumes",
+    [
+        [1.0, float("inf"), 2.0, 0.0],
+        [np.finfo(float).max, np.finfo(float).max, 1.0],
+    ],
+)
+def test_vwap_handles_anomalous_volume(volumes):
+    highs = [10.0, 10.5, 10.75][: len(volumes)]
+    lows = [9.0, 9.5, 9.75][: len(volumes)]
+    closes = [9.5, 10.0, 10.25][: len(volumes)]
+
+    result = indicators.volume_weighted_average_price(highs, lows, closes, volumes)
+    assert result is None or isinstance(result, float)
+    if result is not None:
+        assert (
+            math.isfinite(result)
+            or math.isinf(result)
+            or math.isnan(result)
+        )
+
+
+@pytest.mark.parametrize(
+    "func, args",
+    [
+        (indicators.ema, ([1.0, "oops", 3.0], 3)),
+        (indicators.rsi, (["oops", 1.0, 2.0, 3.0], 2)),
+        (
+            indicators.average_true_range,
+            ([1.0, 2.0, "bad"], [0.5, 1.5, 1.0], [0.75, 1.25, 1.5], 2),
+        ),
+        (
+            indicators.volume_weighted_average_price,
+            ([1.0, 2.0], [0.5, 1.0], [0.75, 1.5], [1.0, "bad"]),
+        ),
+    ],
+)
+def test_indicators_invalid_types_raise_type_error(func, args):
+    with pytest.raises((TypeError, ValueError)):
+        func(*args)

--- a/backend/tests/test_stock_service_edge_cases.py
+++ b/backend/tests/test_stock_service_edge_cases.py
@@ -1,0 +1,90 @@
+import asyncio
+from typing import Any, Dict
+from unittest.mock import AsyncMock
+
+import pytest
+
+from backend.services.stock_service import StockService
+from backend.utils.config import Config
+
+
+class DummyCache:
+    def __init__(self) -> None:
+        self.values: Dict[str, Any] = {}
+
+    async def get(self, key: str):
+        return self.values.get(key.lower())
+
+    async def set(self, key: str, value: Any, ttl: Any = None):  # noqa: ARG002
+        self.values[key.lower()] = value
+
+
+class DummySession:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):  # noqa: D401
+        return False
+
+
+@pytest.fixture(autouse=True)
+def restore_config():
+    original_twelve = Config.TWELVEDATA_API_KEY
+    original_alpha = Config.ALPHA_VANTAGE_API_KEY
+    yield
+    Config.TWELVEDATA_API_KEY = original_twelve
+    Config.ALPHA_VANTAGE_API_KEY = original_alpha
+
+
+@pytest.mark.asyncio
+async def test_fetch_yahoo_finance_with_corrupt_payload(monkeypatch):
+    service = StockService(cache_client=DummyCache(), session_factory=lambda timeout=None: DummySession())
+    monkeypatch.setattr(service, "_fetch_json", AsyncMock(return_value={"chart": {}}))
+
+    with pytest.raises(KeyError):
+        await service._fetch_yahoo_finance(None, "AAPL")
+
+
+@pytest.mark.asyncio
+async def test_fetch_alpha_vantage_with_missing_quote(monkeypatch):
+    Config.ALPHA_VANTAGE_API_KEY = "alpha-key"
+    service = StockService(cache_client=DummyCache(), session_factory=lambda timeout=None: DummySession())
+    monkeypatch.setattr(service, "_fetch_json", AsyncMock(return_value={}))
+
+    with pytest.raises(KeyError):
+        await service._fetch_alpha_vantage(None, "MSFT")
+
+
+@pytest.mark.asyncio
+async def test_get_price_skips_providers_without_keys(monkeypatch):
+    Config.TWELVEDATA_API_KEY = None
+    Config.ALPHA_VANTAGE_API_KEY = None
+
+    service = StockService(cache_client=DummyCache(), session_factory=lambda timeout=None: DummySession())
+    provider_mock = AsyncMock(return_value={"price": 123.45, "change": 1.5})
+    monkeypatch.setattr(service, "_call_with_retries", provider_mock)
+
+    result = await service.get_price("AAPL")
+
+    assert result == {"price": 123.45, "change": 1.5, "source": "Yahoo Finance"}
+    provider_mock.assert_awaited_once()
+    called_handler, _, _, source_name = provider_mock.await_args.args
+    assert source_name == "Yahoo Finance"
+    assert called_handler is service.apis[-1]["callable"]
+
+
+@pytest.mark.asyncio
+async def test_get_price_returns_none_when_all_fail(monkeypatch):
+    Config.TWELVEDATA_API_KEY = "td-key"
+    Config.ALPHA_VANTAGE_API_KEY = "alpha-key"
+
+    service = StockService(cache_client=DummyCache(), session_factory=lambda timeout=None: DummySession())
+    failure_mock = AsyncMock(side_effect=[None, None, None])
+    monkeypatch.setattr(service, "_call_with_retries", failure_mock)
+
+    result = await service.get_price("NFLX")
+
+    assert result is None
+    assert failure_mock.await_count == 3
+    sources = [call.args[3] for call in failure_mock.await_args_list]
+    assert sources == [api["name"] for api in service.apis]


### PR DESCRIPTION
## Summary
- add indicator edge case tests covering empty input, extreme values, and invalid data types
- add stock service tests for corrupted payloads, missing API keys, and failure fallbacks
- add forex service tests to validate fallback order, caching, and invalid symbols

## Testing
- pytest --cov=backend

------
https://chatgpt.com/codex/tasks/task_e_68dd07d792a8832195c3ecbea66393bb