### PR TITLE
Add database setup error alias log for table creation failures

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -83,7 +83,28 @@ def create_all_if_local(engine) -> None:
         )
         return
 
-    Base.metadata.create_all(bind=engine)
+    try:
+        Base.metadata.create_all(bind=engine)
+    except Exception as error:  # pragma: no cover - defensive logging
+        logger.warning(
+            {
+                "service": "database",
+                "event": "database_autocreate_failed",
+                "env": "local",
+                "error": str(error),
+                "level": "warning",
+            }
+        )
+        logger.warning(
+            {
+                "service": "app",
+                "event": "database_setup_error",
+                "error": str(error),
+                "level": "warning",
+            }
+        )
+        return
+
     logger.info(
         {
             "service": "database",


### PR DESCRIPTION
## Summary
- wrap metadata creation in a defensive try/except to preserve startup flow
- log the existing database_autocreate_failed event and emit the compatibility database_setup_error alias

## Testing
- ENV=test ENVIRONMENT=test .venv/bin/pytest backend/tests/test_main_resilience.py::test_lifespan_logs_database_setup_error -q *(fails: virtual environment not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68debfb857948321b79551170f11ec57