### PR TITLE
Fix formatting config and log database setup errors

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -87,6 +87,7 @@ async def lifespan(app: FastAPI):
                 Base.metadata.create_all(bind=database_engine, checkfirst=True)
                 logger.info("database_ready")
             except Exception as exc:
+                logger.error("database_setup_error", exc_info=True)
                 database_ready = False
                 database_setup_failed = True
                 database_setup_error_message = str(exc)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -11,8 +11,8 @@ fastapi-limiter==0.1.6
 # Seguridad / Autenticación
 PyJWT==2.9.0
 python-jose[cryptography]==3.3.0
-passlib[bcrypt]==1.7.4
-bcrypt==4.2.0
+passlib==1.7.4
+bcrypt==4.0.1
 
 # ORM y DB
 SQLAlchemy==2.0.35

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ ignore = []
 
 [tool.ruff.format]
 indent-style = "space"
-indent-width = 4
 quote-style = "double"
 skip-magic-trailing-comma = false
 line-ending = "lf"


### PR DESCRIPTION
## Summary
- ensure the Ruff formatter configuration prefers spaces by dropping the redundant indent-width override
- pin bcrypt and passlib to the requested versions in the backend requirements
- add structured error logging with stack traces when database initialization fails during app startup

## Testing
- pre-commit run --all-files *(fails: command not found)*
- ENV=test ENVIRONMENT=test pytest backend -q *(fails: sqlite OperationalError because the users table is missing when running with ENV=test)*

------
https://chatgpt.com/codex/tasks/task_e_68dec6580c3883219a4bfddcc385c46d