### PR TITLE
Add root-level frontend and backend test scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,12 @@
     "dev": "npm --prefix frontend run dev",
     "backend": "cd backend && python -m uvicorn app.main:app --reload --host 0.0.0.0 --port 8000",
     "test": "npm --prefix frontend run test",
-    "build": "npm --prefix frontend run build"
+    "build": "npm --prefix frontend run build",
+    "test:frontend": "pnpm --prefix frontend test:dev",
+    "test:frontend:list": "pnpm --prefix frontend test:dev --listTests",
+    "test:frontend:paths": "pnpm --prefix frontend test:dev -- --runTestsByPath src/app/__tests__/portfolio-page.test.tsx src/components/portfolio/__tests__/PortfolioPanel.test.tsx",
+    "test:backend": "pytest backend",
+    "test:backend:cov": "pytest --cov=backend --cov-report=term-missing backend"
   },
   "keywords": [
     "finance",


### PR DESCRIPTION
## Summary
- add global frontend test scripts that forward to the frontend workspace
- add backend pytest scripts including coverage support

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd86ce2d6c8321afba404b96e3bba5