### PR TITLE
test: extend user and portfolio service coverage

### DIFF
--- a/backend/tests/test_portfolio_service_additional.py
+++ b/backend/tests/test_portfolio_service_additional.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import math
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from backend.models import Base
+from backend.services.portfolio_service import PortfolioService
+
+
+@pytest.fixture()
+def session_factory():
+    engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+    Base.metadata.create_all(engine)
+    factory = sessionmaker(bind=engine, expire_on_commit=False, future=True)
+    try:
+        yield factory
+    finally:
+        Base.metadata.drop_all(engine)
+        engine.dispose()
+
+
+@pytest.fixture()
+def portfolio_service(session_factory) -> PortfolioService:
+    return PortfolioService(session_factory=session_factory)
+
+
+@pytest.mark.asyncio()
+async def test_empty_portfolio_returns_controlled_response(
+    portfolio_service: PortfolioService,
+):
+    result = await portfolio_service.get_portfolio_overview(uuid4())
+    assert result == {"items": [], "total_value": 0.0}
+
+
+@pytest.mark.parametrize(
+    "symbol, amount, expected",
+    [
+        ("   ", 1, "El símbolo es obligatorio"),
+        ("BTC", 0, "La cantidad debe ser mayor que cero"),
+        ("ETH", -5, "La cantidad debe ser mayor que cero"),
+    ],
+)
+def test_create_item_invalid_inputs_raise(
+    portfolio_service: PortfolioService, symbol: str, amount: float, expected: str
+) -> None:
+    with pytest.raises(ValueError) as exc_info:
+        portfolio_service.create_item(uuid4(), symbol=symbol, amount=amount)
+    assert expected in str(exc_info.value)
+
+
+@pytest.mark.asyncio()
+async def test_portfolio_overview_handles_atypical_prices(
+    portfolio_service: PortfolioService, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    user_id = uuid4()
+    first = portfolio_service.create_item(user_id, symbol="XYZ", amount=2)
+    second = portfolio_service.create_item(user_id, symbol="ABC", amount=3)
+
+    prices = iter([-10.0, float("nan")])
+
+    async def fake_resolve(symbol: str) -> float:
+        return next(prices)
+
+    monkeypatch.setattr(portfolio_service, "_resolve_price", fake_resolve)
+
+    overview = await portfolio_service.get_portfolio_overview(user_id)
+
+    assert overview["items"][0]["id"] == first.id
+    assert overview["items"][0]["value"] == pytest.approx(-20.0)
+    assert math.isnan(overview["items"][1]["value"])  # NaN propagated
+    assert math.isnan(overview["total_value"])
+
+
+@pytest.mark.asyncio()
+async def test_portfolio_overview_reflects_latest_state(
+    portfolio_service: PortfolioService, session_factory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    user_id = uuid4()
+    first = portfolio_service.create_item(user_id, symbol="AAA", amount=1)
+    second = portfolio_service.create_item(user_id, symbol="BBB", amount=2)
+
+    price_map = {"AAA": 10.0, "BBB": 20.0}
+
+    async def price_lookup(symbol: str) -> float:
+        return price_map[symbol.strip().upper()]
+
+    monkeypatch.setattr(portfolio_service, "_resolve_price", price_lookup)
+
+    initial = await portfolio_service.get_portfolio_overview(user_id)
+    assert initial["total_value"] == pytest.approx(50.0)
+
+    portfolio_service.delete_item(user_id, second.id)
+
+    updated = await portfolio_service.get_portfolio_overview(user_id)
+    assert {item["id"] for item in updated["items"]} == {first.id}
+    assert updated["total_value"] == pytest.approx(10.0)
+

--- a/backend/tests/test_user_service_tokens_rotation.py
+++ b/backend/tests/test_user_service_tokens_rotation.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import sessionmaker
+
+from backend.core.security import create_refresh_token
+from backend.models import Base, RefreshToken, Session as SessionModel
+from backend.routers.auth import LogoutRequest, logout
+from backend.services import user_service as user_service_module
+from backend.services.user_service import InvalidTokenError, UserService, _utcnow
+
+
+@pytest.fixture()
+def session_factory():
+    engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+    Base.metadata.create_all(engine)
+    factory = sessionmaker(bind=engine, expire_on_commit=False, future=True)
+    try:
+        yield factory
+    finally:
+        Base.metadata.drop_all(engine)
+        engine.dispose()
+
+
+@pytest.fixture()
+def service(session_factory, monkeypatch: pytest.MonkeyPatch) -> UserService:
+    monkeypatch.setattr(user_service_module, "SessionLocal", session_factory)
+    return UserService(session_factory=session_factory, secret_key="secret", algorithm="HS256")
+
+
+def test_rotate_refresh_token_persists_new_entry(service: UserService, session_factory) -> None:
+    user = service.create_user("rotate-db@example.com", "secret")
+    original_refresh = create_refresh_token(sub=str(user.id), jti=str(uuid4()))
+    service.store_refresh_token(user.id, original_refresh)
+
+    rotated_user, new_refresh, refresh_expires = service.rotate_refresh_token(original_refresh)
+
+    assert rotated_user.id == user.id
+    assert new_refresh != original_refresh
+    assert refresh_expires.tzinfo is not None
+
+    with session_factory() as session:
+        rows = session.execute(
+            select(RefreshToken).where(RefreshToken.user_id == user.id)
+        ).scalars().all()
+        assert len(rows) == 1
+        assert rows[0].token == new_refresh
+
+
+def test_rotate_refresh_token_removes_expired_record(service: UserService, session_factory) -> None:
+    user = service.create_user("expired-rotation@example.com", "secret")
+    refresh_token = create_refresh_token(sub=str(user.id), jti=str(uuid4()))
+    stored = service.store_refresh_token(user.id, refresh_token)
+
+    with session_factory() as session:
+        db_token = session.get(RefreshToken, stored.id)
+        assert db_token is not None
+        db_token.expires_at = _utcnow() - timedelta(seconds=1)
+        session.commit()
+
+    with pytest.raises(HTTPException) as exc_info:
+        service.rotate_refresh_token(refresh_token)
+
+    assert exc_info.value.status_code == 401
+    assert exc_info.value.detail == "refresh_expired"
+
+    with session_factory() as session:
+        remaining = session.execute(
+            select(RefreshToken).where(RefreshToken.user_id == user.id)
+        ).scalars().all()
+        assert remaining == []
+
+
+def test_get_current_user_rejects_expired_session(
+    service: UserService, session_factory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    base_time = datetime.now(timezone.utc)
+    times = iter([base_time, base_time + timedelta(seconds=1)])
+
+    monkeypatch.setattr(
+        "backend.core.security._now",
+        lambda: next(times),
+    )
+    user = service.create_user("expired-session@example.com", "secret")
+    active_token, active_session = service.create_session(user.id)
+    expired_token, expired_session = service.create_session(user.id)
+
+    with session_factory() as session:
+        stored = session.get(SessionModel, expired_session.id)
+        assert stored is not None
+        stored.expires_at = _utcnow() - timedelta(minutes=1)
+        session.commit()
+
+    active_sessions = service.get_active_sessions(user.id)
+    assert {sess.id for sess in active_sessions} == {active_session.id}
+
+    with pytest.raises(InvalidTokenError):
+        service.get_current_user(expired_token)
+
+    current_user = service.get_current_user(active_token)
+    assert current_user.id == user.id
+
+
+def test_logout_revoke_all_clears_refresh_tokens(
+    service: UserService, session_factory
+) -> None:
+    user = service.create_user("logout-db@example.com", "secret")
+    first_token = create_refresh_token(sub=str(user.id), jti=str(uuid4()))
+    second_token = create_refresh_token(sub=str(user.id), jti=str(uuid4()))
+    service.store_refresh_token(user.id, first_token)
+    service.store_refresh_token(user.id, second_token)
+
+    with session_factory() as session:
+        request = LogoutRequest(refresh_token=first_token, revoke_all=True)
+        response = logout(request, db=session)
+        assert response == {"detail": "All sessions revoked"}
+
+        remaining = session.execute(
+            select(RefreshToken).where(RefreshToken.user_id == user.id)
+        ).scalars().all()
+        assert remaining == []
+


### PR DESCRIPTION
## Summary
- add rotation, session invalidation, and logout coverage tests for the user service
- add portfolio service tests covering empty responses, invalid inputs, and recalculation edge cases

## Testing
- pytest --cov=backend

------
https://chatgpt.com/codex/tasks/task_e_68dd110ae8f48321baa2c6062452ac97