### PR TITLE
Ensure database setup runs in test environment

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -80,7 +80,7 @@ async def lifespan(app: FastAPI):
 
         database_engine = getattr(database_module, "engine", None)
         database_ready = True
-        if ENV == "local":
+        if ENV in {"local", "test"}:
             try:
                 if database_engine is None:
                     raise RuntimeError("database engine is not configured")


### PR DESCRIPTION
## Summary
- allow the database setup branch to execute when running with ENV=test so metadata creation and resilience logging work during tests

## Testing
- ENV=test ENVIRONMENT=test pytest backend -q

------
https://chatgpt.com/codex/tasks/task_e_68dec95a45d88321bc31ef91c08524ea