### PR TITLE
Add resilience test coverage for key backend services

### DIFF
--- a/backend/tests/test_metrics_resilience.py
+++ b/backend/tests/test_metrics_resilience.py
@@ -1,0 +1,95 @@
+import asyncio
+
+import pytest
+from starlette.requests import Request
+from starlette.responses import Response
+
+from backend.core import metrics
+from backend.core.metrics import MetricsMiddleware
+
+
+@pytest.fixture(autouse=True)
+def reset_metrics() -> None:
+    metrics.REQUEST_COUNT._metrics.clear()
+    metrics.REQUEST_LATENCY._metrics.clear()
+    yield
+    metrics.REQUEST_COUNT._metrics.clear()
+    metrics.REQUEST_LATENCY._metrics.clear()
+
+
+def _make_request(path: str = "/metrics") -> Request:
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": path,
+        "headers": [],
+        "query_string": b"",
+        "server": ("testserver", 80),
+        "client": ("127.0.0.1", 12345),
+    }
+    return Request(scope)
+
+
+@pytest.fixture()
+def anyio_backend() -> str:  # pragma: no cover - used by pytest-asyncio
+    return "asyncio"
+
+
+def _histogram_sample_value(metric, *, name_suffix: str, labels: dict[str, str]) -> float:
+    for metric_family in metric.collect():
+        for sample in metric_family.samples:
+            if sample.name.endswith(name_suffix) and sample.labels == labels:
+                return sample.value
+    raise AssertionError(f"Sample with suffix {name_suffix!r} and labels {labels!r} not found")
+
+
+@pytest.mark.anyio
+async def test_metrics_middleware_accumulates_counts_and_latency() -> None:
+    middleware = MetricsMiddleware(lambda scope, receive, send: None)  # type: ignore[arg-type]
+    request = _make_request("/resilience")
+
+    async def call_next(_request):  # noqa: ANN001
+        await asyncio.sleep(0)
+        return Response(status_code=204)
+
+    await middleware.dispatch(request, call_next)
+    await middleware.dispatch(request, call_next)
+
+    counter = metrics.REQUEST_COUNT.labels(method="GET", path="/resilience", status="204")
+    assert counter._value.get() == pytest.approx(2.0)
+
+    labels = {"method": "GET", "path": "/resilience"}
+    count_value = _histogram_sample_value(metrics.REQUEST_LATENCY, name_suffix="_count", labels=labels)
+    sum_value = _histogram_sample_value(metrics.REQUEST_LATENCY, name_suffix="_sum", labels=labels)
+    assert count_value == pytest.approx(2.0)
+    assert sum_value >= 0.0
+
+
+@pytest.mark.anyio
+async def test_metrics_middleware_records_failures() -> None:
+    middleware = MetricsMiddleware(lambda scope, receive, send: None)  # type: ignore[arg-type]
+    request = _make_request("/error")
+
+    async def call_next(_request):  # noqa: ANN001
+        raise RuntimeError("boom")
+
+    with pytest.raises(RuntimeError):
+        await middleware.dispatch(request, call_next)
+
+    counter = metrics.REQUEST_COUNT.labels(method="GET", path="/error", status="500")
+    assert counter._value.get() == pytest.approx(1.0)
+
+    labels = {"method": "GET", "path": "/error"}
+    count_value = _histogram_sample_value(metrics.REQUEST_LATENCY, name_suffix="_count", labels=labels)
+    assert count_value == pytest.approx(1.0)
+
+
+def test_duplicate_metric_registration_and_invalid_inputs() -> None:
+    counter = metrics.REQUEST_COUNT.labels(method="GET", path="/dup", status="200")
+    counter.inc()
+    counter.inc(3)
+    assert counter._value.get() == pytest.approx(4.0)
+
+    none_counter = metrics.REQUEST_COUNT.labels(method=None, path="/invalid", status="200")
+    none_counter.inc()
+    assert none_counter._value.get() == pytest.approx(1.0)

--- a/backend/tests/test_user_service_resilience.py
+++ b/backend/tests/test_user_service_resilience.py
@@ -1,0 +1,87 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import sessionmaker
+
+from backend.models import Base, RefreshToken, Session, User
+from backend.services import user_service as user_service_module
+from backend.services.user_service import InvalidTokenError, UserService
+
+
+@pytest.fixture()
+def session_factory():
+    engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+    Base.metadata.create_all(engine)
+    factory = sessionmaker(bind=engine, expire_on_commit=False, future=True)
+    try:
+        yield factory
+    finally:
+        Base.metadata.drop_all(engine)
+        engine.dispose()
+
+
+@pytest.fixture()
+def service(session_factory, monkeypatch: pytest.MonkeyPatch) -> UserService:
+    monkeypatch.setattr(user_service_module, "SessionLocal", session_factory)
+    return UserService(session_factory=session_factory, secret_key="secret", algorithm="HS256")
+
+
+def test_create_user_with_invalid_risk_profile_does_not_touch_db(service: UserService, session_factory) -> None:
+    with pytest.raises(ValueError):
+        service.create_user("invalid@example.com", "secret", risk_profile="super-risky")
+
+    with session_factory() as session:
+        assert session.execute(select(User)).first() is None
+
+
+def test_rotate_refresh_token_rejects_expired_entry(service: UserService, session_factory) -> None:
+    user = service.create_user("refresh@example.com", "password123")
+    refresh_token, _ = service.create_refresh_token(user.id)
+    stored = service.store_refresh_token(user.id, refresh_token)
+
+    with session_factory() as session:
+        db_token = session.get(RefreshToken, stored.id)
+        assert db_token is not None
+        db_token.expires_at = datetime.now(timezone.utc) - timedelta(minutes=5)
+        session.commit()
+
+    with pytest.raises(HTTPException) as excinfo:
+        service.rotate_refresh_token(refresh_token)
+
+    assert excinfo.value.status_code == 401
+    assert excinfo.value.detail == "refresh_expired"
+
+    with session_factory() as session:
+        assert session.get(RefreshToken, stored.id) is None
+
+
+def test_revoke_all_refresh_tokens_clears_memory_even_when_empty(service: UserService, session_factory) -> None:
+    user = service.create_user("tokens@example.com", "secret")
+
+    # Primera llamada sin tokens existentes debe ser segura
+    service.revoke_all_refresh_tokens(user.id)
+
+    token, _ = service.create_refresh_token(user.id)
+    assert token in service._in_memory_refresh_tokens
+
+    service.revoke_all_refresh_tokens(user.id)
+    assert token not in service._in_memory_refresh_tokens
+
+    with session_factory() as session:
+        assert session.execute(select(RefreshToken)).first() is None
+
+
+def test_get_current_user_rejects_expired_session(service: UserService, session_factory) -> None:
+    user = service.create_user("session@example.com", "secret")
+    token, session_record = service.create_session(user.id)
+
+    with session_factory() as session:
+        stored_session = session.get(Session, session_record.id)
+        assert stored_session is not None
+        stored_session.expires_at = datetime.now(timezone.utc) - timedelta(minutes=1)
+        session.commit()
+
+    with pytest.raises(InvalidTokenError):
+        service.get_current_user(token)


### PR DESCRIPTION
## Summary
- add a dedicated user service resilience suite to validate risk profile validation, refresh token handling, and session expiry safeguards
- extend alert, stock, forex, and timeseries resilience tests to cover additional corrupt data, fallback, and duplicate/irregular series scenarios
- introduce metrics middleware resilience tests ensuring counters accumulate and histogram samples handle failures and invalid inputs gracefully

## Testing
- pytest backend/tests/test_user_service_resilience.py backend/tests/test_alert_service_resilience.py backend/tests/test_stock_service_resilience.py backend/tests/test_forex_service_resilience.py backend/tests/test_timeseries_service_resilience.py backend/tests/test_metrics_resilience.py -q

------
https://chatgpt.com/codex/tasks/task_e_68dd578590b883218ffcb23d60626368