### PR TITLE
Add resilience tests for routers, auth, main, and cache

### DIFF
--- a/backend/tests/test_alerts_resilience.py
+++ b/backend/tests/test_alerts_resilience.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+from httpx import AsyncClient
+from starlette.testclient import TestClient
+
+os.environ.setdefault("BULLBEAR_SKIP_AUTOCREATE", "1")
+
+from backend.tests._dependency_stubs import ensure as ensure_test_dependencies
+
+ensure_test_dependencies()
+
+from backend.main import app
+from backend.routers import alerts as alerts_router
+from backend.tests.test_alerts_endpoints import (  # noqa: E402
+    DummyUserService,
+    _auth_header,
+    _register_and_login,
+    client as async_client_fixture,
+    dummy_user_service,
+)
+
+
+@pytest.fixture(name="client")
+def _client_fixture(async_client_fixture):  # noqa: ANN001
+    return async_client_fixture
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "payload,expected_status",
+    [
+        (
+            {
+                "title": "Sin activo",
+                "condition": ">",
+                "value": 10,
+                "active": True,
+            },
+            400,
+        ),
+        (
+            {
+                "title": "Tipo incorrecto",
+                "asset": "btc",
+                "condition": ">",
+                "value": "not-a-number",
+            },
+            422,
+        ),
+        (
+            {
+                "title": "Falta condición",
+                "asset": "eth",
+                "value": 1000,
+            },
+            422,
+        ),
+    ],
+)
+async def test_create_alert_invalid_payloads(
+    client: AsyncClient,
+    dummy_user_service: DummyUserService,
+    payload: dict,
+    expected_status: int,
+) -> None:
+    email = f"user-{uuid.uuid4()}@example.com"
+    token = await _register_and_login(dummy_user_service, email, "secret123")
+
+    response = await client.post(
+        "/api/alerts",
+        json=payload,
+        headers=_auth_header(token),
+    )
+
+    assert response.status_code == expected_status
+
+
+@pytest.mark.asyncio
+async def test_delete_nonexistent_alert_returns_404(
+    client: AsyncClient,
+    dummy_user_service: DummyUserService,
+) -> None:
+    email = f"user-{uuid.uuid4()}@example.com"
+    token = await _register_and_login(dummy_user_service, email, "secret123")
+
+    response = await client.delete(
+        f"/api/alerts/{uuid.uuid4()}",
+        headers=_auth_header(token),
+    )
+
+    assert response.status_code == 404
+    body = response.json()
+    assert "detail" in body
+
+
+@pytest.mark.asyncio
+async def test_toggle_alert_activation(
+    client: AsyncClient,
+    dummy_user_service: DummyUserService,
+) -> None:
+    email = f"user-{uuid.uuid4()}@example.com"
+    token = await _register_and_login(dummy_user_service, email, "secret123")
+
+    create_payload = {
+        "title": "BTC swing",
+        "asset": "btc",
+        "value": 42000,
+        "condition": ">",
+    }
+    created = await client.post(
+        "/api/alerts",
+        json=create_payload,
+        headers=_auth_header(token),
+    )
+    assert created.status_code == 201
+    alert_id = created.json()["id"]
+
+    disable = await client.put(
+        f"/api/alerts/{alert_id}",
+        json={"active": False},
+        headers=_auth_header(token),
+    )
+    assert disable.status_code == 200
+    assert disable.json()["active"] is False
+
+    enable = await client.put(
+        f"/api/alerts/{alert_id}",
+        json={"active": True},
+        headers=_auth_header(token),
+    )
+    assert enable.status_code == 200
+    assert enable.json()["active"] is True
+
+
+def test_websocket_subscription_and_disconnect(monkeypatch: pytest.MonkeyPatch) -> None:
+    service = DummyUserService()
+    monkeypatch.setattr(alerts_router, "user_service", service)
+    monkeypatch.setattr(alerts_router, "InvalidTokenError", service.InvalidTokenError)
+    monkeypatch.setattr(alerts_router, "USER_SERVICE_ERROR", None)
+
+    with TestClient(app) as test_client:
+        manager = app.state.alerts_ws_manager
+        with test_client.websocket_connect("/ws/alerts") as connection:
+            hello = connection.receive_json()
+            assert hello["type"] == "system"
+            assert test_client.portal.call(manager.count) == 1
+
+        assert test_client.portal.call(manager.count) == 0

--- a/backend/tests/test_auth_resilience.py
+++ b/backend/tests/test_auth_resilience.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+os.environ.setdefault("BULLBEAR_SKIP_AUTOCREATE", "1")
+
+from backend.tests._dependency_stubs import ensure as ensure_test_dependencies
+
+ensure_test_dependencies()
+
+from backend.main import app
+from backend.database import get_db
+from backend.routers import auth as auth_router
+from backend.tests.test_api_endpoints import DummyUserService as BaseUserService
+
+
+class AuthDummyUserService(BaseUserService):
+    def revoke_refresh_token(self, token: str) -> None:
+        self._refresh_tokens.pop(token, None)
+
+    def revoke_all_refresh_tokens(self, user_id: uuid.UUID) -> None:
+        for key, entry in list(self._refresh_tokens.items()):
+            if getattr(entry, "user_id", None) == user_id:
+                self._refresh_tokens.pop(key, None)
+
+    def ensure_user(self, email: str, password: str) -> None:
+        if self.get_user_by_email(email) is None:
+            self.create_user(email=email, password=password)
+
+
+@pytest.fixture()
+def in_memory_user_service(monkeypatch: pytest.MonkeyPatch) -> AuthDummyUserService:
+    service = AuthDummyUserService()
+    monkeypatch.setattr(auth_router, "user_service", service)
+    monkeypatch.setattr("backend.main.user_service", service)
+    monkeypatch.setattr(auth_router, "UserAlreadyExistsError", service.UserAlreadyExistsError)
+    monkeypatch.setattr(auth_router, "InvalidCredentialsError", service.InvalidCredentialsError)
+    monkeypatch.setattr(auth_router, "InvalidTokenError", service.InvalidTokenError)
+
+    app.dependency_overrides[get_db] = lambda: None
+
+    yield service
+
+    app.dependency_overrides.pop(get_db, None)
+
+
+@pytest_asyncio.fixture()
+async def client(in_memory_user_service: AuthDummyUserService) -> AsyncClient:  # type: ignore[name-defined]
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+        yield client
+
+
+@pytest.mark.asyncio
+async def test_login_with_invalid_credentials_remains_unauthorized(client: AsyncClient) -> None:
+    email = f"resilience_{uuid.uuid4().hex}@example.com"
+    register = await client.post(
+        "/api/auth/register",
+        json={"email": email, "password": "Valid123"},
+    )
+    assert register.status_code in (200, 201)
+
+    for _ in range(2):
+        response = await client.post(
+            "/api/auth/login",
+            json={"email": email, "password": "WrongPass"},
+        )
+        assert response.status_code == 401
+        assert response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_refresh_with_corrupted_token_returns_unauthorized(client: AsyncClient) -> None:
+    response = await client.post(
+        "/api/auth/refresh",
+        json={"refresh_token": "this-is-not-valid"},
+    )
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_logout_with_unknown_token_is_handled(client: AsyncClient) -> None:
+    response = await client.post(
+        "/api/auth/logout",
+        json={"refresh_token": "missing-token"},
+    )
+    assert response.status_code in (200, 204)
+    payload = response.json()
+    assert payload.get("detail") in {"Session revoked", "All sessions revoked"}
+
+
+@pytest.mark.asyncio
+async def test_revoke_all_refresh_tokens_invalidates_existing_ones(client: AsyncClient) -> None:
+    email = f"resilience_all_{uuid.uuid4().hex}@example.com"
+    password = "Valid123"
+    register = await client.post(
+        "/api/auth/register",
+        json={"email": email, "password": password},
+    )
+    assert register.status_code in (200, 201)
+
+    first_login = await client.post(
+        "/api/auth/login",
+        json={"email": email, "password": password},
+    )
+    assert first_login.status_code == 200
+    first_refresh = first_login.json()["refresh_token"]
+
+    second_login = await client.post(
+        "/api/auth/login",
+        json={"email": email, "password": password},
+    )
+    assert second_login.status_code == 200
+    second_refresh = second_login.json()["refresh_token"]
+
+    logout_all = await client.post(
+        "/api/auth/logout",
+        json={"refresh_token": second_refresh, "revoke_all": True},
+    )
+    assert logout_all.status_code == 200
+
+    reuse_first = await client.post(
+        "/api/auth/refresh",
+        json={"refresh_token": first_refresh},
+    )
+    assert reuse_first.status_code == 401
+
+    reuse_second = await client.post(
+        "/api/auth/refresh",
+        json={"refresh_token": second_refresh},
+    )
+    assert reuse_second.status_code == 401

--- a/backend/tests/test_cache_resilience_extra.py
+++ b/backend/tests/test_cache_resilience_extra.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import os
+
+import pytest
+
+os.environ.setdefault("BULLBEAR_SKIP_AUTOCREATE", "1")
+
+from backend.utils import cache as cache_module
+from backend.utils.cache import CacheClient
+
+
+@pytest.fixture(autouse=True)
+def _disable_redis(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(cache_module.Config, "REDIS_URL", "")
+
+
+@pytest.mark.asyncio
+async def test_store_non_serializable_object_in_memory_cache() -> None:
+    class CustomObject:
+        def __init__(self) -> None:
+            self.value = 42
+
+        def method(self) -> int:
+            return self.value
+
+    cache = CacheClient("resilience", ttl=1)
+    obj = CustomObject()
+    await cache.set("complex", obj)
+    retrieved = await cache.get("complex")
+    assert retrieved is obj
+
+
+@pytest.mark.asyncio
+async def test_set_and_delete_clears_value() -> None:
+    cache = CacheClient("resilience", ttl=5)
+    await cache.set("temporary", {"value": 1})
+    await cache.delete("temporary")
+    assert await cache.get("temporary") is None
+
+
+@pytest.mark.asyncio
+async def test_expired_ttl_returns_none() -> None:
+    cache = CacheClient("resilience", ttl=0)
+    await cache.set("expired", "value", ttl=0)
+    assert await cache.get("expired") is None
+
+
+@pytest.mark.asyncio
+async def test_extreme_keys_are_supported() -> None:
+    cache = CacheClient("resilience", ttl=5)
+    long_key = "x" * 256
+    weird_key = "símbolo-Δ-测试"
+
+    await cache.set(long_key, "long")
+    await cache.set(weird_key, "unicode")
+
+    assert await cache.get(long_key) == "long"
+    assert await cache.get(weird_key) == "unicode"

--- a/backend/tests/test_main_resilience.py
+++ b/backend/tests/test_main_resilience.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import asyncio
+import os
+from types import SimpleNamespace
+
+import pytest
+
+os.environ.setdefault("BULLBEAR_SKIP_AUTOCREATE", "1")
+
+from backend.database import Base
+from backend.main import app
+
+
+class DummyRedis:
+    def __init__(self) -> None:
+        self.pings = 0
+        self.closed = False
+
+    async def ping(self) -> bool:
+        self.pings += 1
+        return True
+
+    async def close(self) -> None:
+        await self.aclose()
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+@pytest.mark.asyncio
+async def test_lifespan_records_startup_and_shutdown_logs(monkeypatch: pytest.MonkeyPatch, caplog):
+    dummy_redis = DummyRedis()
+
+    async def fake_from_url(*_args, **_kwargs):  # noqa: ANN001
+        return dummy_redis
+
+    async def fake_fastapi_init(client):  # noqa: ANN001
+        from fastapi_limiter import FastAPILimiter
+
+        FastAPILimiter.redis = client
+
+    fake_engine = SimpleNamespace(dispose=lambda: None)
+
+    monkeypatch.setattr("backend.main.redis.from_url", fake_from_url)
+    monkeypatch.setattr("backend.main.FastAPILimiter.init", fake_fastapi_init)
+    monkeypatch.setattr("backend.main.log_api_integration_report", lambda: asyncio.sleep(0))
+    mock_user_service = SimpleNamespace(ensure_user=lambda *_: None)
+    monkeypatch.setattr("backend.main.user_service", mock_user_service)
+    monkeypatch.setattr("backend.services.user_service.user_service", mock_user_service)
+    monkeypatch.setattr(Base.metadata, "create_all", lambda **_: None)
+    monkeypatch.setattr("backend.database.engine", fake_engine)
+
+    caplog.set_level("INFO")
+    caplog.clear()
+    async with app.router.lifespan_context(app):
+        pass
+
+    messages = " ".join(record.getMessage() for record in caplog.records)
+    assert "fastapi_limiter_initialized" in messages
+    assert "redis_closed" in messages
+    assert "engine_disposed" in messages
+    assert dummy_redis.pings == 1
+    assert dummy_redis.closed is True
+
+
+@pytest.mark.asyncio
+async def test_lifespan_skips_create_all_outside_local(monkeypatch: pytest.MonkeyPatch):
+    fake_metadata = SimpleNamespace(create_all=lambda **_: pytest.fail("create_all should not run"))
+    dummy_redis = DummyRedis()
+
+    async def fake_from_url(*_args, **_kwargs):  # noqa: ANN001
+        return dummy_redis
+
+    monkeypatch.setattr("backend.main.ENV", "production")
+    monkeypatch.setattr(Base, "metadata", fake_metadata)
+    monkeypatch.setattr("backend.database.engine", SimpleNamespace(dispose=lambda: None))
+    monkeypatch.setattr("backend.main.redis.from_url", fake_from_url)
+    monkeypatch.setattr("backend.main.FastAPILimiter.init", lambda *_: asyncio.sleep(0))
+    mock_user_service = SimpleNamespace(ensure_user=lambda *_: None)
+    monkeypatch.setattr("backend.main.user_service", mock_user_service)
+    monkeypatch.setattr("backend.services.user_service.user_service", mock_user_service)
+    monkeypatch.setattr("backend.main.log_api_integration_report", lambda: asyncio.sleep(0))
+
+    async with app.router.lifespan_context(app):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_lifespan_handles_redis_initialization_error(monkeypatch: pytest.MonkeyPatch, caplog):
+    async def failing_from_url(*_args, **_kwargs):  # noqa: ANN001
+        raise RuntimeError("redis down")
+
+    monkeypatch.setattr("backend.main.redis.from_url", failing_from_url)
+    mock_user_service = SimpleNamespace(ensure_user=lambda *_: None)
+    monkeypatch.setattr("backend.main.user_service", mock_user_service)
+    monkeypatch.setattr("backend.services.user_service.user_service", mock_user_service)
+    monkeypatch.setattr(Base.metadata, "create_all", lambda **_: None)
+    monkeypatch.setattr("backend.database.engine", SimpleNamespace(dispose=lambda: None))
+    monkeypatch.setattr("backend.main.FastAPILimiter.init", lambda *_: asyncio.sleep(0))
+    monkeypatch.setattr("backend.main.log_api_integration_report", lambda: asyncio.sleep(0))
+
+    caplog.clear()
+    async with app.router.lifespan_context(app):
+        pass
+
+    messages = " ".join(record.getMessage() for record in caplog.records)
+    assert "fastapi_limiter_unavailable" in messages

--- a/backend/tests/test_markets_resilience.py
+++ b/backend/tests/test_markets_resilience.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import asyncio
+import os
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+os.environ.setdefault("BULLBEAR_SKIP_AUTOCREATE", "1")
+
+from backend.tests._dependency_stubs import ensure as ensure_test_dependencies
+
+ensure_test_dependencies()
+
+from backend.main import app
+from backend.routers import markets as markets_router
+
+
+@pytest_asyncio.fixture()
+async def client() -> AsyncClient:  # type: ignore[name-defined]
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+        yield client
+
+
+@pytest.mark.asyncio
+async def test_crypto_prices_returns_404_for_unknown_symbol(
+    client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    async def fake_price(symbol: str) -> None:  # noqa: ANN001
+        await asyncio.sleep(0)
+        return None
+
+    monkeypatch.setattr(markets_router.market_service, "get_crypto_price", fake_price)
+
+    response = await client.get(
+        "/api/markets/crypto/prices",
+        params={"symbols": "UNKNOWN"},
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"].startswith("No se encontraron")
+
+
+@pytest.mark.asyncio
+async def test_stock_quotes_returns_404_for_unknown_symbol(
+    client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    async def fake_price(symbol: str) -> None:  # noqa: ANN001
+        await asyncio.sleep(0)
+        return None
+
+    monkeypatch.setattr(markets_router.market_service, "get_stock_price", fake_price)
+
+    response = await client.get(
+        "/api/markets/stocks/quotes",
+        params={"symbols": "INVALID"},
+    )
+
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_forex_rates_returns_404_for_unknown_pair(
+    client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    async def fake_quote(symbol: str) -> None:  # noqa: ANN001
+        await asyncio.sleep(0)
+        return None
+
+    monkeypatch.setattr(markets_router.forex_service, "get_quote", fake_quote)
+
+    response = await client.get(
+        "/api/markets/forex/rates",
+        params={"pairs": "ZZZYYY"},
+    )
+
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_crypto_endpoint_uses_binance_fallback(
+    client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    async def primary_failure(symbol: str) -> None:  # noqa: ANN001
+        return None
+
+    async def binance_fallback(symbol: str) -> dict:  # noqa: ANN001
+        return {"price": "42100.5", "source": "Binance"}
+
+    monkeypatch.setattr(
+        markets_router.market_service.crypto_service,
+        "get_price",
+        primary_failure,
+    )
+    monkeypatch.setattr(markets_router.market_service, "get_binance_price", binance_fallback)
+
+    response = await client.get("/api/markets/crypto/BTCUSDT")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["price"] == pytest.approx(42100.5)
+    assert payload["source"].endswith("Binance")
+
+
+@pytest.mark.asyncio
+async def test_parse_symbols_rejects_corrupted_input(client: AsyncClient) -> None:
+    response = await client.get(
+        "/api/markets/crypto/prices",
+        params={"symbols": " , , "},
+    )
+
+    assert response.status_code == 400
+    assert "símbolo" in response.json()["detail"].lower()

--- a/backend/tests/test_news_resilience.py
+++ b/backend/tests/test_news_resilience.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import os
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+os.environ.setdefault("BULLBEAR_SKIP_AUTOCREATE", "1")
+
+from backend.tests._dependency_stubs import ensure as ensure_test_dependencies
+
+ensure_test_dependencies()
+
+from backend.main import app
+from backend.routers import news as news_router
+
+
+class StubNewsService:
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    async def get_latest_news(self, limit: int) -> list[dict]:
+        self.calls.append(f"latest:{limit}")
+        return []
+
+    async def get_crypto_headlines(self, limit: int) -> list[dict]:
+        self.calls.append(f"crypto:{limit}")
+        return [
+            {
+                "title": None,
+                "url": "https://example.com/corrupted",
+                "published_at": "2024-01-01T00:00:00Z",
+                "summary": None,
+            },
+            {
+                "title": "Valid entry",
+                "url": "https://example.com/valid",
+                "published_at": "2024-01-02T00:00:00Z",
+                "summary": "ok",
+            },
+        ]
+
+
+@pytest.fixture()
+def stub_service(monkeypatch: pytest.MonkeyPatch) -> StubNewsService:
+    service = StubNewsService()
+    monkeypatch.setattr(news_router, "news_service", service)
+    return service
+
+
+@pytest_asyncio.fixture()
+async def client() -> AsyncClient:  # type: ignore[name-defined]
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+        yield client
+
+
+@pytest.mark.asyncio
+async def test_latest_news_returns_controlled_empty_list(
+    client: AsyncClient, stub_service: StubNewsService
+) -> None:
+    response = await client.get("/api/news/latest")
+    assert response.status_code == 404
+    assert response.json()["detail"].startswith("No hay noticias")
+    assert stub_service.calls == ["latest:20"]
+
+
+@pytest.mark.asyncio
+async def test_corrupted_provider_payload_is_handled(
+    client: AsyncClient, stub_service: StubNewsService
+) -> None:
+    response = await client.get("/api/news/crypto")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["category"] == "crypto"
+    assert len(payload["articles"]) == 2
+    assert stub_service.calls[-1] == "crypto:10"

--- a/backend/tests/test_portfolio_resilience.py
+++ b/backend/tests/test_portfolio_resilience.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import os
+import uuid
+from types import SimpleNamespace
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+os.environ.setdefault("BULLBEAR_SKIP_AUTOCREATE", "1")
+
+from backend.tests._dependency_stubs import ensure as ensure_test_dependencies
+
+ensure_test_dependencies()
+
+from backend.main import app
+from backend.routers import portfolio as portfolio_router
+
+
+class DummyPortfolioService:
+    def __init__(self) -> None:
+        self.last_deleted: tuple[uuid.UUID, uuid.UUID] | None = None
+
+    async def get_portfolio_overview(self, user_id: uuid.UUID) -> dict:
+        return {"items": [], "total_value": 0.0}
+
+    def delete_item(self, user_id: uuid.UUID, item_id: uuid.UUID) -> bool:
+        self.last_deleted = (user_id, item_id)
+        return False
+
+
+def _override_user() -> SimpleNamespace:
+    return SimpleNamespace(id=uuid.uuid4(), email="test@example.com")
+
+
+@pytest.fixture(autouse=True)
+def _override_dependencies(monkeypatch: pytest.MonkeyPatch) -> None:
+    user = _override_user()
+    app.dependency_overrides[portfolio_router.get_current_user] = lambda: user
+    service = DummyPortfolioService()
+    monkeypatch.setattr(portfolio_router, "portfolio_service", service)
+    yield
+    app.dependency_overrides.pop(portfolio_router.get_current_user, None)
+
+
+@pytest_asyncio.fixture()
+async def client() -> AsyncClient:  # type: ignore[name-defined]
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+        yield client
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"symbol": "BTC", "amount": 0},
+        {"symbol": "ETH", "amount": -1},
+        {"symbol": " ", "amount": 1},
+    ],
+)
+async def test_create_item_invalid_amount_or_symbol(
+    client: AsyncClient, payload: dict
+) -> None:
+    response = await client.post("/api/portfolio", json=payload)
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_delete_nonexistent_item_returns_404(client: AsyncClient) -> None:
+    response = await client.delete(f"/api/portfolio/{uuid.uuid4()}")
+    assert response.status_code == 404
+    assert "detail" in response.json()
+
+
+@pytest.mark.asyncio
+async def test_empty_portfolio_overview_returns_zeroes(client: AsyncClient) -> None:
+    response = await client.get("/api/portfolio")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload == {"items": [], "total_value": 0.0}


### PR DESCRIPTION
## Summary
- add alert resilience coverage for invalid payloads, missing resources, and websocket disconnects
- exercise markets, portfolio, news, and auth endpoints against error and fallback scenarios to harden router behaviour
- verify FastAPI lifespan and cache client edge cases including Redis failures, environment gating, and TTL expiry

## Testing
- pytest backend/tests/test_alerts_resilience.py        backend/tests/test_markets_resilience.py        backend/tests/test_portfolio_resilience.py        backend/tests/test_news_resilience.py        backend/tests/test_auth_resilience.py        backend/tests/test_main_resilience.py        backend/tests/test_cache_resilience_extra.py

------
https://chatgpt.com/codex/tasks/task_e_68dd537fa80883218c7ceb592899d70e