### PR TITLE
Fix frontend Jest Babel configuration

### DIFF
--- a/frontend/babel.config.js
+++ b/frontend/babel.config.js
@@ -1,8 +1,23 @@
-export default {
+const config = {
   presets: [
+    [
+      "@babel/preset-env",
+      { targets: { node: "current" }, modules: "commonjs" },
+    ],
+    "@babel/preset-typescript",
+    "@babel/preset-react",
     "next/babel",
-    ["@babel/preset-env", { targets: { node: "current" } }],
-    ["@babel/preset-react", { runtime: "automatic" }],
-    "@babel/preset-typescript"
-  ]
+  ],
+  ignore: [],
 };
+
+export default config;
+
+// Provide CommonJS export for tooling that still uses require().
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+if (typeof module !== "undefined") {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  module.exports = config;
+}

--- a/frontend/jest.config.base.ts
+++ b/frontend/jest.config.base.ts
@@ -22,13 +22,14 @@ const baseConfig: Config = {
       "<rootDir>/node_modules/@mswjs/interceptors/lib/node/interceptors/$1/index.js",
   },
   transform: {
-    "^.+\\.(js|jsx|ts|tsx)$": [
+    "^.+\\.(ts|tsx|js|jsx)$": [
       "babel-jest",
-      { configFile: path.resolve(__dirname, "babel.config.js") },
+      { configFile: path.resolve(__dirname, "babel.config.js"), babelrc: false },
     ],
   },
   transformIgnorePatterns: [
     "/node_modules/(?!(recharts|d3-|msw|@mswjs|until-async|strict-event-emitter|outvariant|headers-polyfill)/)",
+    "node_modules/(?!(recharts|d3-|msw|@mswjs|until-async|strict-event-emitter|outvariant|headers-polyfill|nanoid|uuid|other-esm-lib)/)",
   ],
   moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json", "node"],
   testMatch: [

--- a/frontend/jest.setup.ts
+++ b/frontend/jest.setup.ts
@@ -2,6 +2,8 @@ import "@testing-library/jest-dom";
 import "jest-axe/extend-expect";
 
 // Polyfills requeridos por MSW en entorno de pruebas
+process.env.NEXT_PUBLIC_API_URL = "http://localhost:3000/api";
+
 import { TextDecoder, TextEncoder } from "util";
 import { ReadableStream, WritableStream, TransformStream } from "stream/web";
 


### PR DESCRIPTION
## Summary
- update `frontend/babel.config.js` to ensure Jest transpiles modules with the expected presets and CommonJS output
- adjust `frontend/jest.config.base.ts` to force `babel-jest` with the shared config and widen ignored ESM dependencies
- define `NEXT_PUBLIC_API_URL` in `frontend/jest.setup.ts` so frontend tests run without missing environment variables

## Testing
- `npm --prefix frontend run test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68dd7af100b48321aa54eec778626aee