### PR TITLE
feat: observability, portfolio CSV, and CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,56 @@
+name: CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+
+jobs:
+  frontend-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "18"
+          cache: "pnpm"
+
+      - name: Install pnpm
+        run: corepack enable
+
+      - name: Install frontend dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run frontend tests
+        run: pnpm test:frontend
+
+  backend-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+          cache-dependency-path: backend/requirements.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r backend/requirements.txt
+          pip install diff-cover
+          corepack enable
+
+      - name: Run backend tests with coverage
+        run: pnpm test:backend:cov
+
+      - name: Generate coverage XML
+        run: python -m coverage xml -i
+
+      - name: Diff coverage (informativo)
+        if: github.event_name == 'pull_request'
+        run: |
+          git fetch origin ${{ github.event.pull_request.base.ref }} --depth=1
+          diff-cover coverage.xml --compare-branch origin/${{ github.event.pull_request.base.ref }} --fail-under=80 || true

--- a/backend/core/logging_config.py
+++ b/backend/core/logging_config.py
@@ -63,5 +63,9 @@ def log_event(
     if extra:
         payload.update(extra)
 
-    log_method = logger.warning if level == "warning" else logger.info
+    normalized_level = level.lower()
+    log_method = getattr(logger, normalized_level, None)
+    if not callable(log_method):
+        log_method = logger.info
+
     log_method(payload)

--- a/backend/core/rate_limit.py
+++ b/backend/core/rate_limit.py
@@ -1,0 +1,64 @@
+"""Shared helpers for rate limit dependencies with graceful fallbacks."""
+
+from __future__ import annotations
+
+import time
+from collections import defaultdict
+from typing import Awaitable, Callable, Dict
+
+from fastapi import HTTPException, Request, Response
+from fastapi_limiter import FastAPILimiter
+from fastapi_limiter.depends import RateLimiter
+
+_IN_MEMORY_BUCKETS: Dict[str, list[float]] = defaultdict(list)
+
+
+def rate_limit(
+    *,
+    times: int,
+    seconds: int,
+    identifier: str,
+    detail: str = "Too Many Requests",
+    fallback_times: int | None = None,
+) -> Callable[[Request, Response], Awaitable[None]]:
+    """Return a dependency that enforces rate limits with Redis or an in-memory fallback."""
+
+    limiter = RateLimiter(times=times, seconds=seconds)
+    bucket_prefix = f"{identifier}:{times}:{seconds}"
+    fallback_limit = fallback_times or times
+
+    async def _dependency(request: Request, response: Response) -> None:
+        redis_client = getattr(FastAPILimiter, "redis", None)
+        if redis_client is not None:
+            try:
+                await limiter(request, response)
+                return
+            except Exception:
+                # Redis sin inicializar; cae al modo en memoria
+                pass
+
+        client_host = request.client.host if request.client else "unknown"
+        bucket_key = f"{client_host}:{bucket_prefix}"
+        window = _IN_MEMORY_BUCKETS[bucket_key]
+        now = time.monotonic()
+        window[:] = [tick for tick in window if now - tick < seconds]
+        if len(window) >= fallback_limit:
+            raise HTTPException(status_code=429, detail=detail)
+        window.append(now)
+
+    return _dependency
+
+
+def reset_rate_limiter_cache(identifier: str | None = None) -> None:
+    """Utility used in tests to reset the fallback buckets."""
+
+    if identifier is None:
+        _IN_MEMORY_BUCKETS.clear()
+        return
+
+    keys = [key for key in _IN_MEMORY_BUCKETS if key.startswith(identifier)]
+    for key in keys:
+        _IN_MEMORY_BUCKETS.pop(key, None)
+
+
+__all__ = ["rate_limit", "reset_rate_limiter_cache"]

--- a/backend/routers/health.py
+++ b/backend/routers/health.py
@@ -1,59 +1,93 @@
+import asyncio
 import os
-import os
-import time
-from collections import defaultdict
+from typing import Any, Dict
 
-from fastapi import APIRouter, Depends, HTTPException, Request, Response
+from fastapi import APIRouter, Depends
+from fastapi.responses import JSONResponse
 from fastapi_limiter import FastAPILimiter
-from fastapi_limiter.depends import RateLimiter
+from sqlalchemy import text
+
+from backend.core.logging_config import get_logger, log_event
+from backend.core.rate_limit import rate_limit
+from backend import database as database_module
 
 # No necesitamos poner prefix aquí, ya lo maneja main.py
 router = APIRouter(tags=["health"])
+logger = get_logger(service="health_router")
+_health_rate_limit = rate_limit(
+    times=5,
+    seconds=60,
+    identifier="health_endpoint",
+    detail="Demasiadas consultas al healthcheck. Intenta nuevamente más tarde.",
+)
 
-# Fallback simple en memoria si no hay Redis (5 req/60s por IP)
-_REQUEST_HISTORY = defaultdict(list)
 
+async def _check_redis() -> Dict[str, Any]:
+    client = getattr(FastAPILimiter, "redis", None)
+    if client is None:
+        return {"status": "skipped", "detail": "redis_not_configured"}
 
-async def _rate_limit_dependency(request: Request, response: Response):
-    """
-    Aplica rate limit. Si FastAPILimiter tiene Redis inicializado, usa RateLimiter real.
-    Si no, aplica un fallback in-memory por IP (5 req / 60s).
-    """
     try:
-        # Con Redis disponible: usa el RateLimiter oficial
-        if getattr(FastAPILimiter, "redis", None):
-            limiter = RateLimiter(times=5, seconds=60)
-            # ⬇️ Firma correcta: (request, response)
-            return await limiter(request, response)
+        await asyncio.wait_for(client.ping(), timeout=0.5)
+    except Exception as exc:  # pragma: no cover - logging defensive
+        log_event(
+            logger,
+            service="health_router",
+            event="redis_ping_error",
+            level="error",
+            error=str(exc),
+        )
+        return {"status": "error", "detail": str(exc)}
 
-        # Fallback local sin Redis
-        identifier = request.client.host if request.client and request.client.host else "local"
-        window = _REQUEST_HISTORY[identifier]
-        now = time.monotonic()
-        window[:] = [tick for tick in window if now - tick < 60]  # ventana 60s
-        if len(window) >= 5:
-            raise HTTPException(status_code=429, detail="Too Many Requests")
-        window.append(now)
-        return
-    except HTTPException:
-        # Propaga 429 u otros HTTPException
-        raise
-    except Exception as e:
-        # Cualquier error inesperado NO debe romper el endpoint
-        raise HTTPException(status_code=500, detail=f"rate_limit_error: {type(e).__name__}") from e
+    return {"status": "ok"}
 
 
-@router.get("", dependencies=[Depends(_rate_limit_dependency)])
-@router.get("/", dependencies=[Depends(_rate_limit_dependency)])
+async def _check_database() -> Dict[str, Any]:
+    engine = getattr(database_module, "engine", None)
+    if engine is None:
+        return {"status": "skipped", "detail": "engine_not_configured"}
+
+    def _ping() -> None:
+        with engine.connect() as connection:
+            connection.execute(text("SELECT 1"))
+
+    try:
+        await asyncio.wait_for(asyncio.to_thread(_ping), timeout=1.0)
+    except Exception as exc:  # pragma: no cover - logging defensive
+        log_event(
+            logger,
+            service="health_router",
+            event="database_ping_error",
+            level="error",
+            error=str(exc),
+        )
+        return {"status": "error", "detail": str(exc)}
+
+    return {"status": "ok"}
+
+
+@router.get("", dependencies=[Depends(_health_rate_limit)])
+@router.get("/", dependencies=[Depends(_health_rate_limit)])
 async def health():
     """
     Endpoint básico de salud para monitoreo.
     Devuelve un 'ok' y el entorno actual.
     """
-    return {
-        "status": "ok",
+    redis_status = await _check_redis()
+    db_status = await _check_database()
+
+    services = {"redis": redis_status, "database": db_status}
+    has_errors = any(service["status"] == "error" for service in services.values())
+    body = {
+        "status": "ok" if not has_errors else "degraded",
         "env": os.getenv("ENV", "unknown"),
+        "services": services,
     }
+
+    if has_errors:
+        return JSONResponse(status_code=503, content=body)
+
+    return body
 
 
 @router.get("/ping")

--- a/backend/schemas/portfolio.py
+++ b/backend/schemas/portfolio.py
@@ -38,8 +38,21 @@ class PortfolioSummaryResponse(BaseModel):
     total_value: float
 
 
+class PortfolioImportError(BaseModel):
+    row: int
+    message: str
+
+
+class PortfolioImportResult(BaseModel):
+    created: int
+    items: List[PortfolioItemResponse]
+    errors: List[PortfolioImportError]
+
+
 __all__ = [
     "PortfolioCreate",
     "PortfolioItemResponse",
     "PortfolioSummaryResponse",
+    "PortfolioImportError",
+    "PortfolioImportResult",
 ]

--- a/backend/tests/test_rate_limits.py
+++ b/backend/tests/test_rate_limits.py
@@ -1,0 +1,70 @@
+import uuid
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from fastapi import HTTPException, Request
+from starlette.responses import Response
+
+from backend.core.rate_limit import reset_rate_limiter_cache
+from backend.main import app
+from backend.routers import alerts as alerts_router
+from backend.routers import auth as auth_router
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _reset_rate_limits() -> None:
+    reset_rate_limiter_cache()
+    yield
+    reset_rate_limiter_cache()
+
+
+class _StubUserService:
+    def authenticate_user(self, *args, **kwargs):  # noqa: ANN001, D401 - simple stub
+        raise auth_router.InvalidCredentialsError("Credenciales inválidas")
+
+
+@pytest.mark.asyncio()
+async def test_login_rate_limit_returns_429(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(auth_router, "user_service", _StubUserService())
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app, client=(f"auth-rate-{uuid.uuid4()}", 80)),
+        base_url="http://testserver",
+    ) as client:
+        for _ in range(5):
+            resp = await client.post(
+                "/api/auth/login",
+                json={"email": "user@example.com", "password": "invalid"},
+            )
+            assert resp.status_code == 401
+
+        final = await client.post(
+            "/api/auth/login",
+            json={"email": "user@example.com", "password": "invalid"},
+        )
+
+    assert final.status_code == 429
+
+
+@pytest.mark.asyncio()
+async def test_alert_dispatch_rate_limit() -> None:
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/api/alerts/send",
+        "headers": [(b"host", b"testserver"), (b"authorization", b"bearer token")],
+        "client": ("127.0.0.1", 9000),
+        "scheme": "http",
+        "server": ("testserver", 80),
+    }
+    request = Request(scope)
+    response = Response()
+
+    for _ in range(5):
+        await alerts_router._dispatch_alert_rate_limit(request, response)
+
+    with pytest.raises(HTTPException) as excinfo:
+        await alerts_router._dispatch_alert_rate_limit(request, response)
+
+    assert excinfo.value.status_code == 429

--- a/frontend/src/lib/__tests__/featureFlags.test.ts
+++ b/frontend/src/lib/__tests__/featureFlags.test.ts
@@ -1,0 +1,32 @@
+import { __resetFeatureFlagsForTests, getFeatureFlag } from "../featureFlags";
+
+describe("feature flags utility", () => {
+  beforeEach(() => {
+    __resetFeatureFlagsForTests();
+    delete process.env.NEXT_PUBLIC_FEATURE_FLAGS;
+  });
+
+  it("interprets JSON arrays", () => {
+    process.env.NEXT_PUBLIC_FEATURE_FLAGS = JSON.stringify(["portfolio-csv", "beta"]);
+    expect(getFeatureFlag("portfolio-csv")).toBe(true);
+    expect(getFeatureFlag("missing")).toBe(false);
+  });
+
+  it("interprets JSON objects with various truthy values", () => {
+    process.env.NEXT_PUBLIC_FEATURE_FLAGS = JSON.stringify({
+      "portfolio-csv": true,
+      other: "true",
+      disabled: false,
+    });
+    expect(getFeatureFlag("portfolio-csv")).toBe(true);
+    expect(getFeatureFlag("other")).toBe(true);
+    expect(getFeatureFlag("disabled")).toBe(false);
+  });
+
+  it("falls back to comma separated strings", () => {
+    process.env.NEXT_PUBLIC_FEATURE_FLAGS = "portfolio-csv, another";
+    expect(getFeatureFlag("portfolio-csv")).toBe(true);
+    expect(getFeatureFlag("another")).toBe(true);
+    expect(getFeatureFlag("absent")).toBe(false);
+  });
+});

--- a/frontend/src/lib/featureFlags.ts
+++ b/frontend/src/lib/featureFlags.ts
@@ -1,0 +1,78 @@
+type FeatureFlags = Record<string, boolean>;
+
+let cachedFlags: FeatureFlags | null = null;
+
+function normalizeFlags(raw: unknown): FeatureFlags {
+  if (!raw) return {};
+
+  if (Array.isArray(raw)) {
+    return raw.reduce<FeatureFlags>((acc, value) => {
+      if (typeof value === "string" && value.trim()) {
+        acc[value.trim()] = true;
+      }
+      return acc;
+    }, {});
+  }
+
+  if (typeof raw === "object") {
+    return Object.entries(raw as Record<string, unknown>).reduce<FeatureFlags>(
+      (acc, [key, value]) => {
+        if (!key) return acc;
+        const normalized = String(key).trim();
+        if (!normalized) return acc;
+        if (typeof value === "boolean") {
+          acc[normalized] = value;
+        } else if (typeof value === "string") {
+          acc[normalized] = value.toLowerCase() in { true: true, on: true, yes: true };
+        } else if (typeof value === "number") {
+          acc[normalized] = value !== 0;
+        }
+        return acc;
+      },
+      {}
+    );
+  }
+
+  if (typeof raw === "string") {
+    const parts = raw
+      .split(/[,\s]+/)
+      .map((part) => part.trim())
+      .filter(Boolean);
+    return parts.reduce<FeatureFlags>((acc, value) => {
+      acc[value] = true;
+      return acc;
+    }, {});
+  }
+
+  return {};
+}
+
+function loadFeatureFlags(): FeatureFlags {
+  if (cachedFlags) {
+    return cachedFlags;
+  }
+
+  const raw = process.env.NEXT_PUBLIC_FEATURE_FLAGS;
+  if (!raw) {
+    cachedFlags = {};
+    return cachedFlags;
+  }
+
+  try {
+    const parsed = JSON.parse(raw);
+    cachedFlags = normalizeFlags(parsed);
+  } catch {
+    cachedFlags = normalizeFlags(raw);
+  }
+
+  return cachedFlags;
+}
+
+export function getFeatureFlag(name: string): boolean {
+  const flags = loadFeatureFlags();
+  return Boolean(flags[name]);
+}
+
+export function __resetFeatureFlagsForTests(): void {
+  cachedFlags = null;
+}


### PR DESCRIPTION
## Summary
- add a reusable rate_limit helper, migrate critical routers to structured log_event usage, and harden the health check with Redis/DB probes
- expose the /metrics endpoint, extend observability tests, and introduce rate limit coverage to prevent regressions
- deliver portfolio CSV import/export flows behind a feature flag with backend validation plus frontend UI and tests
- configure a CI workflow that exercises frontend and backend suites with cached dependencies and diff coverage reporting

## Testing
- not run (environment missing node/pnpm tooling)


------
https://chatgpt.com/codex/tasks/task_e_68ddc0b253cc8321bd5c4e581dc7aaf5