### PR TITLE
feat(test-ux): safe Recharts mock; ErrorBoundary for critical panels; skeletons & empty states

### DIFF
--- a/frontend/__mocks__/recharts.tsx
+++ b/frontend/__mocks__/recharts.tsx
@@ -1,0 +1,87 @@
+import React from "react";
+
+type ResponsiveContainerProps = {
+  width?: number | string;
+  height?: number | string;
+  children?: React.ReactNode | ((dimensions: { width: number; height: number }) => React.ReactNode);
+};
+
+const DEFAULT_WIDTH = 800;
+const DEFAULT_HEIGHT = 400;
+
+const createMockComponent = (name: string) => {
+  const MockComponent: React.FC<React.PropsWithChildren<{ className?: string; style?: React.CSSProperties }>> = ({
+    children,
+    className,
+    style,
+  }) => (
+    <div data-recharts-mock={name} className={className} style={style}>
+      {typeof children === "function" ? (children as () => React.ReactNode)() : children}
+    </div>
+  );
+  MockComponent.displayName = `Mock${name}`;
+  return MockComponent;
+};
+
+export const Area = createMockComponent("Area");
+export const AreaChart = createMockComponent("AreaChart");
+export const Bar = createMockComponent("Bar");
+export const CartesianGrid = createMockComponent("CartesianGrid");
+export const ComposedChart = createMockComponent("ComposedChart");
+export const Legend = createMockComponent("Legend");
+export const Line = createMockComponent("Line");
+export const LineChart = createMockComponent("LineChart");
+export const ReferenceLine = createMockComponent("ReferenceLine");
+export const Tooltip = createMockComponent("Tooltip");
+export const XAxis = createMockComponent("XAxis");
+export const YAxis = createMockComponent("YAxis");
+
+export const ResponsiveContainer: React.FC<ResponsiveContainerProps> = ({
+  width = DEFAULT_WIDTH,
+  height = DEFAULT_HEIGHT,
+  children,
+}) => {
+  const numericWidth = typeof width === "number" ? width : DEFAULT_WIDTH;
+  const numericHeight = typeof height === "number" ? height : DEFAULT_HEIGHT;
+
+  const resolvedChildren =
+    typeof children === "function"
+      ? (children as (dimensions: { width: number; height: number }) => React.ReactNode)({
+          width: numericWidth,
+          height: numericHeight,
+        })
+      : children;
+
+  const resolvedWidth = typeof width === "number" ? `${width}px` : width ?? "100%";
+  const resolvedHeight = typeof height === "number" ? `${height}px` : height ?? `${DEFAULT_HEIGHT}px`;
+
+  return (
+    <div
+      data-recharts-mock="ResponsiveContainer"
+      style={{
+        width: resolvedWidth,
+        height: resolvedHeight,
+        minWidth: resolvedWidth,
+        minHeight: resolvedHeight,
+      }}
+    >
+      {resolvedChildren}
+    </div>
+  );
+};
+
+export default {
+  Area,
+  AreaChart,
+  Bar,
+  CartesianGrid,
+  ComposedChart,
+  Legend,
+  Line,
+  LineChart,
+  ReferenceLine,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+};

--- a/frontend/jest.config.base.ts
+++ b/frontend/jest.config.base.ts
@@ -15,11 +15,11 @@ const baseConfig: Config = {
     "^.+\\.(css|less|scss|sass)$": "identity-obj-proxy",
     "^@/styles/globals\\.css$": "identity-obj-proxy",
     "^@/(.*)$": "<rootDir>/src/$1",
+    "^recharts$": "<rootDir>/__mocks__/recharts.tsx",
     "^msw/node$": "<rootDir>/node_modules/msw/lib/node/index.js",
     "^@mswjs/interceptors/WebSocket$":
       "<rootDir>/src/tests/msw/websocket-interceptor.ts",
-    "^@mswjs/interceptors/(.*)$":
-      "<rootDir>/node_modules/@mswjs/interceptors/lib/node/interceptors/$1/index.js",
+    "^@mswjs/interceptors/(.*)$": "<rootDir>/src/tests/msw/interceptors/$1.ts",
   },
   transform: {
     "^.+\\.(ts|tsx|js|jsx)$": [
@@ -28,8 +28,8 @@ const baseConfig: Config = {
     ],
   },
   transformIgnorePatterns: [
-    "/node_modules/(?!(recharts|d3-|msw|@mswjs|until-async|strict-event-emitter|outvariant|headers-polyfill)/)",
-    "node_modules/(?!(recharts|d3-|msw|@mswjs|until-async|strict-event-emitter|outvariant|headers-polyfill|nanoid|uuid|other-esm-lib)/)",
+    "/node_modules/(?!(\\.pnpm/[^/]+/node_modules/)?(recharts|d3-|msw|@mswjs|until-async|strict-event-emitter|outvariant|headers-polyfill)/)",
+    "node_modules/(?!(\\.pnpm/[^/]+/node_modules/)?(recharts|d3-|msw|@mswjs|until-async|strict-event-emitter|outvariant|headers-polyfill|nanoid|uuid|other-esm-lib)/)",
   ],
   moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json", "node"],
   testMatch: [

--- a/frontend/src/components/common/EmptyState.tsx
+++ b/frontend/src/components/common/EmptyState.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import React from "react";
+
+import { cn } from "@/lib/utils";
+
+interface EmptyStateProps {
+  title: string;
+  description?: string;
+  icon?: React.ReactNode;
+  action?: React.ReactNode;
+  className?: string;
+}
+
+export function EmptyState({ title, description, icon, action, className }: EmptyStateProps) {
+  return (
+    <div
+      role="status"
+      className={cn(
+        "flex flex-col items-center justify-center gap-2 rounded-lg border border-dashed border-border/60 bg-muted/30 p-6 text-center",
+        className
+      )}
+      data-testid="empty-state"
+    >
+      {icon && <div className="text-muted-foreground" aria-hidden="true">{icon}</div>}
+      <h3 className="text-sm font-semibold text-foreground">{title}</h3>
+      {description && <p className="text-sm text-muted-foreground">{description}</p>}
+      {action}
+    </div>
+  );
+}

--- a/frontend/src/components/common/ErrorBoundary.tsx
+++ b/frontend/src/components/common/ErrorBoundary.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import React from "react";
+
+interface ErrorBoundaryProps {
+  children: React.ReactNode;
+  fallback?: React.ReactNode;
+  onError?: (error: Error, info: React.ErrorInfo) => void;
+  resetKeys?: React.DependencyList;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+}
+
+export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { hasError: false };
+
+  static getDerivedStateFromError(): ErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
+    if (process.env.NODE_ENV !== "test") {
+      console.error("ErrorBoundary captured an error", error, info);
+    }
+    this.props.onError?.(error, info);
+  }
+
+  componentDidUpdate(prevProps: ErrorBoundaryProps) {
+    if (this.state.hasError) {
+      const { resetKeys = [] } = this.props;
+      const { resetKeys: prevResetKeys = [] } = prevProps;
+      const hasResetKeyChanged =
+        resetKeys.length !== prevResetKeys.length ||
+        resetKeys.some((key, index) => !Object.is(key, prevResetKeys[index]));
+      if (hasResetKeyChanged || prevProps.children !== this.props.children) {
+        this.reset();
+      }
+    }
+  }
+
+  reset() {
+    this.setState({ hasError: false });
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        this.props.fallback ?? (
+          <div
+            role="alert"
+            className="rounded-lg border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive"
+          >
+            Ha ocurrido un error inesperado. Intenta recargar esta sección.
+          </div>
+        )
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/frontend/src/components/common/Skeleton.tsx
+++ b/frontend/src/components/common/Skeleton.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+
+interface SkeletonProps {
+  className?: string;
+}
+
+export function Skeleton({ className }: SkeletonProps) {
+  return <div className={cn("animate-pulse rounded-md bg-muted", className)} aria-hidden="true" data-testid="skeleton" />;
+}

--- a/frontend/src/components/common/__tests__/ErrorBoundary.test.tsx
+++ b/frontend/src/components/common/__tests__/ErrorBoundary.test.tsx
@@ -1,0 +1,25 @@
+import { customRender, screen } from "@/tests/utils/renderWithProviders";
+
+import { ErrorBoundary } from "../ErrorBoundary";
+
+describe("ErrorBoundary", () => {
+  it("muestra el fallback cuando un componente lanza un error", () => {
+    const consoleSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    function Problematic() {
+      throw new Error("boom");
+    }
+
+    try {
+      customRender(
+        <ErrorBoundary fallback={<span>Ha ocurrido un error crítico</span>}>
+          <Problematic />
+        </ErrorBoundary>
+      );
+    } finally {
+      consoleSpy.mockRestore();
+    }
+
+    expect(screen.getByText("Ha ocurrido un error crítico")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/dashboard/dashboard-page.tsx
+++ b/frontend/src/components/dashboard/dashboard-page.tsx
@@ -17,8 +17,9 @@ import { Badge } from "@/components/ui/badge";
 import { getIndicators, sendChatMessage } from "@/lib/api"; // [Codex] nuevo
 import { usePushNotifications } from "@/hooks/usePushNotifications";
 import { useHistoricalData } from "@/hooks/useHistoricalData"; // [Codex] nuevo
+import { ErrorBoundary } from "@/components/common/ErrorBoundary";
 
-export function DashboardPage() {
+function DashboardPageContent() {
   const { user, loading, token, logout } = useAuth();
   const router = useRouter();
 
@@ -243,5 +244,26 @@ export function DashboardPage() {
         </section>
       </main>
     </div>
+  );
+}
+
+function DashboardPageFallback() {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background p-6">
+      <div className="w-full max-w-md rounded-lg border border-destructive/40 bg-destructive/10 p-6 text-center">
+        <h2 className="text-lg font-semibold text-destructive">No se pudo cargar el dashboard</h2>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Actualiza la página o intenta iniciar sesión nuevamente.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export function DashboardPage() {
+  return (
+    <ErrorBoundary fallback={<DashboardPageFallback />}>
+      <DashboardPageContent />
+    </ErrorBoundary>
   );
 }

--- a/frontend/src/components/news/__tests__/news-panel.test.tsx
+++ b/frontend/src/components/news/__tests__/news-panel.test.tsx
@@ -30,7 +30,8 @@ describe("NewsPanel", () => {
 
     customRender(<NewsPanel token="token" />);
 
-    expect(screen.getByText("Cargando noticias...")).toBeInTheDocument();
+    expect(screen.getByTestId("news-loading")).toBeInTheDocument();
+    expect(screen.getAllByTestId("skeleton")).toHaveLength(9);
   });
 
   it("muestra las noticias recibidas ordenadas", async () => {
@@ -77,9 +78,8 @@ describe("NewsPanel", () => {
 
     customRender(<NewsPanel token="token" />);
 
-    expect(
-      screen.getByText(/no hay noticias disponibles/i)
-    ).toBeInTheDocument();
+    const emptyState = screen.getByTestId("empty-state");
+    expect(within(emptyState).getByText(/no hay noticias disponibles/i)).toBeInTheDocument();
   });
 
   it("muestra estado de error ante fallas en el fetch", () => {
@@ -91,9 +91,9 @@ describe("NewsPanel", () => {
 
     customRender(<NewsPanel token="token" />);
 
-    expect(
-      screen.getByText(/no hay noticias disponibles/i)
-    ).toBeInTheDocument();
+    const emptyState = screen.getByTestId("empty-state");
+    expect(within(emptyState).getByText(/no se pudieron cargar las noticias/i)).toBeInTheDocument();
+    expect(within(emptyState).getByText(/fallo en noticias/i)).toBeInTheDocument();
   });
 
   it("usa texto por defecto cuando faltan la fuente y la fecha", () => {

--- a/frontend/src/components/portfolio/__tests__/PortfolioPanel.test.tsx
+++ b/frontend/src/components/portfolio/__tests__/PortfolioPanel.test.tsx
@@ -1,4 +1,4 @@
-import { act, customRender, screen, waitFor } from "@/tests/utils/renderWithProviders";
+import { act, customRender, screen, waitFor, within } from "@/tests/utils/renderWithProviders";
 import userEvent from "@testing-library/user-event";
 import useSWR from "swr";
 
@@ -91,10 +91,25 @@ describe("PortfolioPanel", () => {
       } as any);
 
     const { rerender } = customRender(<PortfolioPanel token="demo" />);
-    expect(screen.getByText(/Cargando portafolio/i)).toBeInTheDocument();
+    expect(screen.getByTestId("portfolio-loading")).toBeInTheDocument();
+    expect(screen.getAllByTestId("skeleton")).toHaveLength(3);
 
     rerender(<PortfolioPanel token="demo" />);
     expect(screen.getByText(/Error al cargar el portafolio/i)).toBeInTheDocument();
+  });
+
+  it("muestra un estado vacío cuando no existen elementos", () => {
+    mockedUseSWR.mockReturnValue({
+      data: { total_value: 0, items: [] },
+      error: undefined,
+      mutate: jest.fn(),
+      isLoading: false,
+    } as any);
+
+    customRender(<PortfolioPanel token="demo" />);
+
+    const emptyState = screen.getByTestId("empty-state");
+    expect(within(emptyState).getByText(/tu portafolio está vacío/i)).toBeInTheDocument();
   });
 
   it("permite agregar un nuevo activo", async () => {

--- a/frontend/src/tests/msw/interceptors/ClientRequest.ts
+++ b/frontend/src/tests/msw/interceptors/ClientRequest.ts
@@ -1,0 +1,5 @@
+import { loadInterceptor } from "./resolve";
+
+const interceptor = loadInterceptor("ClientRequest");
+
+export = interceptor;

--- a/frontend/src/tests/msw/interceptors/RemoteHttpInterceptor.ts
+++ b/frontend/src/tests/msw/interceptors/RemoteHttpInterceptor.ts
@@ -1,0 +1,5 @@
+import { loadInterceptor } from "./resolve";
+
+const interceptor = loadInterceptor("RemoteHttpInterceptor");
+
+export = interceptor;

--- a/frontend/src/tests/msw/interceptors/XMLHttpRequest.ts
+++ b/frontend/src/tests/msw/interceptors/XMLHttpRequest.ts
@@ -1,0 +1,5 @@
+import { loadInterceptor } from "./resolve";
+
+const interceptor = loadInterceptor("XMLHttpRequest");
+
+export = interceptor;

--- a/frontend/src/tests/msw/interceptors/fetch.ts
+++ b/frontend/src/tests/msw/interceptors/fetch.ts
@@ -1,0 +1,5 @@
+import { loadInterceptor } from "./resolve";
+
+const interceptor = loadInterceptor("fetch");
+
+export = interceptor;

--- a/frontend/src/tests/msw/interceptors/resolve.ts
+++ b/frontend/src/tests/msw/interceptors/resolve.ts
@@ -1,0 +1,41 @@
+import path from "path";
+
+type InterceptorModule = Record<string, unknown>;
+
+const candidates = [
+  path.resolve(
+    __dirname,
+    "../../../..",
+    "node_modules",
+    "@mswjs",
+    "interceptors",
+    "lib",
+    "node",
+    "interceptors"
+  ),
+  path.resolve(
+    __dirname,
+    "../../../../../",
+    "node_modules",
+    ".pnpm",
+    "node_modules",
+    "@mswjs",
+    "interceptors",
+    "lib",
+    "node",
+    "interceptors"
+  ),
+];
+
+export function loadInterceptor(target: string): InterceptorModule {
+  for (const basePath of candidates) {
+    try {
+      // eslint-disable-next-line import/no-dynamic-require, global-require
+      return require(path.join(basePath, target, "index.js")) as InterceptorModule;
+    } catch (error) {
+      // Continue searching in other candidates
+    }
+  }
+
+  throw new Error(`No se pudo resolver el interceptor ${target}`);
+}


### PR DESCRIPTION
## Summary
- add a safe Recharts mock and Jest mapping so chart tests render deterministically
- introduce reusable ErrorBoundary, Skeleton, and EmptyState components and wrap dashboard, portfolio, and news panels with graceful fallbacks
- extend MSW interceptor resolution for pnpm layouts and update tests to cover new loading/empty states and boundary behaviour

## Testing
- pnpm test:dev src/components/news/__tests__/news-panel.test.tsx src/components/portfolio/__tests__/PortfolioPanel.test.tsx src/components/common/__tests__/ErrorBoundary.test.tsx
- pnpm test:frontend *(fails: Jest cannot transform msw dependency `until-async` under pnpm `.pnpm` layout without additional tooling)*

------
https://chatgpt.com/codex/tasks/task_e_68ddb96701048321a4353c8b7d777843