### PR TITLE
Add resilience tests across backend services

### DIFF
--- a/backend/tests/test_ai_service_resilience.py
+++ b/backend/tests/test_ai_service_resilience.py
@@ -1,0 +1,125 @@
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from backend.services import ai_service as ai_service_module
+from backend.services.ai_service import AIService
+
+
+@pytest.fixture
+def anyio_backend() -> str:  # pragma: no cover - required by anyio plugin
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+def configure_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(ai_service_module.Config, "HUGGINGFACE_API_KEY", "token", raising=False)
+    monkeypatch.setattr(ai_service_module.Config, "HUGGINGFACE_MODEL", "test/model", raising=False)
+    monkeypatch.setattr(ai_service_module.Config, "HUGGINGFACE_API_URL", "https://example.com", raising=False)
+    monkeypatch.setattr(ai_service_module.Config, "OLLAMA_HOST", "http://ollama", raising=False)
+    monkeypatch.setattr(ai_service_module.Config, "OLLAMA_MODEL", "mock", raising=False)
+
+
+@pytest.mark.parametrize("message", ["", None])
+def test_build_prompt_rejects_empty_input(message):
+    service = AIService()
+    with pytest.raises(ValueError):
+        service._build_prompt(message, {})  # type: ignore[arg-type]
+
+
+@pytest.mark.anyio
+async def test_timeout_on_primary_provider_falls_back_to_huggingface(monkeypatch: pytest.MonkeyPatch) -> None:
+    service = AIService()
+
+    sleep_mock = AsyncMock()
+    monkeypatch.setattr(ai_service_module.asyncio, "sleep", sleep_mock)
+
+    mistral = AsyncMock(side_effect=asyncio.TimeoutError("timeout"))
+    huggingface = AsyncMock(return_value="respuesta huggingface")
+    ollama = AsyncMock(return_value="respuesta ollama")
+
+    monkeypatch.setattr(AIService, "get_market_context", AsyncMock(return_value={}))
+    monkeypatch.setattr(AIService, "_collect_indicator_snapshots", AsyncMock(return_value={}))
+    monkeypatch.setattr(AIService, "_collect_news_highlights", AsyncMock(return_value=[]))
+    monkeypatch.setattr(AIService, "_collect_alert_suggestions", AsyncMock(return_value=[]))
+    monkeypatch.setattr(AIService, "_collect_forex_quotes", AsyncMock(return_value=[]))
+
+    monkeypatch.setattr(AIService, "process_with_mistral", mistral)
+    monkeypatch.setattr(AIService, "_call_huggingface", huggingface)
+    monkeypatch.setattr(AIService, "_call_ollama", ollama)
+
+    result = await service.process_message("Precio BTC por favor")
+
+    assert result.provider == "huggingface"
+    assert "huggingface" in result.text
+    assert mistral.await_count == 3  # tres reintentos antes del fallback
+    assert huggingface.await_count == 1
+    ollama.assert_not_awaited()
+    assert sleep_mock.await_count == 2
+
+
+@pytest.mark.anyio
+async def test_corrupted_responses_trigger_local_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    service = AIService()
+
+    monkeypatch.setattr(ai_service_module.Config, "HUGGINGFACE_API_KEY", "", raising=False)
+
+    sleep_mock = AsyncMock()
+    monkeypatch.setattr(ai_service_module.asyncio, "sleep", sleep_mock)
+
+    mistral = AsyncMock(return_value="   ")
+    ollama = AsyncMock(return_value="")
+    local_fallback = AsyncMock(return_value="respuesta local")
+
+    monkeypatch.setattr(AIService, "get_market_context", AsyncMock(return_value={}))
+    monkeypatch.setattr(AIService, "_collect_indicator_snapshots", AsyncMock(return_value={}))
+    monkeypatch.setattr(AIService, "_collect_news_highlights", AsyncMock(return_value=[]))
+    monkeypatch.setattr(AIService, "_collect_alert_suggestions", AsyncMock(return_value=[]))
+    monkeypatch.setattr(AIService, "_collect_forex_quotes", AsyncMock(return_value=[]))
+
+    monkeypatch.setattr(AIService, "process_with_mistral", mistral)
+    monkeypatch.setattr(AIService, "_call_ollama", ollama)
+    monkeypatch.setattr(AIService, "generate_response", local_fallback)
+
+    result = await service.process_message("Dame contexto del mercado")
+
+    assert result.provider == "local"
+    assert result.text == "respuesta local"
+    assert mistral.await_count == 3
+    assert ollama.await_count == 3
+    assert sleep_mock.await_count == 4
+    local_fallback.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_long_prompt_triggers_cascade_to_ollama(monkeypatch: pytest.MonkeyPatch) -> None:
+    service = AIService()
+
+    sleep_mock = AsyncMock()
+    monkeypatch.setattr(ai_service_module.asyncio, "sleep", sleep_mock)
+
+    long_message = "BTC " * 5000
+
+    mistral = AsyncMock(side_effect=ValueError("prompt demasiado largo"))
+    huggingface = AsyncMock(side_effect=ValueError("json inválido"))
+    ollama = AsyncMock(return_value="respuesta ollama definitiva")
+
+    monkeypatch.setattr(AIService, "get_market_context", AsyncMock(return_value={}))
+    monkeypatch.setattr(AIService, "_collect_indicator_snapshots", AsyncMock(return_value={}))
+    monkeypatch.setattr(AIService, "_collect_news_highlights", AsyncMock(return_value=[]))
+    monkeypatch.setattr(AIService, "_collect_alert_suggestions", AsyncMock(return_value=[]))
+    monkeypatch.setattr(AIService, "_collect_forex_quotes", AsyncMock(return_value=[]))
+
+    monkeypatch.setattr(AIService, "process_with_mistral", mistral)
+    monkeypatch.setattr(AIService, "_call_huggingface", huggingface)
+    monkeypatch.setattr(AIService, "_call_ollama", ollama)
+
+    result = await service.process_message(long_message)
+
+    assert result.provider == "ollama"
+    assert result.text.endswith("respuesta ollama definitiva")
+    assert mistral.await_count == 3
+    assert huggingface.await_count == 3
+    ollama.assert_awaited_once()
+    assert sleep_mock.await_count == 4

--- a/backend/tests/test_alert_service_resilience.py
+++ b/backend/tests/test_alert_service_resilience.py
@@ -1,0 +1,134 @@
+from datetime import datetime, timedelta
+from types import SimpleNamespace
+from uuid import uuid4
+from unittest.mock import AsyncMock
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from backend.models import Base
+from backend.models.alert import Alert
+import backend.services.alert_service as alert_module
+from backend.services.alert_service import AlertService
+
+
+@pytest.fixture()
+def anyio_backend() -> str:  # pragma: no cover
+    return "asyncio"
+
+
+@pytest.fixture()
+def session_factory():
+    engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+    Base.metadata.create_all(engine)
+    factory = sessionmaker(bind=engine, expire_on_commit=False, future=True)
+    try:
+        yield factory
+    finally:
+        Base.metadata.drop_all(engine)
+        engine.dispose()
+
+
+@pytest.fixture()
+def alert_service(session_factory) -> AlertService:
+    service = AlertService(session_factory=session_factory)
+    service._telegram_token = None
+    service._discord_token = None
+    return service
+
+
+@pytest.mark.anyio
+async def test_suggest_alert_condition_requires_symbol(alert_service: AlertService) -> None:
+    with pytest.raises(ValueError):
+        await alert_service.suggest_alert_condition("   ")
+
+
+def test_validate_condition_expression_detects_corruption(alert_service: AlertService) -> None:
+    with pytest.raises(ValueError):
+        alert_service.validate_condition_expression("RSI(14) > & MACD()")
+
+
+@pytest.mark.anyio
+async def test_evaluate_alerts_respects_repeated_toggle(alert_service: AlertService, monkeypatch: pytest.MonkeyPatch) -> None:
+    alert = SimpleNamespace(
+        asset="ETHUSDT",
+        value=1800.0,
+        condition=">",
+        active=True,
+    )
+
+    monkeypatch.setattr(alert_service, "_fetch_alerts", lambda: [alert])
+    price_provider = AsyncMock(return_value=1900.0)
+    notifier = AsyncMock()
+
+    monkeypatch.setattr(alert_service, "_resolve_price", price_provider)
+    monkeypatch.setattr(alert_service, "_notify", notifier)
+
+    await alert_service.evaluate_alerts()
+    notifier.assert_awaited_once()
+
+    alert.active = False
+    await alert_service.evaluate_alerts()
+    assert notifier.await_count == 1
+
+    alert.active = True
+    await alert_service.evaluate_alerts()
+    assert notifier.await_count == 2
+
+
+@pytest.mark.anyio
+async def test_evaluate_alerts_ignores_expired_entries(alert_service: AlertService, monkeypatch: pytest.MonkeyPatch) -> None:
+    class ExpiringAlert(SimpleNamespace):
+        @property
+        def active(self) -> bool:  # pragma: no cover - trivial property
+            return self.expires_at > datetime.utcnow()
+
+    expired = ExpiringAlert(
+        asset="BTCUSDT",
+        value=30000.0,
+        condition=">",
+        expires_at=datetime.utcnow() - timedelta(minutes=1),
+    )
+
+    monkeypatch.setattr(alert_service, "_fetch_alerts", lambda: [expired])
+    price_provider = AsyncMock()
+    notifier = AsyncMock()
+
+    monkeypatch.setattr(alert_service, "_resolve_price", price_provider)
+    monkeypatch.setattr(alert_service, "_notify", notifier)
+
+    await alert_service.evaluate_alerts()
+
+    price_provider.assert_not_awaited()
+    notifier.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_notify_tolerates_external_failures(alert_service: AlertService, monkeypatch: pytest.MonkeyPatch) -> None:
+    alert = Alert(
+        user_id=uuid4(),
+        title="Breakout",
+        asset="AAPL",
+        condition=">",
+        value=150.0,
+        active=True,
+    )
+
+    class BrokenManager:
+        async def broadcast(self, payload):  # noqa: ANN001
+            raise RuntimeError("ws down")
+
+    alert_service.register_websocket_manager(BrokenManager())
+
+    alert_service._telegram_token = "token"
+    monkeypatch.setattr(alert_module, "Config", SimpleNamespace(TELEGRAM_DEFAULT_CHAT_ID="123"), raising=False)
+    monkeypatch.setattr(alert_service, "_telegram_bot", None, raising=False)
+
+    async def failing_send(chat_id: str, message: str) -> None:  # noqa: ANN001
+        raise RuntimeError("telegram failure")
+
+    monkeypatch.setattr(alert_service, "_send_telegram_message", failing_send)
+
+    # No exception should escape even if both channels fail
+    await alert_service._notify(alert, price=151.5)

--- a/backend/tests/test_cache_resilience.py
+++ b/backend/tests/test_cache_resilience.py
@@ -1,0 +1,52 @@
+from types import SimpleNamespace
+
+import pytest
+
+from backend.utils import cache as cache_module
+from backend.utils.cache import CacheClient
+
+
+@pytest.fixture(autouse=True)
+def disable_redis(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(cache_module.Config, "REDIS_URL", None, raising=False)
+
+
+@pytest.fixture()
+def anyio_backend() -> str:  # pragma: no cover
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_missing_key_returns_none() -> None:
+    client = CacheClient("resilience")
+    assert await client.get("absent") is None
+
+
+@pytest.mark.anyio
+async def test_custom_ttl_expires(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = CacheClient("ttl", ttl=100)
+    current = {"value": 10.0}
+
+    monkeypatch.setattr(cache_module.time, "monotonic", lambda: current["value"])
+
+    await client.set("key", "value", ttl=5)
+    assert await client.get("key") == "value"
+
+    current["value"] += 6
+    assert await client.get("key") is None
+
+
+@pytest.mark.anyio
+async def test_delete_removes_active_key() -> None:
+    client = CacheClient("delete")
+    await client.set("key", "value")
+    await client.delete("key")
+    assert await client.get("key") is None
+
+
+@pytest.mark.anyio
+async def test_set_accepts_unexpected_types() -> None:
+    client = CacheClient("types")
+    payload = SimpleNamespace(symbol="AAPL", price=180.5)
+    await client.set("snapshot", payload)
+    assert await client.get("snapshot") == payload

--- a/backend/tests/test_crypto_service_resilience.py
+++ b/backend/tests/test_crypto_service_resilience.py
@@ -1,0 +1,98 @@
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from backend.services.crypto_service import CryptoService
+from backend.utils import cache as cache_module
+
+
+class InMemoryCache:
+    def __init__(self) -> None:
+        self.data = {}
+
+    async def get(self, key):  # noqa: D401 - simple proxy
+        return self.data.get(key)
+
+    async def set(self, key, value, ttl=None):  # noqa: D401 - simple proxy
+        self.data[key] = value
+
+
+@pytest.fixture(autouse=True)
+def disable_redis(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(cache_module.Config, "REDIS_URL", None, raising=False)
+
+
+@pytest.fixture()
+def anyio_backend() -> str:  # pragma: no cover
+    return "asyncio"
+
+
+@pytest.fixture()
+def service(monkeypatch: pytest.MonkeyPatch) -> CryptoService:
+    monkeypatch.setattr(CryptoService, "RETRY_ATTEMPTS", 2, raising=False)
+    monkeypatch.setattr(CryptoService, "RETRY_BACKOFF", 0.01, raising=False)
+    monkeypatch.setattr(asyncio, "sleep", AsyncMock())
+    return CryptoService(cache_client=InMemoryCache())
+
+
+@pytest.mark.anyio
+async def test_binance_empty_payload_falls_back_to_coinmarketcap(service: CryptoService, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(service, "coingecko", AsyncMock(return_value=None))
+    monkeypatch.setattr(service, "binance", AsyncMock(return_value=None))
+    monkeypatch.setattr(service, "coinmarketcap", AsyncMock(return_value=32100.5))
+    monkeypatch.setattr(service, "twelvedata", AsyncMock(return_value=None))
+    monkeypatch.setattr(service, "alpha_vantage", AsyncMock(return_value=None))
+
+    price = await service.get_price("BTCUSDT")
+    assert price == 32100.5
+
+
+@pytest.mark.anyio
+async def test_incomplete_payload_returns_none(service: CryptoService, monkeypatch: pytest.MonkeyPatch) -> None:
+    async def broken_coinmarketcap(symbol: str):  # noqa: ANN001 - helper
+        raise KeyError("price missing")
+
+    monkeypatch.setattr(service, "coingecko", AsyncMock(return_value=None))
+    monkeypatch.setattr(service, "binance", AsyncMock(return_value=None))
+    monkeypatch.setattr(service, "coinmarketcap", AsyncMock(side_effect=broken_coinmarketcap))
+    monkeypatch.setattr(service, "twelvedata", AsyncMock(return_value=None))
+    monkeypatch.setattr(service, "alpha_vantage", AsyncMock(return_value=None))
+
+    assert await service.get_price("ETHUSDT") is None
+
+
+@pytest.mark.anyio
+async def test_cache_hit_skips_provider_calls(service: CryptoService, monkeypatch: pytest.MonkeyPatch) -> None:
+    cache = InMemoryCache()
+    await cache.set("BTC", 20000.0)
+    service.cache = cache
+
+    provider = AsyncMock(return_value=123.0)
+    monkeypatch.setattr(service, "coingecko", provider)
+
+    result = await service.get_price("BTC")
+    assert result == 20000.0
+    provider.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_timeout_triggers_fallback_chain(service: CryptoService, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(asyncio, "sleep", AsyncMock())
+
+    coingecko = AsyncMock(side_effect=asyncio.TimeoutError())
+    binance = AsyncMock(side_effect=ValueError("down"))
+    coinmarketcap = AsyncMock(return_value=None)
+    twelvedata = AsyncMock(return_value=15.0)
+
+    monkeypatch.setattr(service, "coingecko", coingecko)
+    monkeypatch.setattr(service, "binance", binance)
+    monkeypatch.setattr(service, "coinmarketcap", coinmarketcap)
+    monkeypatch.setattr(service, "twelvedata", twelvedata)
+    monkeypatch.setattr(service, "alpha_vantage", AsyncMock(return_value=None))
+
+    price = await service.get_price("ADAUSDT")
+    assert price == 15.0
+    assert coingecko.await_count == 2
+    assert binance.await_count == 2
+    assert twelvedata.await_count == 1

--- a/backend/tests/test_forex_service_resilience.py
+++ b/backend/tests/test_forex_service_resilience.py
@@ -1,0 +1,96 @@
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from backend.services.forex_service import ForexService
+from backend.utils import cache as cache_module
+
+
+class InMemoryCache:
+    def __init__(self) -> None:
+        self.data = {}
+
+    async def get(self, key):  # noqa: D401 - simple proxy
+        return self.data.get(key)
+
+    async def set(self, key, value, ttl=None):  # noqa: D401 - simple proxy
+        self.data[key] = value
+
+
+@pytest.fixture(autouse=True)
+def disable_redis(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(cache_module.Config, "REDIS_URL", None, raising=False)
+
+
+@pytest.fixture()
+def anyio_backend() -> str:  # pragma: no cover
+    return "asyncio"
+
+
+@pytest.fixture()
+def service(monkeypatch: pytest.MonkeyPatch) -> ForexService:
+    monkeypatch.setattr(ForexService, "RETRY_ATTEMPTS", 2, raising=False)
+    monkeypatch.setattr(ForexService, "RETRY_BACKOFF", 0.01, raising=False)
+    monkeypatch.setattr(asyncio, "sleep", AsyncMock())
+    return ForexService(cache_client=InMemoryCache())
+
+
+@pytest.mark.anyio
+async def test_twelvedata_failure_falls_back_to_yahoo(service: ForexService, monkeypatch: pytest.MonkeyPatch) -> None:
+    twelvedata = AsyncMock(side_effect=ValueError("down"))
+    alphav = AsyncMock(side_effect=KeyError("price"))
+    yahoo = AsyncMock(return_value={"price": 1.1234, "change": -0.001})
+
+    monkeypatch.setattr(service, "_fetch_twelvedata", twelvedata)
+    monkeypatch.setattr(service, "_fetch_alpha_vantage", alphav)
+    monkeypatch.setattr(service, "_fetch_yahoo_finance", yahoo)
+    monkeypatch.setattr(service, "apis", [
+        {"name": "Twelve Data", "callable": service._fetch_twelvedata, "requires_key": True, "api_key": "key"},
+        {"name": "Alpha Vantage", "callable": service._fetch_alpha_vantage, "requires_key": True, "api_key": "key"},
+        {"name": "Yahoo Finance", "callable": service._fetch_yahoo_finance, "requires_key": False, "api_key": None},
+    ])
+
+    quote = await service.get_quote("EURUSD")
+    assert quote == {
+        "symbol": "EUR/USD",
+        "price": 1.1234,
+        "change": -0.001,
+        "source": "Yahoo Finance",
+        "sources": ["Twelve Data", "Alpha Vantage", "Yahoo Finance"],
+    }
+
+
+@pytest.mark.anyio
+async def test_corrupt_payload_returns_none(service: ForexService, monkeypatch: pytest.MonkeyPatch) -> None:
+    failing = AsyncMock(side_effect=TypeError("invalid"))
+    monkeypatch.setattr(service, "_fetch_twelvedata", failing)
+    monkeypatch.setattr(service, "_fetch_alpha_vantage", failing)
+    monkeypatch.setattr(service, "_fetch_yahoo_finance", failing)
+    monkeypatch.setattr(service, "apis", [
+        {"name": "Twelve Data", "callable": service._fetch_twelvedata, "requires_key": True, "api_key": "key"},
+        {"name": "Alpha Vantage", "callable": service._fetch_alpha_vantage, "requires_key": True, "api_key": "key"},
+        {"name": "Yahoo Finance", "callable": service._fetch_yahoo_finance, "requires_key": False, "api_key": None},
+    ])
+
+    assert await service.get_quote("GBPUSD") is None
+
+
+@pytest.mark.anyio
+async def test_all_providers_fail_returns_none(service: ForexService, monkeypatch: pytest.MonkeyPatch) -> None:
+    failing = AsyncMock(side_effect=ValueError("error"))
+    monkeypatch.setattr(service, "_fetch_twelvedata", failing)
+    monkeypatch.setattr(service, "_fetch_alpha_vantage", failing)
+    monkeypatch.setattr(service, "_fetch_yahoo_finance", failing)
+    monkeypatch.setattr(service, "apis", [
+        {"name": "Twelve Data", "callable": service._fetch_twelvedata, "requires_key": True, "api_key": "key"},
+        {"name": "Alpha Vantage", "callable": service._fetch_alpha_vantage, "requires_key": True, "api_key": "key"},
+        {"name": "Yahoo Finance", "callable": service._fetch_yahoo_finance, "requires_key": False, "api_key": None},
+    ])
+
+    assert await service.get_quote("USDJPY") is None
+
+
+def test_invalid_symbol_raises_value_error(service: ForexService) -> None:
+    with pytest.raises(ValueError):
+        service._split_symbol("BAD")

--- a/backend/tests/test_indicators_resilience.py
+++ b/backend/tests/test_indicators_resilience.py
@@ -1,0 +1,87 @@
+import math
+from typing import List
+
+import pytest
+
+from backend.utils import indicators
+
+
+@pytest.mark.parametrize(
+    "values, period, expected",
+    [
+        ([], 5, None),
+        ([1.0], 3, None),
+        ([1.0, 2.0], 5, None),
+    ],
+)
+def test_ema_handles_insufficient_data(values: List[float], period: int, expected):
+    assert indicators.ema(values, period) is expected
+
+
+def test_macd_requires_enough_samples():
+    assert indicators.macd([1.0] * 10) is None
+
+
+def test_rsi_handles_small_series_and_constant_data():
+    assert indicators.rsi([1.0] * 15, period=20) is None
+    assert indicators.rsi([10.0] * 20, period=14) == 100.0
+
+
+def test_bollinger_with_zero_mean_returns_none_bandwidth():
+    data = [0.0] * 20
+    bands = indicators.bollinger(data)
+    assert bands is not None
+    assert bands["bandwidth"] is None
+
+
+def test_indicators_tolerate_extreme_values_without_crashing():
+    series = [float("nan"), float("inf"), float("-inf")] + [float(i) for i in range(-5, 25)]
+
+    result = indicators.ema(series, period=3)
+    assert result is None or math.isnan(result)
+
+    atr = indicators.average_true_range(series, series, series, period=3)
+    assert atr is None or isinstance(atr, float)
+
+    finite_tail = [v for v in series if math.isfinite(v)][-20:]
+    boll = indicators.bollinger(finite_tail)
+    assert boll is not None
+    assert set(boll.keys()) == {"middle", "upper", "lower", "bandwidth"}
+
+
+def test_macd_long_series_runs_quickly():
+    values = [float(i % 20) for i in range(5000)]
+    result = indicators.macd(values)
+    assert result is not None
+    assert set(result.keys()) == {"macd", "signal", "hist"}
+
+
+def test_stochastic_rsi_and_ichimoku_return_expected_types():
+    closes = [float(i) for i in range(200)]
+    stochastic = indicators.stochastic_rsi(closes, period=14, smooth_k=3, smooth_d=3)
+    assert stochastic is not None
+    assert set(stochastic.keys()) == {"%K", "%D"}
+
+    highs = [p + 2.0 for p in closes]
+    lows = [p - 2.0 for p in closes]
+    ichimoku = indicators.ichimoku_cloud(highs, lows, closes)
+    assert ichimoku is not None
+    assert set(ichimoku.keys()) == {
+        "tenkan_sen",
+        "kijun_sen",
+        "senkou_span_a",
+        "senkou_span_b",
+        "chikou_span",
+    }
+
+
+def test_volume_weighted_average_price_requires_nonzero_volume():
+    result = indicators.volume_weighted_average_price([1.0], [1.0], [1.0], [0.0])
+    assert result is None
+
+
+def test_average_true_range_with_insufficient_data_returns_none():
+    highs = [1.0, 2.0]
+    lows = [0.5, 1.5]
+    closes = [0.8, 1.8]
+    assert indicators.average_true_range(highs, lows, closes, period=5) is None

--- a/backend/tests/test_mistral_service_resilience.py
+++ b/backend/tests/test_mistral_service_resilience.py
@@ -1,0 +1,84 @@
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+import backend.services.mistral_service as mistral_module
+from backend.services.mistral_service import MistralAPIError, MistralService
+
+
+class DummySession:
+    async def __aenter__(self):  # noqa: D401 - simple context manager
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:  # noqa: D401 - simple context manager
+        return None
+
+
+@pytest.fixture()
+def anyio_backend() -> str:  # pragma: no cover
+    return "asyncio"
+
+
+@pytest.fixture()
+def service(monkeypatch: pytest.MonkeyPatch) -> MistralService:
+    svc = MistralService()
+    svc.api_key = "token"
+    monkeypatch.setattr(asyncio, "sleep", AsyncMock())
+    monkeypatch.setattr(mistral_module.aiohttp, "ClientSession", lambda: DummySession())
+    return svc
+
+
+@pytest.mark.anyio
+async def test_chat_completion_fallbacks_to_small_on_429(service: MistralService, monkeypatch: pytest.MonkeyPatch) -> None:
+    models_tried: list[str] = []
+
+    async def fake_request(session, headers, payload):  # noqa: ANN001
+        model = payload["model"]
+        models_tried.append(model)
+        if model == service.models["medium"]:
+            raise MistralAPIError(429, "busy", model)
+        return {"choices": [{"message": {"content": "small success"}}]}
+
+    monkeypatch.setattr(service, "_perform_request", fake_request)
+
+    response = await service.chat_completion([{"role": "user", "content": "hola"}], model="medium")
+
+    assert response == "small success"
+    assert service.models["medium"] in models_tried
+    assert service.models["small"] in models_tried
+
+
+@pytest.mark.anyio
+async def test_chat_completion_uses_large_after_server_errors(service: MistralService, monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_request(session, headers, payload):  # noqa: ANN001
+        model = payload["model"]
+        if model in (service.models["medium"], service.models["small"]):
+            raise MistralAPIError(500, "server error", model)
+        return {"choices": [{"message": {"content": "large success"}}]}
+
+    monkeypatch.setattr(service, "_perform_request", fake_request)
+
+    response = await service.chat_completion([{"role": "user", "content": "hola"}], model="medium")
+    assert response == "large success"
+
+
+@pytest.mark.anyio
+async def test_analyze_market_sentiment_handles_corrupt_payload(service: MistralService, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(service, "chat_completion", AsyncMock(return_value="{not json}"))
+
+    sentiment = await service.analyze_market_sentiment("Breaking news")
+    assert sentiment == {"sentiment_score": 0.0, "confidence": 0.0, "keywords": []}
+
+
+@pytest.mark.anyio
+async def test_chat_completion_raises_clear_error_when_all_models_fail(service: MistralService, monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_request(session, headers, payload):  # noqa: ANN001
+        raise MistralAPIError(503, "unavailable", payload["model"])
+
+    monkeypatch.setattr(service, "_perform_request", fake_request)
+
+    with pytest.raises(MistralAPIError) as exc_info:
+        await service.chat_completion([{"role": "user", "content": "hola"}], model="medium")
+
+    assert exc_info.value.status == 503

--- a/backend/tests/test_portfolio_service_resilience.py
+++ b/backend/tests/test_portfolio_service_resilience.py
@@ -1,0 +1,91 @@
+import sys
+from types import SimpleNamespace
+from uuid import uuid4
+from unittest.mock import AsyncMock
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from backend.models import Base
+from backend.services.portfolio_service import PortfolioService
+
+
+@pytest.fixture()
+def session_factory():
+    engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+    Base.metadata.create_all(engine)
+    factory = sessionmaker(bind=engine, expire_on_commit=False, future=True)
+    try:
+        yield factory
+    finally:
+        Base.metadata.drop_all(engine)
+        engine.dispose()
+
+
+@pytest.fixture()
+def anyio_backend() -> str:  # pragma: no cover
+    return "asyncio"
+
+
+@pytest.fixture()
+def service(session_factory) -> PortfolioService:
+    return PortfolioService(session_factory=session_factory)
+
+
+def test_create_item_rejects_non_numeric_amount(service: PortfolioService) -> None:
+    with pytest.raises(ValueError):
+        service.create_item(uuid4(), symbol="AAPL", amount="abc")
+
+
+@pytest.mark.anyio
+async def test_overview_handles_missing_prices(service: PortfolioService) -> None:
+    user_id = uuid4()
+    first = service.create_item(user_id, symbol="AAA", amount=1)
+    second = service.create_item(user_id, symbol="BBB", amount=2)
+
+    async def resolve(symbol: str):  # noqa: ANN001
+        return None
+
+    service._resolve_price = resolve  # type: ignore[assignment]
+
+    overview = await service.get_portfolio_overview(user_id)
+    assert overview["items"][0]["id"] == first.id
+    assert overview["items"][0]["value"] is None
+    assert overview["items"][1]["id"] == second.id
+    assert overview["total_value"] == 0.0
+
+
+@pytest.mark.anyio
+async def test_resolve_price_ignores_invalid_provider_payloads(service: PortfolioService, monkeypatch: pytest.MonkeyPatch) -> None:
+    market = SimpleNamespace(
+        get_crypto_price=AsyncMock(return_value={"price": "not-a-number"}),
+        get_stock_price=AsyncMock(return_value={"price": 100.0}),
+    )
+    forex = SimpleNamespace(get_quote=AsyncMock(return_value={"price": "1.2"}))
+
+    module = sys.modules["backend.services.portfolio_service"]
+    monkeypatch.setattr(module, "market_service", market, raising=False)
+    monkeypatch.setattr(module, "forex_service", forex, raising=False)
+
+    price = await service._resolve_price("BTC")
+    assert price == 100.0
+    assert market.get_crypto_price.await_count == 1
+    assert market.get_stock_price.await_count == 1
+
+
+@pytest.mark.anyio
+async def test_resolve_price_returns_none_when_all_sources_fail(service: PortfolioService, monkeypatch: pytest.MonkeyPatch) -> None:
+    failing_async = AsyncMock(return_value={"price": "bad"})
+    market = SimpleNamespace(
+        get_crypto_price=AsyncMock(return_value={"price": None}),
+        get_stock_price=failing_async,
+    )
+    forex = SimpleNamespace(get_quote=AsyncMock(return_value={"price": None}))
+
+    module = sys.modules["backend.services.portfolio_service"]
+    monkeypatch.setattr(module, "market_service", market, raising=False)
+    monkeypatch.setattr(module, "forex_service", forex, raising=False)
+
+    price = await service._resolve_price("EURUSD")
+    assert price is None

--- a/backend/tests/test_stock_service_resilience.py
+++ b/backend/tests/test_stock_service_resilience.py
@@ -1,0 +1,103 @@
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from backend.services.stock_service import StockService
+from backend.utils import cache as cache_module
+
+
+class InMemoryCache:
+    def __init__(self) -> None:
+        self.data = {}
+
+    async def get(self, key):  # noqa: D401 - simple proxy
+        return self.data.get(key)
+
+    async def set(self, key, value, ttl=None):  # noqa: D401 - simple proxy
+        self.data[key] = value
+
+
+@pytest.fixture(autouse=True)
+def disable_redis(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(cache_module.Config, "REDIS_URL", None, raising=False)
+
+
+@pytest.fixture
+def anyio_backend() -> str:  # pragma: no cover
+    return "asyncio"
+
+
+@pytest.fixture()
+def anyio_backend() -> str:  # pragma: no cover
+    return "asyncio"
+
+
+@pytest.fixture()
+def service(monkeypatch: pytest.MonkeyPatch) -> StockService:
+    monkeypatch.setattr(StockService, "RETRY_ATTEMPTS", 2, raising=False)
+    monkeypatch.setattr(StockService, "RETRY_BACKOFF", 0.01, raising=False)
+    monkeypatch.setattr(asyncio, "sleep", AsyncMock())
+    return StockService(cache_client=InMemoryCache())
+
+
+@pytest.mark.anyio
+async def test_get_price_skips_corrupt_payload_and_falls_back(service: StockService, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(service, "_fetch_alpha_vantage", AsyncMock(side_effect=KeyError("price")))
+    monkeypatch.setattr(service, "_fetch_twelvedata", AsyncMock(side_effect=ValueError("bad data")))
+    monkeypatch.setattr(service, "_fetch_yahoo_finance", AsyncMock(return_value={"price": 120.5, "change": 1.2}))
+
+    monkeypatch.setattr(service, "apis", [
+        {"name": "Alpha Vantage", "callable": service._fetch_alpha_vantage, "requires_key": True, "api_key": "key"},
+        {"name": "Twelve Data", "callable": service._fetch_twelvedata, "requires_key": True, "api_key": "key"},
+        {"name": "Yahoo Finance", "callable": service._fetch_yahoo_finance, "requires_key": False, "api_key": None},
+    ])
+
+    result = await service.get_price("AAPL")
+    assert result == {"price": 120.5, "change": 1.2, "source": "Yahoo Finance"}
+
+
+@pytest.mark.anyio
+async def test_missing_api_keys_use_open_provider(service: StockService, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(service, "_fetch_yahoo_finance", AsyncMock(return_value={"price": 99.0, "change": -0.5}))
+
+    monkeypatch.setattr(service, "apis", [
+        {"name": "Alpha Vantage", "callable": service._fetch_alpha_vantage, "requires_key": True, "api_key": ""},
+        {"name": "Twelve Data", "callable": service._fetch_twelvedata, "requires_key": True, "api_key": None},
+        {"name": "Yahoo Finance", "callable": service._fetch_yahoo_finance, "requires_key": False, "api_key": None},
+    ])
+
+    result = await service.get_price("TSLA")
+    assert result == {"price": 99.0, "change": -0.5, "source": "Yahoo Finance"}
+
+
+@pytest.mark.anyio
+async def test_all_providers_fail_returns_none(service: StockService, monkeypatch: pytest.MonkeyPatch) -> None:
+    failing = AsyncMock(side_effect=ValueError("fail"))
+    monkeypatch.setattr(service, "_fetch_yahoo_finance", failing)
+
+    monkeypatch.setattr(service, "apis", [
+        {"name": "Alpha Vantage", "callable": failing, "requires_key": True, "api_key": ""},
+        {"name": "Twelve Data", "callable": failing, "requires_key": True, "api_key": ""},
+        {"name": "Yahoo Finance", "callable": failing, "requires_key": False, "api_key": None},
+    ])
+
+    assert await service.get_price("NFLX") is None
+
+
+@pytest.mark.anyio
+async def test_non_numeric_payload_triggers_retry(service: StockService, monkeypatch: pytest.MonkeyPatch) -> None:
+    def _invalid(*args, **kwargs):  # noqa: ANN001 - helper for clarity
+        raise TypeError("non numeric")
+
+    monkeypatch.setattr(service, "_fetch_alpha_vantage", AsyncMock(side_effect=_invalid))
+    monkeypatch.setattr(service, "_fetch_twelvedata", AsyncMock(return_value={"price": 55.0, "change": 0.0}))
+
+    monkeypatch.setattr(service, "apis", [
+        {"name": "Alpha Vantage", "callable": service._fetch_alpha_vantage, "requires_key": True, "api_key": "key"},
+        {"name": "Twelve Data", "callable": service._fetch_twelvedata, "requires_key": True, "api_key": "key"},
+        {"name": "Yahoo Finance", "callable": service._fetch_yahoo_finance, "requires_key": False, "api_key": None},
+    ])
+
+    result = await service.get_price("MSFT")
+    assert result == {"price": 55.0, "change": 0.0, "source": "Twelve Data"}

--- a/backend/tests/test_timeseries_service_resilience.py
+++ b/backend/tests/test_timeseries_service_resilience.py
@@ -1,0 +1,71 @@
+from datetime import datetime, timedelta
+
+import pytest
+
+from backend.services import timeseries_service as ts
+
+
+@pytest.fixture()
+def anyio_backend() -> str:  # pragma: no cover
+    return "asyncio"
+
+
+def test_resample_series_rejects_unknown_interval():
+    sample = [{"timestamp": "2023-01-01T00:00:00Z", "close": 1.0}]
+    with pytest.raises(ValueError):
+        ts.resample_series(sample, "1minute")
+
+
+def test_resample_series_merges_duplicates_and_orders():
+    base = datetime(2023, 1, 1, 0, 0, 0)
+    series = [
+        {"timestamp": (base + timedelta(minutes=5)).isoformat(), "close": 12.0, "volume": 3.0},
+        {"timestamp": base.isoformat(), "close": 10.0, "volume": 1.0},
+        {"timestamp": (base + timedelta(minutes=30)).isoformat(), "close": 11.5, "volume": 2.0},
+        {"timestamp": (base + timedelta(hours=1)).isoformat(), "close": 9.0},
+    ]
+
+    aggregated = ts.resample_series(series, "1h")
+    assert len(aggregated) == 2
+
+    first, second = aggregated
+    assert first["open"] == pytest.approx(10.0)
+    assert first["close"] == pytest.approx(11.5)
+    assert first["high"] == pytest.approx(12.0)
+    assert first["low"] == pytest.approx(10.0)
+    assert first["volume"] == pytest.approx(6.0)
+
+    assert second["timestamp"].endswith("Z")
+    assert second["close"] == pytest.approx(9.0)
+
+
+def test_resample_series_rejects_corrupt_points():
+    corrupt = [{"timestamp": None, "close": 10.0}]
+    with pytest.raises((TypeError, ValueError)):
+        ts.resample_series(corrupt, "1h")
+
+    corrupt_price = [(datetime.utcnow().isoformat(), None)]
+    with pytest.raises((TypeError, ValueError)):
+        ts.resample_series(corrupt_price, "1h")
+
+
+def test_resample_series_handles_large_dataset():
+    base = datetime(2023, 1, 1)
+    series = [
+        {
+            "timestamp": (base + timedelta(minutes=i)).isoformat(),
+            "close": float(i % 50),
+            "volume": float(i % 7),
+        }
+        for i in range(0, 5000)
+    ]
+
+    aggregated = ts.resample_series(series, "1h")
+    expected = ((len(series) - 1) // 60) + 1
+    assert len(aggregated) == expected
+
+
+@pytest.mark.anyio
+async def test_get_crypto_closes_rejects_invalid_interval():
+    with pytest.raises(ValueError):
+        await ts.get_crypto_closes_binance("BTCUSDT", "abc")


### PR DESCRIPTION
## Summary
- add resilience test coverage for technical indicators to validate behavior on empty, extreme, and long input series
- verify AI, alert, timeseries, stock, crypto, forex, mistral, and portfolio services gracefully handle timeouts, corrupt payloads, and fallback paths
- strengthen cache client guarantees for missing keys, TTL expiration, deletion, and complex value storage

## Testing
- pytest backend/tests/test_indicators_resilience.py backend/tests/test_ai_service_resilience.py backend/tests/test_alert_service_resilience.py backend/tests/test_timeseries_service_resilience.py backend/tests/test_stock_service_resilience.py backend/tests/test_crypto_service_resilience.py backend/tests/test_forex_service_resilience.py backend/tests/test_mistral_service_resilience.py backend/tests/test_portfolio_service_resilience.py backend/tests/test_cache_resilience.py

------
https://chatgpt.com/codex/tasks/task_e_68dd22509cc88321a288b8b5ee2ea73a