### PR TITLE
Adjust Ruff extend exclude ordering

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ skip_glob = ["backend/alembic/*"]
 line-length = 100
 target-version = "py312"
 src = ["backend"]
-extend-exclude = [".venv", "backend/alembic", "alembic"]
+extend-exclude = [".venv", "alembic", "backend/alembic"]
 select = ["E", "F", "I", "UP", "B", "SIM", "PIE"]
 ignore = []
 


### PR DESCRIPTION
## Summary
- reorder the Ruff extend-exclude list to keep .venv ahead of other entries

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de8a94e20083218e066cd1daae4a86