### PR TITLE
Key login rate limits by email

### DIFF
--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -13,7 +13,7 @@ import re
 from pydantic import BaseModel, field_validator
 
 from backend.core.logging_config import get_logger, log_event
-from backend.core.rate_limit import rate_limit
+from backend.core.rate_limit import login_rate_limiter, rate_limit
 from backend.core.security import create_access_token, create_refresh_token, decode_refresh
 from backend.database import get_db
 from backend.models import User
@@ -30,12 +30,7 @@ router = APIRouter(prefix="/api/auth", tags=["auth"])
 security = HTTPBearer()
 logger = get_logger(service="auth_router")
 
-_login_rate_limit = rate_limit(
-    times=5,
-    seconds=60,
-    identifier="auth_login",
-    detail="Demasiados intentos de inicio de sesión. Intenta nuevamente más tarde.",
-)
+_login_rate_limit = login_rate_limiter(times=5, seconds=60)
 _refresh_rate_limit = rate_limit(
     times=10,
     seconds=120,


### PR DESCRIPTION
## Summary
- add a login-specific rate limiter keyed by email with in-memory fallback support
- apply the new limiter to the authentication router and keep refresh limits unchanged
- clear Redis counters during startup when running in testing mode to avoid stale rate limit state

## Testing
- pytest backend/tests/test_auth_flow.py -q
- pytest backend/tests/test_auth_refresh.py -q
- pytest backend/tests/test_auth_resilience.py -q
- pytest backend/tests/test_chat_history.py -q
- pytest backend/tests/test_push_notifications.py -q
- pytest backend/tests/test_api_endpoints.py::test_alert_workflow_triggers_notification -q
- pytest backend/tests/test_api_endpoints.py::test_alerts_list_returns_created_alert -q
- pytest backend -q

------
https://chatgpt.com/codex/tasks/task_e_68ddd5743420832195164bb5efa902e9