### PR TITLE
Add comprehensive edge-case coverage across backend services

### DIFF
--- a/backend/tests/test_ai_service_prompt_edge_cases.py
+++ b/backend/tests/test_ai_service_prompt_edge_cases.py
@@ -1,0 +1,153 @@
+import asyncio
+from unittest.mock import AsyncMock
+from typing import Any, Dict
+
+import pytest
+
+from backend.services import ai_service as ai_service_module
+from backend.services.ai_service import AIService
+
+
+@pytest.fixture(autouse=True)
+def configure_ai_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(ai_service_module.Config, "HUGGINGFACE_API_KEY", "token", raising=False)
+    monkeypatch.setattr(ai_service_module.Config, "HUGGINGFACE_MODEL", "base/model", raising=False)
+    monkeypatch.setattr(
+        ai_service_module.Config,
+        "HUGGINGFACE_RISK_MODELS",
+        {"conservador": "hf/conservative", "agresivo": "hf/aggressive"},
+        raising=False,
+    )
+    monkeypatch.setattr(ai_service_module.Config, "HUGGINGFACE_API_URL", "https://example.com/models", raising=False)
+    monkeypatch.setattr(ai_service_module.Config, "OLLAMA_HOST", "http://localhost:11434", raising=False)
+    monkeypatch.setattr(ai_service_module.Config, "OLLAMA_MODEL", "ollama-test", raising=False)
+
+
+@pytest.fixture
+def service() -> AIService:
+    return AIService()
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+def test_build_prompt_rejects_empty_message(service: AIService) -> None:
+    with pytest.raises(ValueError):
+        service._build_prompt("", {})
+
+
+def test_build_prompt_accepts_large_messages(service: AIService) -> None:
+    long_message = "Analiza " + "BTC " * 1024
+
+    prompt = service._build_prompt(long_message, {})
+
+    assert "BTC" in prompt
+    assert len(prompt) > len(long_message)
+
+
+@pytest.mark.anyio
+async def test_process_message_empty_prompt_triggers_local_fallback(
+    service: AIService, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    async def mistral_failure(message: str, context: Dict[str, Any]) -> str:  # noqa: ARG001
+        raise RuntimeError("provider down")
+
+    async def huggingface_failure(self, message: str, context: Dict[str, Any]) -> str:  # noqa: ARG001
+        raise ValueError("json decode error")
+
+    async def ollama_failure(self, message: str, context: Dict[str, Any]) -> str:  # noqa: ARG001
+        raise asyncio.TimeoutError("ollama timeout")
+
+    monkeypatch.setattr(AIService, "process_with_mistral", mistral_failure)
+    monkeypatch.setattr(AIService, "_call_huggingface", huggingface_failure)
+    monkeypatch.setattr(AIService, "_call_ollama", ollama_failure)
+    monkeypatch.setattr(ai_service_module.asyncio, "sleep", AsyncMock(return_value=None))
+
+    result = await service.process_message("")
+
+    assert result.provider == "local"
+    assert "BullBearBroker" in result.text
+
+
+@pytest.mark.anyio
+async def test_call_huggingface_raises_for_unexpected_payload(monkeypatch: pytest.MonkeyPatch) -> None:
+    service = AIService()
+
+    class DummyResponse:
+        status = 200
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):  # noqa: D401
+            return False
+
+        async def json(self):  # noqa: D401
+            return "not-json"
+
+    class DummySession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):  # noqa: D401
+            return False
+
+        def post(self, *args, **kwargs):  # noqa: D401
+            return DummyResponse()
+
+    monkeypatch.setattr(ai_service_module.aiohttp, "ClientSession", lambda: DummySession())
+
+    with pytest.raises(ValueError):
+        await service._call_huggingface("mensaje", {"risk_profile": "agresivo"})
+
+
+@pytest.mark.anyio
+async def test_model_selection_uses_risk_profile_mapping(service: AIService) -> None:
+    class DummyResponse:
+        status = 200
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):  # noqa: D401
+            return False
+
+        async def json(self):  # noqa: D401
+            return [{"generated_text": "respuesta"}]
+
+    class DummySession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):  # noqa: D401
+            return False
+
+        def post(self, *args, **kwargs):  # noqa: D401
+            return DummyResponse()
+
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(ai_service_module.aiohttp, "ClientSession", lambda: DummySession())
+
+    payload = await service._call_huggingface("hola", {"risk_profile": "agresivo"})
+
+    assert payload == "respuesta"
+
+    monkeypatch.undo()
+
+
+@pytest.mark.anyio
+async def test_call_with_backoff_tracks_invalid_provider(service: AIService, monkeypatch: pytest.MonkeyPatch) -> None:
+    attempts: Dict[str, int] = {"invalid": 0}
+
+    async def failing_provider() -> str:
+        attempts["invalid"] += 1
+        raise ValueError("bad provider response")
+
+    monkeypatch.setattr(ai_service_module.asyncio, "sleep", AsyncMock(return_value=None))
+
+    with pytest.raises(ValueError):
+        await service._call_with_backoff([("invalid", failing_provider)])
+
+    assert attempts["invalid"] == 3

--- a/backend/tests/test_alert_service_delivery_edge_cases.py
+++ b/backend/tests/test_alert_service_delivery_edge_cases.py
@@ -1,0 +1,122 @@
+from datetime import datetime, timedelta
+from uuid import uuid4
+from unittest.mock import AsyncMock
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from backend.models import Alert, Base
+from importlib import import_module
+
+alert_service_module = import_module("backend.services.alert_service")
+from backend.services.alert_service import AlertService
+
+
+@pytest.fixture()
+def in_memory_factory():
+    engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+    Base.metadata.create_all(engine)
+    factory = sessionmaker(bind=engine, expire_on_commit=False, future=True)
+    try:
+        yield factory
+    finally:
+        Base.metadata.drop_all(engine)
+        engine.dispose()
+
+
+@pytest.fixture()
+def service(in_memory_factory) -> AlertService:
+    svc = AlertService(session_factory=in_memory_factory)
+    svc.register_websocket_manager(None)
+    return svc
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_send_external_alert_without_targets_raises(service: AlertService) -> None:
+    with pytest.raises(ValueError):
+        await service.send_external_alert(message="hola")
+
+
+@pytest.mark.anyio
+async def test_send_external_alert_reports_delivery_failure(service: AlertService, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        alert_service_module.Config,
+        "TELEGRAM_DEFAULT_CHAT_ID",
+        "12345",
+        raising=False,
+    )
+    monkeypatch.setattr(service, "_send_telegram_message", AsyncMock(side_effect=RuntimeError("telegram down")))
+
+    result = await service.send_external_alert(message="hola", telegram_chat_id="12345")
+
+    assert result["telegram"]["status"] == "error"
+    assert "telegram down" in result["telegram"]["error"]
+
+
+@pytest.mark.anyio
+async def test_notify_tolerates_websocket_and_telegram_failures(service: AlertService, monkeypatch: pytest.MonkeyPatch) -> None:
+    alert = Alert(
+        id=uuid4(),
+        user_id=uuid4(),
+        title="Breakout",
+        asset="BTCUSDT",
+        condition=">",
+        value=45000.0,
+        active=True,
+        created_at=datetime.utcnow(),
+        updated_at=datetime.utcnow(),
+    )
+
+    class BrokenManager:
+        async def broadcast(self, payload):  # noqa: ANN001
+            raise RuntimeError("websocket offline")
+
+    service.register_websocket_manager(BrokenManager())
+    monkeypatch.setattr(
+        alert_service_module.Config,
+        "TELEGRAM_DEFAULT_CHAT_ID",
+        "12345",
+        raising=False,
+    )
+    monkeypatch.setattr(service, "_send_telegram_message", AsyncMock(side_effect=RuntimeError("telegram offline")))
+
+    await service._notify(alert, price=45500.0)
+
+    service._send_telegram_message.assert_awaited()  # type: ignore[attr-defined]
+
+
+@pytest.mark.anyio
+async def test_evaluate_alerts_handles_reactivation_flow(service: AlertService, monkeypatch: pytest.MonkeyPatch) -> None:
+    alert = Alert(
+        id=uuid4(),
+        user_id=uuid4(),
+        title="Support",
+        asset="ETHUSDT",
+        condition=">",
+        value=1800.0,
+        active=False,
+        created_at=datetime.utcnow() - timedelta(days=1),
+        updated_at=datetime.utcnow() - timedelta(hours=2),
+    )
+
+    alerts = [alert]
+
+    monkeypatch.setattr(service, "_fetch_alerts", lambda: alerts)
+    price_resolver = AsyncMock(return_value=1900.0)
+    monkeypatch.setattr(service, "_resolve_price", price_resolver)
+    notifier = AsyncMock()
+    monkeypatch.setattr(service, "_notify", notifier)
+
+    await service.evaluate_alerts()
+    notifier.assert_not_awaited()
+
+    alert.active = True
+    await service.evaluate_alerts()
+
+    notifier.assert_awaited_once_with(alert, 1900.0)

--- a/backend/tests/test_indicators_nan_edge_cases.py
+++ b/backend/tests/test_indicators_nan_edge_cases.py
@@ -1,0 +1,62 @@
+import math
+from typing import List
+
+import numpy as np
+import pytest
+
+from backend.utils import indicators
+
+
+@pytest.mark.parametrize(
+    "values",
+    [
+        [math.nan, math.nan, math.nan],
+        [1.0, math.nan, 2.0, 3.0],
+    ],
+)
+def test_indicators_handle_nan_sequences(values: List[float]) -> None:
+    ema_value = indicators.ema(list(values), period=3)
+    rsi_value = indicators.rsi(list(values), period=3)
+
+    assert ema_value is None or math.isnan(ema_value) or math.isfinite(ema_value)
+    assert rsi_value is None or math.isnan(rsi_value) or math.isfinite(rsi_value)
+
+
+@pytest.mark.parametrize(
+    "highs,lows,closes",
+    [
+        ([-1.0, -0.5, -0.25, -0.125], [-2.0, -1.5, -1.0, -0.75], [-1.5, -1.0, -0.75, -0.5]),
+        ([10.0, 20.0, 30.0, -1e308], [9.0, 19.0, 29.0, -1e308], [9.5, 19.5, 29.5, -1e308]),
+    ],
+)
+def test_atr_controls_negative_and_extreme_values(highs, lows, closes) -> None:
+    result = indicators.average_true_range(highs, lows, closes, period=2)
+
+    assert result is None or math.isfinite(result) or math.isinf(result)
+
+
+@pytest.mark.parametrize(
+    "highs,lows,closes,volumes",
+    [
+        ([10.0, 10.2, 10.4, 10.6], [9.5, 9.7, 9.9, 10.1], [9.8, 10.0, 10.2, 10.4], [-10.0, -5.0, -1.0, -0.5]),
+        ([1e150, 1e151, 1e152], [1e140, 1e141, 1e142], [1e145, 1e146, 1e147], [1.0, 1.0, 1.0]),
+    ],
+)
+def test_vwap_handles_negative_and_large_inputs(highs, lows, closes, volumes) -> None:
+    result = indicators.volume_weighted_average_price(highs, lows, closes, volumes)
+
+    assert result is None or math.isfinite(result) or math.isnan(result)
+
+
+def test_indicators_support_long_sequences_without_overflow() -> None:
+    length = 5000
+    values = np.linspace(1.0, 100.0, num=length).tolist()
+    volumes = np.linspace(1.0, 5.0, num=length).tolist()
+
+    ema_value = indicators.ema(values, period=50)
+    rsi_value = indicators.rsi(values, period=14)
+    atr_value = indicators.average_true_range(values, values, values, period=14)
+    vwap_value = indicators.volume_weighted_average_price(values, values, values, volumes)
+
+    for candidate in (ema_value, rsi_value, atr_value, vwap_value):
+        assert candidate is None or math.isfinite(candidate) or math.isnan(candidate)

--- a/backend/tests/test_market_services_fallback_edge_cases.py
+++ b/backend/tests/test_market_services_fallback_edge_cases.py
@@ -1,0 +1,120 @@
+from typing import Any, Dict, Optional
+from unittest.mock import AsyncMock
+
+import pytest
+
+from backend.services.crypto_service import CryptoService
+from backend.services.forex_service import ForexService
+from backend.services.stock_service import StockService
+from backend.utils.config import Config
+
+
+@pytest.fixture(autouse=True)
+def restore_config() -> None:
+    original_td = Config.TWELVEDATA_API_KEY
+    original_alpha = Config.ALPHA_VANTAGE_API_KEY
+    original_cmc = getattr(Config, "COINMARKETCAP_API_KEY", None)
+    try:
+        yield
+    finally:
+        Config.TWELVEDATA_API_KEY = original_td
+        Config.ALPHA_VANTAGE_API_KEY = original_alpha
+        if hasattr(Config, "COINMARKETCAP_API_KEY"):
+            Config.COINMARKETCAP_API_KEY = original_cmc
+
+
+class DummyCache:
+    def __init__(self) -> None:
+        self.values: Dict[str, Any] = {}
+
+    async def get(self, key: str) -> Optional[Any]:
+        return self.values.get(key)
+
+    async def set(self, key: str, value: Any, ttl: Optional[int] = None) -> None:  # noqa: ARG002
+        self.values[key] = value
+
+
+@pytest.mark.asyncio
+async def test_crypto_service_falls_back_when_primary_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    cache = DummyCache()
+    service = CryptoService(cache_client=cache)
+
+    call_order: list[str] = []
+
+    async def fake_call(provider, symbol, name):  # noqa: ANN001
+        call_order.append(name)
+        if name == "CoinGecko":
+            return None
+        if name == "Binance":
+            return 42.0
+        return None
+
+    monkeypatch.setattr(service, "_call_with_retries", fake_call)
+
+    price = await service.get_price("BTCUSDT")
+
+    assert price == 42.0
+    assert call_order[:2] == ["CoinGecko", "Binance"]
+
+    # Cached value avoids re-fetching
+    second = await service.get_price("BTCUSDT")
+    assert second == 42.0
+    assert call_order == ["CoinGecko", "Binance"]
+
+
+@pytest.mark.asyncio
+async def test_forex_service_skips_providers_without_keys(monkeypatch: pytest.MonkeyPatch) -> None:
+    Config.TWELVEDATA_API_KEY = None
+    Config.ALPHA_VANTAGE_API_KEY = None
+
+    service = ForexService(cache_client=DummyCache(), session_factory=lambda timeout=None: AsyncMock())
+
+    class DummySession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):  # noqa: D401
+            return False
+
+    def fake_session_factory(timeout=None):  # noqa: ANN001
+        return DummySession()
+
+    service._session_factory = fake_session_factory
+
+    async def fake_call(handler, session, symbol, source_name):  # noqa: ANN001
+        if source_name == "Yahoo Finance":
+            return {"price": 1.2, "change": 0.01}
+        return None
+
+    monkeypatch.setattr(service, "_call_with_retries", fake_call)
+
+    result = await service.get_quote("EURUSD")
+
+    assert result == {
+        "symbol": "EUR/USD",
+        "price": 1.2,
+        "change": 0.01,
+        "source": "Yahoo Finance",
+        "sources": ["Yahoo Finance"],
+    }
+
+
+@pytest.mark.asyncio
+async def test_stock_service_handles_corrupt_provider_payload(monkeypatch: pytest.MonkeyPatch) -> None:
+    Config.TWELVEDATA_API_KEY = ""
+    Config.ALPHA_VANTAGE_API_KEY = ""
+
+    cache = DummyCache()
+    service = StockService(cache_client=cache, session_factory=lambda timeout=None: AsyncMock())
+
+    async def fake_call(handler, session, symbol, source_name):  # noqa: ANN001
+        if source_name == "Yahoo Finance":
+            return {"price": 120.0, "change": 1.5}
+        return {"price": "nan"}
+
+    monkeypatch.setattr(service, "_call_with_retries", fake_call)
+
+    result = await service.get_price("AAPL")
+
+    assert result == {"price": 120.0, "change": 1.5, "source": "Yahoo Finance"}
+    assert cache.values["AAPL"] == {"price": 120.0, "change": 1.5, "source": "Yahoo Finance"}

--- a/backend/tests/test_timeseries_service_resilience_extended.py
+++ b/backend/tests/test_timeseries_service_resilience_extended.py
@@ -1,0 +1,63 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from backend.services.timeseries_service import resample_series
+
+
+def test_resample_series_returns_empty_for_empty_input() -> None:
+    assert resample_series([], "1h") == []
+
+
+def test_resample_series_rejects_invalid_interval() -> None:
+    with pytest.raises(ValueError):
+        resample_series([{ "timestamp": datetime.now(timezone.utc), "close": 1.0 }], "15m")
+
+
+def test_resample_series_collapses_duplicate_buckets() -> None:
+    base = datetime(2024, 1, 1, 12, 15, tzinfo=timezone.utc)
+    series = [
+        {"timestamp": base.isoformat(), "close": 10.0, "volume": 1.0},
+        {"timestamp": (base + timedelta(minutes=10)).isoformat(), "close": 11.0, "volume": 2.0},
+        {"timestamp": (base + timedelta(minutes=20)).isoformat(), "close": 12.0, "volume": 3.0},
+    ]
+
+    aggregated = resample_series(series, "1h")
+
+    assert len(aggregated) == 1
+    bucket = aggregated[0]
+    assert bucket["open"] == 10.0
+    assert bucket["close"] == 12.0
+    assert bucket["high"] == 12.0
+    assert bucket["low"] == 10.0
+    assert bucket["volume"] == pytest.approx(6.0)
+
+
+def test_resample_series_with_irregular_points() -> None:
+    base = datetime(2024, 1, 1, 0, 0, tzinfo=timezone.utc)
+    series = [
+        (base + timedelta(minutes=5), 100.0, 1.0),
+        (base + timedelta(hours=1, minutes=30), 110.0, 2.0),
+        (base + timedelta(hours=1, minutes=45), 108.0, 0.5),
+        (base + timedelta(hours=2, minutes=5), 112.0, None),
+    ]
+
+    aggregated = resample_series(series, "1h")
+
+    assert len(aggregated) == 3
+    assert aggregated[1]["high"] == 110.0
+    assert aggregated[1]["low"] == 108.0
+
+
+@pytest.mark.timeout(2)
+def test_resample_series_handles_large_dataset_performance() -> None:
+    base = datetime(2024, 1, 1, 0, 0, tzinfo=timezone.utc)
+    series = []
+    for index in range(20_000):
+        timestamp = base + timedelta(minutes=index)
+        series.append({"timestamp": timestamp.isoformat(), "close": float(index % 500), "volume": 1.0})
+
+    buckets = resample_series(series, "1h")
+
+    assert len(buckets) == pytest.approx(len(series) / 60, rel=0.1)
+    assert buckets[0]["open"] == series[0]["close"]

--- a/backend/tests/test_user_service_sessions_edge_cases.py
+++ b/backend/tests/test_user_service_sessions_edge_cases.py
@@ -1,0 +1,81 @@
+import time
+from datetime import datetime, timedelta, timezone
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from backend.core.security import create_refresh_token
+from backend.models import Base, RefreshToken, Session
+from backend.services import user_service as user_service_module
+from backend.services.user_service import InvalidTokenError, UserService
+
+
+@pytest.fixture()
+def session_factory():
+    engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+    Base.metadata.create_all(engine)
+    factory = sessionmaker(bind=engine, expire_on_commit=False, future=True)
+    try:
+        yield factory
+    finally:
+        Base.metadata.drop_all(engine)
+        engine.dispose()
+
+
+@pytest.fixture()
+def service(session_factory, monkeypatch: pytest.MonkeyPatch) -> UserService:
+    monkeypatch.setattr(user_service_module, "SessionLocal", session_factory)
+    return UserService(session_factory=session_factory, secret_key="secret", algorithm="HS256")
+
+
+def test_get_current_user_rejects_expired_session(service: UserService, session_factory) -> None:
+    user = service.create_user("expired@example.com", "secret")
+    token, session_record = service.create_session(user.id, expires_in=timedelta(minutes=5))
+
+    with session_factory() as session:
+        stored = session.get(Session, session_record.id)
+        assert stored is not None
+        stored.expires_at = datetime.utcnow() - timedelta(minutes=1)
+        session.commit()
+
+    with pytest.raises(InvalidTokenError):
+        service.get_current_user(token)
+
+
+def test_rotate_refresh_token_replaces_database_record(service: UserService, session_factory) -> None:
+    user = service.create_user("rotate2@example.com", "secret")
+    token = create_refresh_token(sub=str(user.id))
+    stored = service.store_refresh_token(user.id, token)
+
+    with session_factory() as session:
+        db_token = session.get(RefreshToken, stored.id)
+        assert db_token is not None
+
+    time.sleep(1)
+
+    new_user, new_token, expires_at = service.rotate_refresh_token(token)
+
+    assert new_user.id == user.id
+    assert new_token != token
+    assert expires_at.tzinfo == timezone.utc
+
+    with session_factory() as session:
+        tokens = session.query(RefreshToken).filter(RefreshToken.user_id == user.id).all()
+        assert len(tokens) == 1
+        assert tokens[0].token == new_token
+
+
+def test_revoke_all_refresh_tokens_removes_in_memory_records(service: UserService) -> None:
+    user = service.create_user("revoke@example.com", "secret")
+    token1, _ = service.create_refresh_token(user.id)
+    token2, _ = service.create_refresh_token(user.id)
+
+    assert token1 in service._in_memory_refresh_tokens
+    assert token2 in service._in_memory_refresh_tokens
+
+    service.revoke_all_refresh_tokens(user.id)
+
+    assert token1 not in service._in_memory_refresh_tokens
+    assert token2 not in service._in_memory_refresh_tokens


### PR DESCRIPTION
## Summary
- add indicator stress tests covering NaN inputs, extreme ranges, and long sequences
- exercise AI, alert, market data, and timeseries services against failure modes and fallback cascades
- validate user session and refresh-token edge cases with in-memory and database-backed flows

## Testing
- `pytest backend/tests/test_indicators_nan_edge_cases.py backend/tests/test_ai_service_prompt_edge_cases.py backend/tests/test_alert_service_delivery_edge_cases.py backend/tests/test_timeseries_service_resilience_extended.py backend/tests/test_market_services_fallback_edge_cases.py backend/tests/test_user_service_sessions_edge_cases.py`


------
https://chatgpt.com/codex/tasks/task_e_68dd1c2681d88321bcaf18a3765ce0bd