### PR TITLE
Fix sys.path setup for generate_postman script

### DIFF
--- a/scripts/generate_postman.py
+++ b/scripts/generate_postman.py
@@ -2,7 +2,12 @@
 import json
 import argparse
 from pathlib import Path
+import sys
 from fastapi.openapi.utils import get_openapi
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
 
 # Importa la app principal
 from backend.main import app  # si no existe aquí, ajusta a la ruta real sin romper el proyecto


### PR DESCRIPTION
## Summary
- add the repository root to `sys.path` so `scripts/generate_postman.py` can import `backend.main`

## Testing
- python scripts/generate_postman.py --export-openapi
- python scripts/generate_postman.py

------
https://chatgpt.com/codex/tasks/task_e_68dec1263c048321a07775b3c1223e51