### PR TITLE
Stabilize portfolio tests and silence chart warnings

### DIFF
--- a/frontend/jest.setup.ts
+++ b/frontend/jest.setup.ts
@@ -2,7 +2,35 @@ import "@testing-library/jest-dom";
 import "jest-axe/extend-expect";
 
 // Polyfills requeridos por MSW en entorno de pruebas
-process.env.NEXT_PUBLIC_API_URL = "http://localhost:3000/api";
+process.env.NEXT_PUBLIC_API_URL ||= "http://localhost:8000";
+
+if (typeof (global as any).ResizeObserver === "undefined") {
+  (global as any).ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+}
+
+try {
+  jest.mock("recharts", () => {
+    const original = jest.requireActual("recharts");
+    const React = jest.requireActual("react");
+    const MockResponsiveContainer = ({ width, height, children }: any) =>
+      React.createElement(
+        "div",
+        { style: { width: width || 800, height: height || 400 } },
+        children
+      );
+
+    return {
+      ...original,
+      ResponsiveContainer: MockResponsiveContainer,
+    };
+  });
+} catch (error) {
+  // Si ya estaba mockeado en otro lugar, omitimos la redefinición
+}
 
 import { TextDecoder, TextEncoder } from "util";
 import { ReadableStream, WritableStream, TransformStream } from "stream/web";

--- a/frontend/src/components/portfolio/__tests__/PortfolioPanel.test.tsx
+++ b/frontend/src/components/portfolio/__tests__/PortfolioPanel.test.tsx
@@ -134,7 +134,9 @@ describe("PortfolioPanel", () => {
       });
     });
 
-    expect(mutate).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(mutate).toHaveBeenCalled();
+    });
   });
 
   it("muestra un mensaje de error cuando crear el activo falla", async () => {
@@ -211,7 +213,10 @@ describe("PortfolioPanel", () => {
     await waitFor(() => {
       expect(mockedDeletePortfolioItem).toHaveBeenCalledWith("secure", "1");
     });
-    expect(mutate).toHaveBeenCalled();
+
+    await waitFor(() => {
+      expect(mutate).toHaveBeenCalled();
+    });
   });
 
   it("muestra un mensaje cuando faltan precios para un activo", () => {


### PR DESCRIPTION
## Summary
- wrap portfolio page test interactions in act helpers and wait for SWR updates
- await SWR mutate calls inside portfolio panel tests to avoid act warnings
- mock ResizeObserver and ResponsiveContainer plus stabilize NEXT_PUBLIC_API_URL for tests

## Testing
- pnpm test:dev --runTestsByPath src/app/__tests__/portfolio-page.test.tsx src/components/portfolio/__tests__/PortfolioPanel.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68dd828a27c88321b08d16b1f783cb65