### PR TITLE
Ensure routers and services meet Ruff linting rules

### DIFF
--- a/backend/routers/alerts.py
+++ b/backend/routers/alerts.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from typing import Dict, Optional, List
+from typing import Annotated
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
@@ -13,11 +13,19 @@ from pydantic import BaseModel, Field, field_validator
 from backend.core.logging_config import get_logger, log_event
 from backend.core.metrics import ALERTS_RATE_LIMITED
 from backend.core.rate_limit import rate_limit
+from backend.schemas.alert import (
+    AlertCreate,
+    AlertResponse,
+    AlertSuggestionPayload,
+    AlertSuggestionResult,
+    AlertUpdate,
+)
+from backend.utils.config import Config
 
-USER_SERVICE_ERROR: Optional[Exception] = None
+USER_SERVICE_ERROR: Exception | None = None
 
 try:  # pragma: no cover - allow running from different entrypoints
-    from backend.models import Alert, User
+    from backend.models import User
     from backend.services.alert_service import alert_service
     from backend.services.user_service import (
         InvalidTokenError,
@@ -25,14 +33,14 @@ try:  # pragma: no cover - allow running from different entrypoints
         user_service,
     )
 except RuntimeError as exc:  # pragma: no cover - missing configuration
-    from backend.models import Alert, User  # type: ignore
+    from backend.models import User  # type: ignore
 
     user_service = None  # type: ignore[assignment]
     UserNotFoundError = RuntimeError  # type: ignore[assignment]
     InvalidTokenError = RuntimeError  # type: ignore[assignment]
     USER_SERVICE_ERROR = exc
 except ImportError:  # pragma: no cover - fallback for package-based imports
-    from backend.models import Alert, User  # type: ignore
+    from backend.models import User  # type: ignore
 
     try:
         from backend.services.alert_service import alert_service  # type: ignore
@@ -49,22 +57,13 @@ except ImportError:  # pragma: no cover - fallback for package-based imports
     except ImportError:  # pragma: no cover - fallback when running from app package
         from services.alert_service import alert_service  # type: ignore
 
-from backend.schemas.alert import (
-    AlertCreate,
-    AlertResponse,
-    AlertSuggestionPayload,
-    AlertSuggestionResult,
-    AlertUpdate,
-)
-from backend.utils.config import Config
-
 # 👇 sin prefix aquí
 router = APIRouter(tags=["alerts"])
 security = HTTPBearer()
 logger = get_logger(service="alerts_router")
 
 def _record_alert_rate_limit(request: Request, action: str) -> None:
-    payload: Dict[str, object] = {
+    payload: dict[str, object] = {
         "service": "alerts_router",
         "event": "alerts_rate_limited",
         "level": "warning",
@@ -95,8 +94,8 @@ _dispatch_alert_rate_limit = rate_limit(
 
 class AlertDispatchRequest(BaseModel):
     message: str = Field(..., min_length=1, max_length=500)
-    telegram_chat_id: Optional[str] = None
-    discord_channel_id: Optional[str] = None
+    telegram_chat_id: str | None = None
+    discord_channel_id: str | None = None
 
     @field_validator("message")
     @classmethod
@@ -108,7 +107,7 @@ class AlertDispatchRequest(BaseModel):
 
     @field_validator("telegram_chat_id", "discord_channel_id")
     @classmethod
-    def _strip_optional(cls, value: Optional[str]) -> Optional[str]:
+    def _strip_optional(cls, value: str | None) -> str | None:
         if value is None:
             return value
         cleaned = value.strip()
@@ -131,7 +130,7 @@ def _ensure_user_service_available() -> None:
 
 
 async def get_current_user(
-    credentials: HTTPAuthorizationCredentials = Depends(security),
+    credentials: Annotated[HTTPAuthorizationCredentials, Depends(security)]
 ) -> User:
     _ensure_user_service_available()
 
@@ -143,8 +142,10 @@ async def get_current_user(
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=str(exc)) from exc
 
 
-@router.get("", response_model=List[AlertResponse])
-async def list_alerts(current_user: User = Depends(get_current_user)) -> List[AlertResponse]:
+@router.get("", response_model=list[AlertResponse])
+async def list_alerts(
+    current_user: Annotated[User, Depends(get_current_user)]
+) -> list[AlertResponse]:
     """List alerts for the authenticated user."""
 
     _ensure_user_service_available()
@@ -160,7 +161,8 @@ async def list_alerts(current_user: User = Depends(get_current_user)) -> List[Al
     dependencies=[Depends(_create_alert_rate_limit)],
 )
 async def create_alert(
-    alert_in: AlertCreate, current_user: User = Depends(get_current_user)
+    alert_in: AlertCreate,
+    current_user: Annotated[User, Depends(get_current_user)],
 ) -> AlertResponse:
     """Create a new alert associated with the authenticated user."""
 
@@ -175,7 +177,10 @@ async def create_alert(
     try:
         alert_service.validate_condition_expression(alert_in.condition)
     except ValueError as exc:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
 
     normalized_value = alert_in.value if alert_in.value is not None else 0.0
     normalized_active = alert_in.active if alert_in.active is not None else True
@@ -214,9 +219,11 @@ async def create_alert(
 
 @router.post("/suggest", response_model=AlertSuggestionResult)
 async def suggest_alert_condition(
-    payload: AlertSuggestionPayload, current_user: User = Depends(get_current_user)
+    payload: AlertSuggestionPayload,
+    current_user: Annotated[User, Depends(get_current_user)],
 ) -> AlertSuggestionResult:
-    """Genera una condición sugerida reforzada con IA para agilizar la creación de alertas."""  # [Codex] nuevo
+    """Genera una condición sugerida reforzada con IA para agilizar
+    la creación de alertas."""  # [Codex] nuevo
 
     _ensure_user_service_available()
 
@@ -230,7 +237,7 @@ async def suggest_alert_condition(
 @router.delete("/{alert_id}", status_code=status.HTTP_200_OK)
 async def delete_alert(
     alert_id: UUID,
-    current_user: User = Depends(get_current_user),
+    current_user: Annotated[User, Depends(get_current_user)],
 ) -> dict:
     """Delete an alert owned by the authenticated user."""
 
@@ -252,7 +259,7 @@ async def delete_alert(
 async def update_alert(
     alert_id: UUID,
     alert_in: AlertUpdate,
-    current_user: User = Depends(get_current_user),
+    current_user: Annotated[User, Depends(get_current_user)],
 ) -> AlertResponse:
     """Update an existing alert owned by the authenticated user."""
 
@@ -290,8 +297,8 @@ async def update_alert(
 )
 async def send_alert_notification(
     payload: AlertDispatchRequest,
-    current_user: User = Depends(get_current_user),
-) -> Dict[str, Dict[str, str]]:
+    current_user: Annotated[User, Depends(get_current_user)],
+) -> dict[str, dict[str, str]]:
     """Trigger an immediate alert notification via Telegram and/or Discord."""
 
     _ensure_user_service_available()
@@ -328,11 +335,16 @@ async def send_alert_notification(
             level="error",
             error=str(exc),
         )
-        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=str(exc)) from exc
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=str(exc),
+        ) from exc
 
 
 @router.delete("", status_code=status.HTTP_200_OK)
-async def delete_all_alerts(current_user: User = Depends(get_current_user)) -> dict:
+async def delete_all_alerts(
+    current_user: Annotated[User, Depends(get_current_user)]
+) -> dict:
     """Delete all alerts for the authenticated user."""
 
     _ensure_user_service_available()

--- a/backend/routers/health.py
+++ b/backend/routers/health.py
@@ -1,15 +1,15 @@
 import asyncio
 import os
-from typing import Any, Dict
+from typing import Any
 
 from fastapi import APIRouter, Depends
 from fastapi.responses import JSONResponse
 from fastapi_limiter import FastAPILimiter
 from sqlalchemy import text
 
+from backend import database as database_module
 from backend.core.logging_config import get_logger, log_event
 from backend.core.rate_limit import rate_limit
-from backend import database as database_module
 
 # No necesitamos poner prefix aquí, ya lo maneja main.py
 router = APIRouter(tags=["health"])
@@ -22,7 +22,7 @@ _health_rate_limit = rate_limit(
 )
 
 
-async def _check_redis() -> Dict[str, Any]:
+async def _check_redis() -> dict[str, Any]:
     client = getattr(FastAPILimiter, "redis", None)
     if client is None:
         return {"status": "skipped", "detail": "redis_not_configured"}
@@ -42,7 +42,7 @@ async def _check_redis() -> Dict[str, Any]:
     return {"status": "ok"}
 
 
-async def _check_database() -> Dict[str, Any]:
+async def _check_database() -> dict[str, Any]:
     engine = getattr(database_module, "engine", None)
     if engine is None:
         return {"status": "skipped", "detail": "engine_not_configured"}

--- a/backend/routers/news.py
+++ b/backend/routers/news.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Any, Awaitable, Callable, Dict, List
+from collections.abc import Awaitable, Callable
+from typing import Any
 
 from fastapi import APIRouter, HTTPException
 
@@ -14,14 +15,14 @@ except ImportError:  # pragma: no cover - fallback for package-based imports
 router = APIRouter(tags=["News"])
 
 
-NewsFetcher = Callable[[int], Awaitable[List[Dict[str, Any]]]]
+NewsFetcher = Callable[[int], Awaitable[list[dict[str, Any]]]]
 
 
 async def _get_news(
     category: str,
     limit: int,
     fetcher: NewsFetcher,
-) -> List[Dict[str, Any]]:
+) -> list[dict[str, Any]]:
     try:
         articles = await fetcher(limit)
     except Exception as exc:  # pragma: no cover - defensive logging happens in the service
@@ -40,7 +41,7 @@ async def _get_news(
 
 
 @router.get("/latest")
-async def get_latest_news(limit: int = 20) -> Dict[str, Any]:
+async def get_latest_news(limit: int = 20) -> dict[str, Any]:
     """Aggregate the latest headlines from all providers."""
 
     try:
@@ -61,7 +62,7 @@ async def get_latest_news(limit: int = 20) -> Dict[str, Any]:
 
 
 @router.get("/crypto")
-async def get_crypto_news(limit: int = 10) -> Dict[str, Any]:
+async def get_crypto_news(limit: int = 10) -> dict[str, Any]:
     """Return crypto-related news articles following the configured fallbacks."""
 
     articles = await _get_news("crypto", limit, news_service.get_crypto_headlines)
@@ -69,7 +70,7 @@ async def get_crypto_news(limit: int = 10) -> Dict[str, Any]:
 
 
 @router.get("/finance")
-async def get_finance_news(limit: int = 10) -> Dict[str, Any]:
+async def get_finance_news(limit: int = 10) -> dict[str, Any]:
     """Return finance news articles following the configured fallbacks."""
 
     articles = await _get_news("finance", limit, news_service.get_finance_headlines)

--- a/backend/routers/portfolio.py
+++ b/backend/routers/portfolio.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from typing import Optional
+from typing import Annotated
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, File, HTTPException, UploadFile, status
@@ -18,7 +18,7 @@ from backend.schemas.portfolio import (
     PortfolioSummaryResponse,
 )
 
-USER_SERVICE_ERROR: Optional[Exception] = None
+USER_SERVICE_ERROR: Exception | None = None
 
 try:  # pragma: no cover - allow running from different entrypoints
     from backend.models import User
@@ -60,7 +60,9 @@ def _ensure_user_service_available() -> None:
         raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=detail)
 
 
-async def get_current_user(credentials: HTTPAuthorizationCredentials = Depends(security)) -> User:
+async def get_current_user(
+    credentials: Annotated[HTTPAuthorizationCredentials, Depends(security)]
+) -> User:
     _ensure_user_service_available()
     try:
         return await asyncio.to_thread(
@@ -71,7 +73,9 @@ async def get_current_user(credentials: HTTPAuthorizationCredentials = Depends(s
 
 
 @router.get("", response_model=PortfolioSummaryResponse)
-async def list_portfolio(current_user: User = Depends(get_current_user)) -> PortfolioSummaryResponse:
+async def list_portfolio(
+    current_user: Annotated[User, Depends(get_current_user)]
+) -> PortfolioSummaryResponse:
     summary = await portfolio_service.get_portfolio_overview(current_user.id)
     items = [
         PortfolioItemResponse(
@@ -87,7 +91,9 @@ async def list_portfolio(current_user: User = Depends(get_current_user)) -> Port
 
 
 @router.get("/export", response_class=Response)
-async def export_portfolio(current_user: User = Depends(get_current_user)) -> Response:
+async def export_portfolio(
+    current_user: Annotated[User, Depends(get_current_user)]
+) -> Response:
     csv_payload = await asyncio.to_thread(
         portfolio_service.export_to_csv, current_user.id
     )
@@ -101,7 +107,8 @@ async def export_portfolio(current_user: User = Depends(get_current_user)) -> Re
 
 @router.post("/import", response_model=PortfolioImportResult)
 async def import_portfolio(
-    file: UploadFile = File(...), current_user: User = Depends(get_current_user)
+    file: Annotated[UploadFile, File(...)],
+    current_user: Annotated[User, Depends(get_current_user)],
 ) -> PortfolioImportResult:
     content_type = file.content_type or "text/csv"
     if "csv" not in content_type:
@@ -145,7 +152,8 @@ async def import_portfolio(
 
 @router.post("", response_model=PortfolioItemResponse, status_code=status.HTTP_201_CREATED)
 async def create_portfolio_item(
-    payload: PortfolioCreate, current_user: User = Depends(get_current_user)
+    payload: PortfolioCreate,
+    current_user: Annotated[User, Depends(get_current_user)],
 ) -> PortfolioItemResponse:
     try:
         item = await asyncio.to_thread(
@@ -170,7 +178,8 @@ async def create_portfolio_item(
 
 @router.delete("/{item_id}", status_code=status.HTTP_200_OK)
 async def delete_portfolio_item(
-    item_id: UUID, current_user: User = Depends(get_current_user)
+    item_id: UUID,
+    current_user: Annotated[User, Depends(get_current_user)],
 ) -> dict:
     deleted = await asyncio.to_thread(
         portfolio_service.delete_item, current_user.id, item_id

--- a/backend/services/__init__.py
+++ b/backend/services/__init__.py
@@ -3,8 +3,8 @@
 from .alert_service import AlertService, alert_service
 from .forex_service import ForexService, forex_service
 from .news_service import NewsService, news_service
-from .sentiment_service import SentimentService, sentiment_service
 from .portfolio_service import PortfolioService, portfolio_service
+from .sentiment_service import SentimentService, sentiment_service
 
 __all__ = [
     "AlertService",

--- a/backend/services/alert_service.py
+++ b/backend/services/alert_service.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import Awaitable, Dict, List, Optional, Tuple, NamedTuple
 import re
+from collections.abc import Awaitable
+from typing import NamedTuple
 
 # APScheduler es opcional
 try:
@@ -58,10 +59,10 @@ class AlertService:
     def __init__(
         self,
         *,
-        session_factory: Optional[sessionmaker] = DefaultSessionLocal,
-        scheduler: Optional[AsyncIOScheduler] = None,
+        session_factory: sessionmaker | None = DefaultSessionLocal,
+        scheduler: AsyncIOScheduler | None = None,
         interval_seconds: int = 60,
-        telegram_bot_token: Optional[str] = Config.TELEGRAM_BOT_TOKEN,
+        telegram_bot_token: str | None = Config.TELEGRAM_BOT_TOKEN,
     ) -> None:
         self._session_factory = session_factory
         if scheduler is not None:
@@ -91,7 +92,9 @@ class AlertService:
             LOGGER.warning("AlertService: sin base de datos, se omite el scheduler")
             return
         if self._scheduler is None:
-            LOGGER.warning("AlertService: APScheduler no disponible, las alertas se ejecutarán bajo demanda")
+            LOGGER.warning(
+                "AlertService: APScheduler no disponible, las alertas se ejecutarán bajo demanda"
+            )
             return
         if not self._scheduler.running:
             self._scheduler.start()
@@ -117,7 +120,7 @@ class AlertService:
         if not alerts:
             return
 
-        triggered: List[Tuple[Alert, float]] = []
+        triggered: list[tuple[Alert, float]] = []
         for alert in alerts:
             if not getattr(alert, "active", True):
                 continue
@@ -133,7 +136,7 @@ class AlertService:
         for alert, price in triggered:
             await self._notify(alert, price)
 
-    def _fetch_alerts(self) -> List[Alert]:
+    def _fetch_alerts(self) -> list[Alert]:
         assert self._session_factory is not None
         with self._session_factory() as session:
             result = session.scalars(select(Alert).where(Alert.active.is_(True))).all()
@@ -141,7 +144,7 @@ class AlertService:
                 session.expunge(alert)
             return result
 
-    async def _resolve_price(self, symbol: str) -> Optional[float]:
+    async def _resolve_price(self, symbol: str) -> float | None:
         stock = await market_service.get_stock_price(symbol)
         if stock and stock.get("price") is not None:
             return float(stock["price"])
@@ -199,7 +202,7 @@ class AlertService:
         except Exception as exc:
             LOGGER.warning("AlertService: error enviando mensaje a Telegram: %s", exc)
 
-    async def suggest_alert_condition(self, asset: str, interval: str = "1h") -> Dict[str, str]:
+    async def suggest_alert_condition(self, asset: str, interval: str = "1h") -> dict[str, str]:
         """Genera una condición sugerida usando IA para un activo dado."""  # [Codex] nuevo
         asset_clean = (asset or "").strip().upper()
         if not asset_clean:
@@ -210,8 +213,8 @@ class AlertService:
             interval_norm = "1h"
 
         prompt = (
-            f"Genera una recomendación breve para configurar una alerta automática en el activo {asset_clean} "
-            f"con datos del intervalo {interval_norm}. "
+            "Genera una recomendación breve para configurar una alerta automática "
+            f"en el activo {asset_clean} con datos del intervalo {interval_norm}. "
             "Responde EXACTAMENTE en dos líneas usando el formato:\n"
             "Condición: <regla técnica concisa>\nNota: <explicación corta>."
             "Utiliza indicadores como RSI, MACD, ATR o VWAP según aplique."
@@ -240,7 +243,11 @@ class AlertService:
                 note = line.split(":", 1)[-1].strip() if ":" in line else line
 
         if not condition:
-            condition = ai_text.splitlines()[0].strip() if ai_text.strip() else "Condición no disponible"
+            condition = (
+                ai_text.splitlines()[0].strip()
+                if ai_text.strip()
+                else "Condición no disponible"
+            )
         if not note:
             note = "Generada automáticamente por IA"
 
@@ -267,9 +274,9 @@ class AlertService:
         self,
         *,
         message: str,
-        telegram_chat_id: Optional[str] = None,
-        discord_channel_id: Optional[str] = None,
-    ) -> Dict[str, Dict[str, str]]:
+        telegram_chat_id: str | None = None,
+        discord_channel_id: str | None = None,
+    ) -> dict[str, dict[str, str]]:
         """Send an arbitrary alert message through configured providers."""
 
         targets = []
@@ -281,7 +288,7 @@ class AlertService:
         if not targets:
             raise ValueError("No notification targets were provided")
 
-        results: Dict[str, Dict[str, str]] = {}
+        results: dict[str, dict[str, str]] = {}
         deliveries = []
         for provider, target in targets:
             if provider == "telegram":
@@ -315,7 +322,7 @@ class AlertService:
         provider: str,
         target: str,
         coroutine: Awaitable[None],
-    ) -> Tuple[str, str, Optional[str]]:
+    ) -> tuple[str, str, str | None]:
         try:
             await coroutine
             return provider, target, None
@@ -337,13 +344,14 @@ class AlertService:
 
         url = f"https://api.telegram.org/bot{token}/sendMessage"
         payload = {"chat_id": chat_id, "text": message}
-        async with aiohttp.ClientSession() as session:
-            async with session.post(url, json=payload, timeout=10) as response:
-                if response.status >= 400:
-                    body = await response.text()
-                    raise RuntimeError(
-                        f"Telegram API devolvió estado {response.status}: {body}"
-                    )
+        async with aiohttp.ClientSession() as session, session.post(
+            url, json=payload, timeout=10
+        ) as response:
+            if response.status >= 400:
+                body = await response.text()
+                raise RuntimeError(
+                    f"Telegram API devolvió estado {response.status}: {body}"
+                )
 
     async def _send_discord_message(self, channel_id: str, message: str) -> None:
         if not self._discord_token:
@@ -360,13 +368,14 @@ class AlertService:
         }
         payload = {"content": message}
 
-        async with aiohttp.ClientSession() as session:
-            async with session.post(url, headers=headers, json=payload, timeout=10) as response:
-                if response.status >= 400:
-                    body = await response.text()
-                    raise RuntimeError(
-                        f"Discord API devolvió estado {response.status}: {body}"
-                    )
+        async with aiohttp.ClientSession() as session, session.post(
+            url, headers=headers, json=payload, timeout=10
+        ) as response:
+            if response.status >= 400:
+                body = await response.text()
+                raise RuntimeError(
+                    f"Discord API devolvió estado {response.status}: {body}"
+                )
 
 
 class _ConditionExpressionParser:
@@ -459,8 +468,8 @@ class _ConditionExpressionParser:
             break
 
     # ---- Token utilities -------------------------------------------------
-    def _tokenize(self, expression: str) -> List["_Token"]:
-        tokens: List[_Token] = []
+    def _tokenize(self, expression: str) -> list[_Token]:
+        tokens: list[_Token] = []
         position = 0
         while position < len(expression):
             match = self._TOKEN_REGEX.match(expression, position)
@@ -479,12 +488,12 @@ class _ConditionExpressionParser:
                 tokens.append(_Token(kind.upper(), value))
         return tokens
 
-    def _current(self) -> Optional["_Token"]:
+    def _current(self) -> _Token | None:
         if self.index < len(self.tokens):
             return self.tokens[self.index]
         return None
 
-    def _match(self, token_type: str) -> Optional["_Token"]:
+    def _match(self, token_type: str) -> _Token | None:
         current = self._current()
         if current and current.type == token_type:
             self.index += 1

--- a/backend/services/crypto_service.py
+++ b/backend/services/crypto_service.py
@@ -1,6 +1,6 @@
 import asyncio
 import logging
-from typing import Awaitable, Callable, Dict, Optional, Tuple
+from collections.abc import Awaitable, Callable
 
 import aiohttp
 
@@ -27,7 +27,7 @@ COINGECKO_MAP = {
 }
 
 
-def normalize_symbol(symbol: str) -> Dict[str, str]:
+def normalize_symbol(symbol: str) -> dict[str, str]:
     """
     Normaliza un símbolo tipo 'BTCUSDT' en sus variantes
     para distintos proveedores.
@@ -52,11 +52,11 @@ class CryptoService:
     RETRY_ATTEMPTS = 3
     RETRY_BACKOFF = 0.75
 
-    def __init__(self, cache_client: Optional[CacheClient] = None):
+    def __init__(self, cache_client: CacheClient | None = None):
         self.cache = cache_client or CacheClient("crypto-prices", ttl=45)
-        self._coingecko_id_cache: Dict[str, Optional[str]] = {}
+        self._coingecko_id_cache: dict[str, str | None] = {}
 
-    async def get_price(self, symbol: str) -> Optional[float]:
+    async def get_price(self, symbol: str) -> float | None:
         """Obtener precio de un activo crypto con reintentos y fallback."""
         try:
             cache_key = symbol.upper()
@@ -67,7 +67,7 @@ class CryptoService:
             # 🔹 Normalizamos una sola vez
             normalized = normalize_symbol(symbol)
 
-            providers: Tuple[Tuple[str, Callable[[str], Awaitable[Optional[float]]]], ...] = (
+            providers: tuple[tuple[str, Callable[[str], Awaitable[float | None]]], ...] = (
                 ("CoinGecko", lambda _: self.coingecko(normalized["coingecko"])),
                 ("Binance", lambda _: self.binance(normalized["binance"])),
                 (
@@ -96,7 +96,7 @@ class CryptoService:
             LOGGER.exception("Error getting crypto price for %s: %s", symbol, exc)
             return None
 
-    async def coingecko(self, coin_id: str) -> Optional[float]:
+    async def coingecko(self, coin_id: str) -> float | None:
         """API Primaria: CoinGecko"""
         if not coin_id:
             return None
@@ -110,11 +110,11 @@ class CryptoService:
             return None
 
         price = data.get(coin_id, {}).get("usd")
-        if isinstance(price, (int, float)):
+        if isinstance(price, int | float):
             return float(price)
         return None
 
-    async def binance(self, symbol: str) -> Optional[float]:
+    async def binance(self, symbol: str) -> float | None:
         """API Secundaria: Binance"""
         url = "https://api.binance.com/api/v3/ticker/price"
         params = {"symbol": symbol}  # 🔹 ahora no agregamos 'USDT' extra
@@ -122,7 +122,7 @@ class CryptoService:
         try:
             async with aiohttp.ClientSession(timeout=CLIENT_TIMEOUT) as session:
                 data = await self._request_json(url, session=session, params=params)
-        except (aiohttp.ClientError, asyncio.TimeoutError, ValueError) as exc:
+        except (TimeoutError, aiohttp.ClientError, ValueError) as exc:
             LOGGER.error("Error obteniendo precio en Binance para %s: %s", symbol, exc)
             return None
 
@@ -132,7 +132,7 @@ class CryptoService:
             LOGGER.error("Respuesta inválida de Binance para %s: %s", symbol, exc)
             return None
 
-    async def coinmarketcap(self, symbol: str) -> Optional[float]:
+    async def coinmarketcap(self, symbol: str) -> float | None:
         """API Fallback: CoinMarketCap"""
         if not Config.COINMARKETCAP_API_KEY:
             raise RuntimeError("COINMARKETCAP_API_KEY is not configured")
@@ -145,7 +145,7 @@ class CryptoService:
                 data = await self._request_json(
                     url, session=session, headers=headers, params=params
                 )
-        except (aiohttp.ClientError, asyncio.TimeoutError, ValueError) as exc:
+        except (TimeoutError, aiohttp.ClientError, ValueError) as exc:
             LOGGER.error("Error obteniendo precio en CoinMarketCap para %s: %s", symbol, exc)
             return None
 
@@ -156,7 +156,7 @@ class CryptoService:
             LOGGER.error("Respuesta inválida de CoinMarketCap para %s: %s", symbol, exc)
             return None
 
-    async def twelvedata(self, pair: str) -> Optional[float]:
+    async def twelvedata(self, pair: str) -> float | None:
         """Support crypto pricing using TwelveData when API key is available."""
 
         if not Config.TWELVEDATA_API_KEY:
@@ -168,7 +168,7 @@ class CryptoService:
         try:
             async with aiohttp.ClientSession(timeout=CLIENT_TIMEOUT) as session:
                 data = await self._request_json(url, session=session, params=params)
-        except (aiohttp.ClientError, asyncio.TimeoutError, ValueError) as exc:
+        except (TimeoutError, aiohttp.ClientError, ValueError) as exc:
             LOGGER.error("Error obteniendo precio en TwelveData para %s: %s", pair, exc)
             return None
 
@@ -178,7 +178,7 @@ class CryptoService:
             LOGGER.error("Respuesta inválida de TwelveData para %s: %s", pair, exc)
             return None
 
-    async def alpha_vantage(self, symbol: str) -> Optional[float]:
+    async def alpha_vantage(self, symbol: str) -> float | None:
         """Fallback provider using Alpha Vantage currency exchange endpoint."""
 
         if not Config.ALPHA_VANTAGE_API_KEY:
@@ -195,7 +195,7 @@ class CryptoService:
         try:
             async with aiohttp.ClientSession(timeout=CLIENT_TIMEOUT) as session:
                 data = await self._request_json(url, session=session, params=params)
-        except (aiohttp.ClientError, asyncio.TimeoutError, ValueError) as exc:
+        except (TimeoutError, aiohttp.ClientError, ValueError) as exc:
             LOGGER.error("Error obteniendo precio en Alpha Vantage para %s: %s", symbol, exc)
             return None
 
@@ -211,7 +211,7 @@ class CryptoService:
         self,
         url: str,
         *,
-        session: Optional[aiohttp.ClientSession] = None,
+        session: aiohttp.ClientSession | None = None,
         **kwargs,
     ):
         owns_session = session is None
@@ -220,14 +220,14 @@ class CryptoService:
             async with session.get(url, **kwargs) as response:
                 response.raise_for_status()
                 return await response.json()
-        except (aiohttp.ClientError, asyncio.TimeoutError, ValueError) as exc:
+        except (TimeoutError, aiohttp.ClientError, ValueError) as exc:
             LOGGER.error("Error al solicitar %s: %s", url, exc)
             raise
         finally:
             if owns_session:
                 await session.close()
 
-    async def _resolve_coingecko_id(self, symbol: str) -> Optional[str]:
+    async def _resolve_coingecko_id(self, symbol: str) -> str | None:
         normalized = symbol.lower()
         if normalized in self._coingecko_id_cache:
             return self._coingecko_id_cache[normalized]
@@ -253,10 +253,10 @@ class CryptoService:
 
     async def _call_with_retries(
         self,
-        handler: Callable[[str], Awaitable[Optional[float]]],
+        handler: Callable[[str], Awaitable[float | None]],
         symbol: str,
         source_name: str,
-    ) -> Optional[float]:
+    ) -> float | None:
         backoff = self.RETRY_BACKOFF
         for attempt in range(1, self.RETRY_ATTEMPTS + 1):
             try:

--- a/backend/services/forex_service.py
+++ b/backend/services/forex_service.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import asyncio
-from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+from collections.abc import Sequence
+from typing import Any
 
 import aiohttp
 from aiohttp import ClientError, ClientTimeout, ContentTypeError
@@ -25,7 +26,7 @@ class ForexService:
     def __init__(
         self,
         *,
-        cache_client: Optional[CacheClient] = None,
+        cache_client: CacheClient | None = None,
         session_factory=aiohttp.ClientSession,
     ) -> None:
         self.cache = cache_client or CacheClient("forex-quotes", ttl=60)
@@ -53,7 +54,7 @@ class ForexService:
             },
         )
 
-    async def get_quote(self, symbol: str) -> Optional[Dict[str, Any]]:
+    async def get_quote(self, symbol: str) -> dict[str, Any] | None:
         """Devuelve información de precio para ``symbol``."""
 
         normalized = self._normalize_symbol(symbol)
@@ -63,7 +64,7 @@ class ForexService:
             return cached_value
 
         async with self._session_factory(timeout=self._timeout) as session:
-            attempted_sources: List[str] = []
+            attempted_sources: list[str] = []
             for api in self.apis:
                 if api["requires_key"] and not api["api_key"]:
                     continue
@@ -85,10 +86,10 @@ class ForexService:
 
         return None
 
-    async def get_quotes(self, symbols: Sequence[str]) -> Dict[str, Optional[Dict[str, Any]]]:
+    async def get_quotes(self, symbols: Sequence[str]) -> dict[str, dict[str, Any] | None]:
         """Obtiene cotizaciones para múltiples símbolos."""
 
-        results: Dict[str, Optional[Dict[str, Any]]] = {}
+        results: dict[str, dict[str, Any] | None] = {}
         for symbol in symbols:
             results[symbol] = await self.get_quote(symbol)
         return results
@@ -99,13 +100,13 @@ class ForexService:
         session: aiohttp.ClientSession,
         symbol: str,
         source_name: str,
-    ) -> Optional[Dict[str, Any]]:
+    ) -> dict[str, Any] | None:
         backoff = self.RETRY_BACKOFF
         for attempt in range(1, self.RETRY_ATTEMPTS + 1):
             try:
                 return await handler(session, symbol)
             except (
-                asyncio.TimeoutError,
+                TimeoutError,
                 KeyError,
                 ValueError,
                 ClientError,
@@ -113,7 +114,8 @@ class ForexService:
                 TypeError,
             ) as exc:
                 print(
-                    f"ForexService: intento {attempt} fallido con {source_name} para {symbol}: {exc}"
+                    "ForexService: intento "
+                    f"{attempt} fallido con {source_name} para {symbol}: {exc}"
                 )
             except Exception as exc:  # pragma: no cover - errores inesperados
                 print(
@@ -129,10 +131,10 @@ class ForexService:
         session: aiohttp.ClientSession,
         url: str,
         *,
-        params: Optional[Dict[str, Any]] = None,
-        headers: Optional[Dict[str, str]] = None,
+        params: dict[str, Any] | None = None,
+        headers: dict[str, str] | None = None,
         source_name: str,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         async with session.get(url, params=params, headers=headers) as response:
             if response.status >= 400:
                 raise ClientError(f"{source_name} devolvió estado {response.status}")
@@ -140,7 +142,7 @@ class ForexService:
 
     async def _fetch_twelvedata(
         self, session: aiohttp.ClientSession, symbol: str
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         if not Config.TWELVEDATA_API_KEY:
             raise KeyError("TWELVEDATA_API_KEY no configurada")
         url = "https://api.twelvedata.com/quote"
@@ -155,7 +157,7 @@ class ForexService:
 
     async def _fetch_yahoo_finance(
         self, session: aiohttp.ClientSession, symbol: str
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         yahoo_symbol = self._to_yahoo_symbol(symbol)
         url = f"https://query1.finance.yahoo.com/v8/finance/chart/{yahoo_symbol}"
         data = await self._fetch_json(
@@ -169,7 +171,7 @@ class ForexService:
 
     async def _fetch_alpha_vantage(
         self, session: aiohttp.ClientSession, symbol: str
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         if not Config.ALPHA_VANTAGE_API_KEY:
             raise KeyError("ALPHA_VANTAGE_API_KEY no configurada")
 
@@ -210,7 +212,7 @@ class ForexService:
         return symbol
 
     @staticmethod
-    def _split_symbol(symbol: str) -> Tuple[str, str]:
+    def _split_symbol(symbol: str) -> tuple[str, str]:
         normalized = ForexService._normalize_symbol(symbol)
         if "/" in normalized:
             base, quote = normalized.split("/", maxsplit=1)

--- a/backend/services/integration_reporter.py
+++ b/backend/services/integration_reporter.py
@@ -3,15 +3,14 @@
 from __future__ import annotations
 
 import logging
-from typing import List, Tuple
 
 try:  # pragma: no cover - execution context may vary in tests
-    from backend.services.market_service import market_service
     from backend.services.forex_service import forex_service
+    from backend.services.market_service import market_service
     from backend.utils.config import Config
 except ImportError:  # pragma: no cover - fallback for package layout
-    from services.market_service import market_service  # type: ignore
     from services.forex_service import forex_service  # type: ignore
+    from services.market_service import market_service  # type: ignore
     from utils.config import Config  # type: ignore
 
 LOGGER = logging.getLogger(__name__)
@@ -20,8 +19,8 @@ LOGGER = logging.getLogger(__name__)
 async def log_api_integration_report() -> None:
     """Log the runtime status of the core market integrations."""
 
-    statuses: List[Tuple[str, str]] = []
-    remediations: List[str] = []
+    statuses: list[tuple[str, str]] = []
+    remediations: list[str] = []
 
     # Nota de corrección: registramos claves ausentes para dejar constancia de los
     # fallbacks que aplicamos automáticamente en las integraciones.
@@ -42,10 +41,14 @@ async def log_api_integration_report() -> None:
     try:
         binance_payload = await market_service.get_binance_price("BTC")
         if binance_payload:
-            statuses.append((
-                "Binance",
-                f"ok precio={binance_payload.get('price')} fuente={binance_payload.get('source', 'N/D')}",
-            ))
+            statuses.append(
+                (
+                    "Binance",
+                    "ok precio="
+                    f"{binance_payload.get('price')} "
+                    f"fuente={binance_payload.get('source', 'N/D')}",
+                )
+            )
         else:
             statuses.append(("Binance", "sin datos (verificar símbolo o conexión)"))
     except Exception as exc:  # pragma: no cover - logging informativo
@@ -56,10 +59,14 @@ async def log_api_integration_report() -> None:
     try:
         stock_payload = await market_service.get_stock_price("AAPL")
         if stock_payload:
-            statuses.append((
-                "Yahoo Finance",
-                f"ok precio={stock_payload.get('price')} fuente={stock_payload.get('source', 'Yahoo Finance')}",
-            ))
+            statuses.append(
+                (
+                    "Yahoo Finance",
+                    "ok precio="
+                    f"{stock_payload.get('price')} "
+                    f"fuente={stock_payload.get('source', 'Yahoo Finance')}",
+                )
+            )
         else:
             statuses.append(("Yahoo Finance", "sin datos (respuesta vacía)") )
     except Exception as exc:  # pragma: no cover - logging informativo
@@ -70,10 +77,14 @@ async def log_api_integration_report() -> None:
     try:
         forex_payload = await forex_service.get_quote("EURUSD")
         if forex_payload:
-            statuses.append((
-                "Forex",
-                f"ok precio={forex_payload.get('price')} fuente={forex_payload.get('source', 'Yahoo Finance')}",
-            ))
+            statuses.append(
+                (
+                    "Forex",
+                    "ok precio="
+                    f"{forex_payload.get('price')} "
+                    f"fuente={forex_payload.get('source', 'Yahoo Finance')}",
+                )
+            )
         else:
             statuses.append(("Forex", "sin datos (pares no disponibles)"))
     except Exception as exc:  # pragma: no cover - logging informativo
@@ -84,10 +95,14 @@ async def log_api_integration_report() -> None:
     try:
         commodities_payload = await forex_service.get_quote("XAUUSD")
         if commodities_payload:
-            statuses.append((
-                "Commodities",
-                f"ok precio={commodities_payload.get('price')} fuente={commodities_payload.get('source', 'Yahoo Finance')}",
-            ))
+            statuses.append(
+                (
+                    "Commodities",
+                    "ok precio="
+                    f"{commodities_payload.get('price')} "
+                    f"fuente={commodities_payload.get('source', 'Yahoo Finance')}",
+                )
+            )
         else:
             statuses.append(("Commodities", "sin datos (verificar símbolo)"))
     except Exception as exc:  # pragma: no cover - logging informativo

--- a/backend/services/market_service.py
+++ b/backend/services/market_service.py
@@ -4,14 +4,17 @@ import html
 import re
 import time
 import xml.etree.ElementTree as ET
-from datetime import datetime, timezone
+from collections.abc import Sequence
+from datetime import UTC, datetime
 from email.utils import parsedate_to_datetime
-from typing import Any, Dict, List, Optional, Sequence
+from typing import Any
 from urllib.parse import urlparse
 
 import aiohttp
 from aiohttp import ClientError
+
 from backend.core.logging_config import get_logger
+
 # Plotly puede no estar disponible en entornos de prueba sin dependencias opcionales.
 try:  # pragma: no cover - depende del entorno
     import plotly.graph_objects as go
@@ -37,16 +40,16 @@ class MarketService:
     def __init__(
         self,
         *,
-        crypto_service: Optional[CryptoService] = None,
-        stock_service: Optional[StockService] = None,
-        news_cache: Optional[CacheClient] = None,
+        crypto_service: CryptoService | None = None,
+        stock_service: StockService | None = None,
+        news_cache: CacheClient | None = None,
     ) -> None:
         self.crypto_service = crypto_service or CryptoService()
         self.stock_service = stock_service or StockService()
         self.news_cache = news_cache or CacheClient("market-news", ttl=180)
         self.chart_cache = CacheClient("market-chart", ttl=300)
         self.history_cache = CacheClient("market-history", ttl=600)
-        self.binance_cache: Dict[str, Dict[str, Any]] = {}
+        self.binance_cache: dict[str, dict[str, Any]] = {}
         self.cache_timeout = 2  # segundos (más rápido para datos en tiempo real)
         self.base_urls = {
             "binance": "https://api.binance.com/api/v3",
@@ -69,7 +72,7 @@ class MarketService:
         *,
         interval: str = "1d",
         range_: str = "1mo",
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """Obtiene histórico de precios desde Yahoo Finance."""
 
         cache_key = f"{symbol}:{interval}:{range_}".lower()
@@ -81,13 +84,14 @@ class MarketService:
         params = {"interval": interval, "range": range_}
         url = f"https://query1.finance.yahoo.com/v8/finance/chart/{yahoo_symbol}"
 
-        async with aiohttp.ClientSession(timeout=CLIENT_TIMEOUT) as session:
-            async with session.get(url, params=params) as response:
-                if response.status != 200:
-                    raise ClientError(
-                        f"Yahoo Finance devolvió estado {response.status} para {symbol}"
-                    )
-                payload = await response.json()
+        async with aiohttp.ClientSession(timeout=CLIENT_TIMEOUT) as session, session.get(
+            url, params=params
+        ) as response:
+            if response.status != 200:
+                raise ClientError(
+                    f"Yahoo Finance devolvió estado {response.status} para {symbol}"
+                )
+            payload = await response.json()
 
         try:
             result = payload["chart"]["result"][0]
@@ -97,11 +101,11 @@ class MarketService:
         except (KeyError, IndexError, TypeError) as exc:
             raise ValueError(f"Datos históricos no disponibles para {symbol}") from exc
 
-        values: List[Dict[str, Any]] = []
-        for ts, close in zip(timestamps, closes):
+        values: list[dict[str, Any]] = []
+        for ts, close in zip(timestamps, closes, strict=False):
             if close is None:
                 continue
-            dt = datetime.fromtimestamp(ts, tz=timezone.utc)
+            dt = datetime.fromtimestamp(ts, tz=UTC)
             values.append({"timestamp": dt.isoformat(), "close": float(close)})
 
         if not values:
@@ -122,7 +126,7 @@ class MarketService:
         interval: str = "1h",
         limit: int = 300,
         market: str = "auto",
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """Obtener velas OHLC usando proveedores gratuitos y cachearlas."""
 
         limit = max(10, min(limit, 1000))
@@ -133,8 +137,8 @@ class MarketService:
 
         symbol_up = symbol.upper()
         market_mode = market.lower()
-        data: Optional[Dict[str, Any]] = None
-        errors: List[str] = []
+        data: dict[str, Any] | None = None
+        errors: list[str] = []
 
         if market_mode in {"auto", "crypto"} and self._looks_like_crypto(symbol_up):
             try:
@@ -165,7 +169,7 @@ class MarketService:
 
     async def _fetch_binance_history(
         self, symbol: str, interval: str, limit: int
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         allowed = {
             "1m",
             "3m",
@@ -189,22 +193,23 @@ class MarketService:
         params = {"symbol": symbol, "interval": interval, "limit": str(limit)}
         url = f"{self.base_urls['binance']}/klines"
 
-        async with aiohttp.ClientSession(timeout=CLIENT_TIMEOUT) as session:
-            async with session.get(url, params=params) as response:
-                if response.status != 200:
-                    text = await response.text()
-                    raise ClientError(
-                        f"Binance devolvió {response.status} para {symbol}: {text[:120]}"
-                    )
-                payload = await response.json()
+        async with aiohttp.ClientSession(timeout=CLIENT_TIMEOUT) as session, session.get(
+            url, params=params
+        ) as response:
+            if response.status != 200:
+                text = await response.text()
+                raise ClientError(
+                    f"Binance devolvió {response.status} para {symbol}: {text[:120]}"
+                )
+            payload = await response.json()
 
-        candles: List[Dict[str, Any]] = []
+        candles: list[dict[str, Any]] = []
         for entry in payload:
             try:
                 open_time = int(entry[0]) / 1000
                 candles.append(
                     {
-                        "timestamp": datetime.fromtimestamp(open_time, tz=timezone.utc).isoformat(),
+                        "timestamp": datetime.fromtimestamp(open_time, tz=UTC).isoformat(),
                         "open": float(entry[1]),
                         "high": float(entry[2]),
                         "low": float(entry[3]),
@@ -228,7 +233,7 @@ class MarketService:
 
     async def _fetch_yahoo_history(
         self, symbol: str, interval: str, limit: int
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         yahoo_symbol = self._format_symbol_for_yahoo(symbol)
         range_map = {
             "1m": "7d",
@@ -245,13 +250,14 @@ class MarketService:
         params = {"interval": interval, "range": range_map.get(interval, "1y")}
         url = f"https://query1.finance.yahoo.com/v8/finance/chart/{yahoo_symbol}"
 
-        async with aiohttp.ClientSession(timeout=CLIENT_TIMEOUT) as session:
-            async with session.get(url, params=params) as response:
-                if response.status != 200:
-                    raise ClientError(
-                        f"Yahoo Finance devolvió estado {response.status} para {symbol}"
-                    )
-                payload = await response.json()
+        async with aiohttp.ClientSession(timeout=CLIENT_TIMEOUT) as session, session.get(
+            url, params=params
+        ) as response:
+            if response.status != 200:
+                raise ClientError(
+                    f"Yahoo Finance devolvió estado {response.status} para {symbol}"
+                )
+            payload = await response.json()
 
         try:
             result = payload["chart"]["result"][0]
@@ -265,13 +271,13 @@ class MarketService:
         except (KeyError, IndexError, TypeError) as exc:
             raise ValueError(f"Datos históricos no disponibles para {symbol}") from exc
 
-        candles: List[Dict[str, Any]] = []
+        candles: list[dict[str, Any]] = []
         for ts, open_, high, low, close, volume in zip(
-            timestamps, opens, highs, lows, closes, volumes
+            timestamps, opens, highs, lows, closes, volumes, strict=False
         ):
             if None in (open_, high, low, close):
                 continue
-            dt = datetime.fromtimestamp(ts, tz=timezone.utc)
+            dt = datetime.fromtimestamp(ts, tz=UTC)
             candles.append(
                 {
                     "timestamp": dt.isoformat(),
@@ -346,7 +352,7 @@ class MarketService:
             return f"{base}{quote}=X"
         return upper
 
-    async def get_top_performers(self) -> Dict[str, Any]:
+    async def get_top_performers(self) -> dict[str, Any]:
         """Obtener los mejores performers del mercado priorizando datos reales."""
         try:
             crypto_data = await self.get_binance_top_performers()
@@ -360,7 +366,7 @@ class MarketService:
             LOGGER.exception("Error getting real market data: %s", exc)
             return await self.get_simulated_data()
 
-    async def get_crypto_price(self, symbol: str) -> Optional[Dict[str, Any]]:
+    async def get_crypto_price(self, symbol: str) -> dict[str, Any] | None:
         """Obtiene información de precio para un activo crypto delegando en CryptoService."""
         try:
             crypto_price = await self.crypto_service.get_price(symbol)
@@ -379,7 +385,7 @@ class MarketService:
         if price is None:
             return None
 
-        payload: Dict[str, Any] = {
+        payload: dict[str, Any] = {
             "symbol": symbol.upper(),
             "type": "crypto",
             "price": float(price),
@@ -412,7 +418,7 @@ class MarketService:
 
         return payload
 
-    async def get_stock_price(self, symbol: str) -> Optional[Dict[str, Any]]:
+    async def get_stock_price(self, symbol: str) -> dict[str, Any] | None:
         """Obtiene información de precio para un activo bursátil delegando en StockService."""
         try:
             stock_payload = await self.stock_service.get_price(symbol)
@@ -440,19 +446,18 @@ class MarketService:
             "source": stock_payload.get("source", "StockService"),
         }
 
-    async def get_binance_top_performers(self) -> Dict[str, List[Dict[str, Any]]]:
+    async def get_binance_top_performers(self) -> dict[str, list[dict[str, Any]]]:
         """Obtener top performers de Binance."""
         try:
             url = f"{self.base_urls['binance']}/ticker/24hr"
-            async with aiohttp.ClientSession(timeout=CLIENT_TIMEOUT) as session:
-                async with session.get(url) as response:
-                    if response.status != 200:
-                        raise ClientError(
-                            f"Binance API returned status {response.status}"
-                        )
-                    data = await response.json()
+            async with aiohttp.ClientSession(timeout=CLIENT_TIMEOUT) as session, session.get(
+                url
+            ) as response:
+                if response.status != 200:
+                    raise ClientError(f"Binance API returned status {response.status}")
+                data = await response.json()
 
-            usdt_pairs: List[Dict[str, Any]] = []
+            usdt_pairs: list[dict[str, Any]] = []
             for item in data:
                 if not item["symbol"].endswith("USDT"):
                     continue
@@ -491,7 +496,7 @@ class MarketService:
             LOGGER.exception("Error getting Binance top performers: %s", exc)
             return {"top_gainers": [], "top_losers": []}
 
-    async def get_binance_price(self, symbol: str) -> Optional[Dict[str, Any]]:
+    async def get_binance_price(self, symbol: str) -> dict[str, Any] | None:
         """Obtener precio de Binance con cache."""
         cache_key = f"binance_{symbol.upper()}"
         current_time = time.time()
@@ -504,16 +509,17 @@ class MarketService:
             url = f"{self.base_urls['binance']}/ticker/24hr"
             params = {"symbol": f"{symbol.upper()}USDT"}
 
-            async with aiohttp.ClientSession(timeout=CLIENT_TIMEOUT) as session:
-                async with session.get(url, params=params) as response:
-                    if response.status != 200:
-                        LOGGER.warning(
-                            "Binance API error for %s: Status %s",
-                            symbol,
-                            response.status,
-                        )
-                        return None
-                    data = await response.json()
+            async with aiohttp.ClientSession(timeout=CLIENT_TIMEOUT) as session, session.get(
+                url, params=params
+            ) as response:
+                if response.status != 200:
+                    LOGGER.warning(
+                        "Binance API error for %s: Status %s",
+                        symbol,
+                        response.status,
+                    )
+                    return None
+                data = await response.json()
 
             price_data = {
                 "price": float(data["lastPrice"]),
@@ -533,22 +539,23 @@ class MarketService:
 
     async def get_binance_orderbook(
         self, symbol: str, limit: int = 10
-    ) -> Optional[Dict[str, Any]]:
+    ) -> dict[str, Any] | None:
         """Obtener orderbook de Binance."""
         try:
             url = f"{self.base_urls['binance']}/depth"
             params = {"symbol": f"{symbol.upper()}USDT", "limit": limit}
 
-            async with aiohttp.ClientSession(timeout=CLIENT_TIMEOUT) as session:
-                async with session.get(url, params=params) as response:
-                    if response.status != 200:
-                        LOGGER.warning(
-                            "Binance orderbook error for %s: Status %s",
-                            symbol,
-                            response.status,
-                        )
-                        return None
-                    data = await response.json()
+            async with aiohttp.ClientSession(timeout=CLIENT_TIMEOUT) as session, session.get(
+                url, params=params
+            ) as response:
+                if response.status != 200:
+                    LOGGER.warning(
+                        "Binance orderbook error for %s: Status %s",
+                        symbol,
+                        response.status,
+                    )
+                    return None
+                data = await response.json()
 
             return {
                 "bids": [
@@ -567,7 +574,7 @@ class MarketService:
 
     async def get_binance_klines(
         self, symbol: str, interval: str = "1h", limit: int = 24
-    ) -> Optional[List[Dict[str, Any]]]:
+    ) -> list[dict[str, Any]] | None:
         """Obtener datos de velas (klines) de Binance."""
         try:
             url = f"{self.base_urls['binance']}/klines"
@@ -577,16 +584,17 @@ class MarketService:
                 "limit": limit,
             }
 
-            async with aiohttp.ClientSession(timeout=CLIENT_TIMEOUT) as session:
-                async with session.get(url, params=params) as response:
-                    if response.status != 200:
-                        LOGGER.warning(
-                            "Binance klines error for %s: Status %s",
-                            symbol,
-                            response.status,
-                        )
-                        return None
-                    data = await response.json()
+            async with aiohttp.ClientSession(timeout=CLIENT_TIMEOUT) as session, session.get(
+                url, params=params
+            ) as response:
+                if response.status != 200:
+                    LOGGER.warning(
+                        "Binance klines error for %s: Status %s",
+                        symbol,
+                        response.status,
+                    )
+                    return None
+                data = await response.json()
 
             return [
                 {
@@ -604,8 +612,8 @@ class MarketService:
             return None
 
     async def get_price(
-        self, symbol: str, asset_type: Optional[str] = None
-    ) -> Optional[Dict[str, Any]]:
+        self, symbol: str, asset_type: str | None = None
+    ) -> dict[str, Any] | None:
         """Obtener precio de un activo específico usando los nuevos helpers de servicios."""
         try:
             resolved_type = asset_type or await self.detect_asset_type(symbol)
@@ -633,8 +641,8 @@ class MarketService:
         }
 
     async def get_stock_market_data(
-        self, symbols: Optional[Sequence[str]] = None
-    ) -> List[Dict[str, Any]]:
+        self, symbols: Sequence[str] | None = None
+    ) -> list[dict[str, Any]]:
         """Obtiene información de un conjunto de símbolos bursátiles usando StockService."""
         tickers = tuple(symbols or self.default_stock_watchlist)
         if not tickers:
@@ -643,8 +651,8 @@ class MarketService:
         tasks = [self.get_stock_price(symbol) for symbol in tickers]
         results = await asyncio.gather(*tasks, return_exceptions=True)
 
-        data: List[Dict[str, Any]] = []
-        for symbol, result in zip(tickers, results):
+        data: list[dict[str, Any]] = []
+        for symbol, result in zip(tickers, results, strict=False):
             if isinstance(result, Exception):
                 LOGGER.error("Error fetching stock price for %s: %s", symbol, result)
                 continue
@@ -654,8 +662,8 @@ class MarketService:
         return data
 
     async def get_crypto_market_data(
-        self, symbols: Optional[Sequence[str]] = None
-    ) -> List[Dict[str, Any]]:
+        self, symbols: Sequence[str] | None = None
+    ) -> list[dict[str, Any]]:
         """Obtiene información crypto adicional usando los nuevos helpers."""
         if not symbols:
             return []
@@ -663,8 +671,8 @@ class MarketService:
         tasks = [self.get_crypto_price(symbol) for symbol in symbols]
         results = await asyncio.gather(*tasks, return_exceptions=True)
 
-        data: List[Dict[str, Any]] = []
-        for symbol, result in zip(symbols, results):
+        data: list[dict[str, Any]] = []
+        for symbol, result in zip(symbols, results, strict=False):
             if isinstance(result, Exception):
                 LOGGER.error("Error fetching crypto price for %s: %s", symbol, result)
                 continue
@@ -675,9 +683,9 @@ class MarketService:
 
     async def process_market_data(
         self,
-        stock_data: List[Dict[str, Any]],
-        crypto_data: Dict[str, List[Dict[str, Any]]],
-    ) -> Dict[str, Any]:
+        stock_data: list[dict[str, Any]],
+        crypto_data: dict[str, list[dict[str, Any]]],
+    ) -> dict[str, Any]:
         """Procesar datos de mercado con información real disponible."""
         crypto_gainers = [
             self._format_performer(item)
@@ -691,8 +699,8 @@ class MarketService:
         stocks_with_change = [
             item for item in stock_data if item.get("raw_change") is not None
         ]
-        stock_top: List[Dict[str, Any]] = []
-        stock_bottom: List[Dict[str, Any]] = []
+        stock_top: list[dict[str, Any]] = []
+        stock_bottom: list[dict[str, Any]] = []
         if stocks_with_change:
             sorted_stocks = sorted(
                 stocks_with_change, key=lambda x: x["raw_change"], reverse=True
@@ -723,14 +731,14 @@ class MarketService:
             "market_summary": market_summary,
         }
 
-    async def get_news(self, symbol: str, limit: int = 10) -> List[Dict[str, Any]]:
+    async def get_news(self, symbol: str, limit: int = 10) -> list[dict[str, Any]]:
         """Obtiene noticias relevantes para un símbolo con caché y múltiples fuentes."""
         cache_key = f"{symbol.upper()}:{limit}"
         cached = await self.news_cache.get(cache_key)
         if cached is not None:
             return cached
 
-        articles: List[Dict[str, Any]] = []
+        articles: list[dict[str, Any]] = []
 
         if Config.NEWSAPI_API_KEY:
             try:
@@ -794,7 +802,7 @@ class MarketService:
         }
         return "crypto" if symbol.upper() in crypto_symbols else "stock"
 
-    async def get_simulated_data(self) -> Dict[str, Any]:
+    async def get_simulated_data(self) -> dict[str, Any]:
         """Fallback sin datos sintéticos para evitar métricas artificiadas."""
         # Ajuste: en lugar de devolver precios ficticios dejamos la estructura vacía
         # para garantizar que el cliente sepa que las fuentes externas fallaron.
@@ -808,12 +816,11 @@ class MarketService:
 
     async def close(self) -> None:
         """Cerrar conexiones (placeholder para compatibilidad)."""
-        pass
 
     def _combine_ranked_lists(
-        self, sources: Sequence[List[Dict[str, Any]]], limit: int
-    ) -> List[Dict[str, Any]]:
-        combined: List[Dict[str, Any]] = []
+        self, sources: Sequence[list[dict[str, Any]]], limit: int
+    ) -> list[dict[str, Any]]:
+        combined: list[dict[str, Any]] = []
         indices = [0] * len(sources)
         while len(combined) < limit:
             progressed = False
@@ -829,7 +836,7 @@ class MarketService:
                 break
         return combined
 
-    def _format_performer(self, item: Dict[str, Any]) -> Dict[str, Any]:
+    def _format_performer(self, item: dict[str, Any]) -> dict[str, Any]:
         return {
             "symbol": item.get("symbol", ""),
             "price": self._format_currency(item.get("price")),
@@ -838,28 +845,28 @@ class MarketService:
             "source": item.get("source", "Unknown"),
         }
 
-    def _format_currency(self, value: Optional[float]) -> str:
-        if value is None or not isinstance(value, (int, float)):
+    def _format_currency(self, value: float | None) -> str:
+        if value is None or not isinstance(value, int | float):
             return "N/A"
         return f"${value:,.2f}"
 
-    def _format_percent(self, value: Optional[float]) -> str:
-        if value is None or not isinstance(value, (int, float)):
+    def _format_percent(self, value: float | None) -> str:
+        if value is None or not isinstance(value, int | float):
             return "N/A"
         return f"{value:+.2f}%"
 
-    def _format_volume(self, value: Optional[float]) -> str:
-        if value is None or not isinstance(value, (int, float)):
+    def _format_volume(self, value: float | None) -> str:
+        if value is None or not isinstance(value, int | float):
             return "N/A"
         return f"{value:,.0f}"
 
     def _build_market_summary(
         self,
-        stock_data: List[Dict[str, Any]],
-        crypto_data: Dict[str, List[Dict[str, Any]]],
-    ) -> Dict[str, Any]:
-        summary: Dict[str, Any] = {
-            "generated_at": datetime.now(timezone.utc).isoformat(),
+        stock_data: list[dict[str, Any]],
+        crypto_data: dict[str, list[dict[str, Any]]],
+    ) -> dict[str, Any]:
+        summary: dict[str, Any] = {
+            "generated_at": datetime.now(UTC).isoformat(),
             "stocks_covered": len(stock_data),
             "crypto_pairs": len(crypto_data.get("top_gainers", []))
             + len(crypto_data.get("top_losers", [])),
@@ -868,7 +875,7 @@ class MarketService:
         stocks_with_change = [
             item["raw_change"]
             for item in stock_data
-            if isinstance(item.get("raw_change"), (int, float))
+            if isinstance(item.get("raw_change"), int | float)
         ]
         if stocks_with_change:
             avg_change = sum(stocks_with_change) / len(stocks_with_change)
@@ -887,7 +894,7 @@ class MarketService:
 
         return summary
 
-    async def _fetch_newsapi(self, symbol: str, limit: int) -> List[Dict[str, Any]]:
+    async def _fetch_newsapi(self, symbol: str, limit: int) -> list[dict[str, Any]]:
         url = "https://newsapi.org/v2/everything"
         headers = {"Authorization": f"Bearer {Config.NEWSAPI_API_KEY}"}
         params = {
@@ -897,18 +904,19 @@ class MarketService:
             "pageSize": limit,
         }
 
-        async with aiohttp.ClientSession(timeout=CLIENT_TIMEOUT) as session:
-            async with session.get(url, params=params, headers=headers) as response:
-                if response.status != 200:
-                    LOGGER.warning(
-                        "NewsAPI returned status %s for %s",
-                        response.status,
-                        symbol,
-                    )
-                    return []
-                payload = await response.json()
+        async with aiohttp.ClientSession(timeout=CLIENT_TIMEOUT) as session, session.get(
+            url, params=params, headers=headers
+        ) as response:
+            if response.status != 200:
+                LOGGER.warning(
+                    "NewsAPI returned status %s for %s",
+                    response.status,
+                    symbol,
+                )
+                return []
+            payload = await response.json()
 
-        articles: List[Dict[str, Any]] = []
+        articles: list[dict[str, Any]] = []
         for article in payload.get("articles", []):
             source_info = article.get("source") or {}
             articles.append(
@@ -924,7 +932,7 @@ class MarketService:
             )
         return articles
 
-    async def _fetch_mediastack(self, symbol: str, limit: int) -> List[Dict[str, Any]]:
+    async def _fetch_mediastack(self, symbol: str, limit: int) -> list[dict[str, Any]]:
         url = "http://api.mediastack.com/v1/news"
         params = {
             "access_key": Config.MEDIASTACK_API_KEY,
@@ -934,18 +942,19 @@ class MarketService:
             "languages": "en",
         }
 
-        async with aiohttp.ClientSession(timeout=CLIENT_TIMEOUT) as session:
-            async with session.get(url, params=params) as response:
-                if response.status != 200:
-                    LOGGER.warning(
-                        "MediaStack returned status %s for %s",
-                        response.status,
-                        symbol,
-                    )
-                    return []
-                payload = await response.json()
+        async with aiohttp.ClientSession(timeout=CLIENT_TIMEOUT) as session, session.get(
+            url, params=params
+        ) as response:
+            if response.status != 200:
+                LOGGER.warning(
+                    "MediaStack returned status %s for %s",
+                    response.status,
+                    symbol,
+                )
+                return []
+            payload = await response.json()
 
-        articles: List[Dict[str, Any]] = []
+        articles: list[dict[str, Any]] = []
         for article in payload.get("data", []):
             articles.append(
                 {
@@ -958,20 +967,21 @@ class MarketService:
             )
         return articles
 
-    async def _fetch_rss(self, symbol: str, limit: int) -> List[Dict[str, Any]]:
+    async def _fetch_rss(self, symbol: str, limit: int) -> list[dict[str, Any]]:
         query = f"{symbol} stock"
         url = f"https://news.google.com/rss/search?q={query}&hl=en-US&gl=US&ceid=US:en"
 
-        async with aiohttp.ClientSession(timeout=CLIENT_TIMEOUT) as session:
-            async with session.get(url) as response:
-                if response.status != 200:
-                    LOGGER.warning(
-                        "RSS feed returned status %s for %s",
-                        response.status,
-                        symbol,
-                    )
-                    return []
-                text = await response.text()
+        async with aiohttp.ClientSession(timeout=CLIENT_TIMEOUT) as session, session.get(
+            url
+        ) as response:
+            if response.status != 200:
+                LOGGER.warning(
+                    "RSS feed returned status %s for %s",
+                    response.status,
+                    symbol,
+                )
+                return []
+            text = await response.text()
 
         try:
             root = ET.fromstring(text)
@@ -979,7 +989,7 @@ class MarketService:
             LOGGER.warning("Failed to parse RSS feed for %s: %s", symbol, exc)
             return []
 
-        articles: List[Dict[str, Any]] = []
+        articles: list[dict[str, Any]] = []
         for item in root.findall(".//item")[:limit]:
             title = item.findtext("title") or "Sin título"
             link = item.findtext("link")
@@ -996,7 +1006,7 @@ class MarketService:
             )
         return articles
 
-    def _normalize_datetime(self, value: Optional[str]) -> Optional[str]:
+    def _normalize_datetime(self, value: str | None) -> str | None:
         if not value:
             return None
         try:
@@ -1007,14 +1017,14 @@ class MarketService:
             except (TypeError, ValueError, IndexError):
                 return None
         if dt.tzinfo is None:
-            dt = dt.replace(tzinfo=timezone.utc)
-        return dt.astimezone(timezone.utc).isoformat()
+            dt = dt.replace(tzinfo=UTC)
+        return dt.astimezone(UTC).isoformat()
 
     def _clean_html(self, text: str) -> str:
         cleaned = re.sub(r"<[^>]+>", "", text or "")
         return html.unescape(cleaned).strip()
 
-    def _extract_domain(self, url: Optional[str]) -> str:
+    def _extract_domain(self, url: str | None) -> str:
         if not url:
             return "Unknown"
         try:

--- a/backend/services/news_service.py
+++ b/backend/services/news_service.py
@@ -6,9 +6,10 @@ import asyncio
 import html
 import logging
 import re
-from datetime import datetime, timezone
+from collections.abc import Callable, Iterable
+from datetime import UTC, datetime
 from email.utils import parsedate_to_datetime
-from typing import Any, Callable, Dict, Iterable, List, Optional
+from typing import Any
 from urllib.parse import urlparse
 
 import aiohttp
@@ -34,14 +35,14 @@ class NewsService:
     def __init__(
         self,
         *,
-        cache_client: Optional[CacheClient] = None,
+        cache_client: CacheClient | None = None,
         session_factory: Callable[..., aiohttp.ClientSession] = aiohttp.ClientSession,
     ) -> None:
         self.cache = cache_client or CacheClient("news-service", ttl=120)
         self._session_factory = session_factory
         self._timeout = ClientTimeout(total=10)
 
-    async def get_crypto_headlines(self, limit: int = 10) -> List[Dict[str, Any]]:
+    async def get_crypto_headlines(self, limit: int = 10) -> list[dict[str, Any]]:
         """Return crypto headlines prioritising CryptoPanic and falling back to NewsAPI."""
 
         return await self._get_articles(
@@ -51,7 +52,7 @@ class NewsService:
             fallback_query="cryptocurrency OR bitcoin OR ethereum",
         )
 
-    async def get_finance_headlines(self, limit: int = 10) -> List[Dict[str, Any]]:
+    async def get_finance_headlines(self, limit: int = 10) -> list[dict[str, Any]]:
         """Return finance headlines prioritising Finfeed and falling back to NewsAPI."""
 
         return await self._get_articles(
@@ -61,7 +62,7 @@ class NewsService:
             fallback_query="stock market OR finance",
         )
 
-    async def get_latest_news(self, limit: int = 20) -> List[Dict[str, Any]]:
+    async def get_latest_news(self, limit: int = 20) -> list[dict[str, Any]]:
         """Aggregate the freshest crypto and finance headlines."""
 
         limited = max(1, min(limit, 100))
@@ -70,14 +71,14 @@ class NewsService:
             asyncio.create_task(self.get_finance_headlines(limited)),
         ]
 
-        aggregated: List[Dict[str, Any]] = []
+        aggregated: list[dict[str, Any]] = []
         for result in await asyncio.gather(*tasks, return_exceptions=True):
             if isinstance(result, Exception):
                 LOGGER.warning("NewsService: error agregando noticias: %s", result)
                 continue
             aggregated.extend(result)
 
-        unique_items: List[Dict[str, Any]] = []
+        unique_items: list[dict[str, Any]] = []
         seen: set[str] = set()
         for item in aggregated:
             identifier = (item.get("url") or item.get("title") or "").strip().lower()
@@ -94,16 +95,16 @@ class NewsService:
         *,
         cache_namespace: str,
         limit: int,
-        primary_fetcher: Optional[Callable[[aiohttp.ClientSession, int], Any]],
+        primary_fetcher: Callable[[aiohttp.ClientSession, int], Any] | None,
         fallback_query: str,
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         limited = max(1, min(limit, 50))
         cache_key = f"{cache_namespace}:{limited}"
         cached = await self.cache.get(cache_key)
         if cached is not None:
             return cached
 
-        articles: List[Dict[str, Any]] = []
+        articles: list[dict[str, Any]] = []
 
         async with self._session_factory(timeout=self._timeout) as session:
             if primary_fetcher is not None:
@@ -117,7 +118,7 @@ class NewsService:
                     query=fallback_query,
                 )
 
-        normalized: List[Dict[str, Any]] = []
+        normalized: list[dict[str, Any]] = []
         seen_identifiers: set[str] = set()
         for item in articles:
             pruned = self._prune_article(item)
@@ -144,7 +145,7 @@ class NewsService:
         session: aiohttp.ClientSession,
         limit: int,
         **kwargs: Any,
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         backoff = self.RETRY_BACKOFF
         for attempt in range(1, self.RETRY_ATTEMPTS + 1):
             try:
@@ -154,7 +155,7 @@ class NewsService:
                     return []
                 return result
             except (
-                asyncio.TimeoutError,
+                TimeoutError,
                 ClientError,
                 ContentTypeError,
                 KeyError,
@@ -180,7 +181,7 @@ class NewsService:
 
     async def _fetch_cryptopanic(
         self, session: aiohttp.ClientSession, limit: int, **_: Any
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         if not Config.CRYPTOPANIC_API_KEY:
             raise KeyError("CRYPTOPANIC_API_KEY is not configured")
 
@@ -201,7 +202,7 @@ class NewsService:
         )
 
         results = payload.get("results") or []
-        articles: List[Dict[str, Any]] = []
+        articles: list[dict[str, Any]] = []
         for item in results:
             url_value = item.get("url") or item.get("source_url")
             source_info = item.get("source") or {}
@@ -225,7 +226,7 @@ class NewsService:
 
     async def _fetch_finfeed(
         self, session: aiohttp.ClientSession, limit: int, **_: Any
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         if not Config.FINFEED_API_KEY:
             raise KeyError("FINFEED_API_KEY is not configured")
 
@@ -240,14 +241,14 @@ class NewsService:
             source_name="Finfeed",
         )
 
-        data: Iterable[Dict[str, Any]] = (
+        data: Iterable[dict[str, Any]] = (
             payload.get("data")
             or payload.get("articles")
             or payload.get("results")
             or []
         )
 
-        articles: List[Dict[str, Any]] = []
+        articles: list[dict[str, Any]] = []
         for item in data:
             link = item.get("url") or item.get("link")
             articles.append(
@@ -274,7 +275,7 @@ class NewsService:
         limit: int,
         *,
         query: str,
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         if not Config.NEWSAPI_API_KEY:
             raise KeyError("NEWSAPI_API_KEY is not configured")
 
@@ -294,7 +295,7 @@ class NewsService:
             source_name="NewsAPI",
         )
 
-        articles: List[Dict[str, Any]] = []
+        articles: list[dict[str, Any]] = []
         for article in payload.get("articles", []):
             source_info = article.get("source") or {}
             url_value = article.get("url")
@@ -324,16 +325,16 @@ class NewsService:
         session: aiohttp.ClientSession,
         url: str,
         *,
-        params: Optional[Dict[str, Any]] = None,
-        headers: Optional[Dict[str, str]] = None,
+        params: dict[str, Any] | None = None,
+        headers: dict[str, str] | None = None,
         source_name: str,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         async with session.get(url, params=params, headers=headers) as response:
             if response.status >= 400:
                 raise ClientError(f"{source_name} returned status {response.status}")
             return await response.json()
 
-    def _prune_article(self, article: Dict[str, Any]) -> Dict[str, Any]:
+    def _prune_article(self, article: dict[str, Any]) -> dict[str, Any]:
         return {
             "source": article.get("source") or "Unknown",
             "title": article.get("title") or "Untitled",
@@ -342,19 +343,19 @@ class NewsService:
             "summary": article.get("summary") or "",
         }
 
-    def _sort_key(self, article: Dict[str, Any]) -> datetime:
+    def _sort_key(self, article: dict[str, Any]) -> datetime:
         published = article.get("published_at")
         if not published:
-            return datetime.min.replace(tzinfo=timezone.utc)
+            return datetime.min.replace(tzinfo=UTC)
         try:
             return datetime.fromisoformat(published.replace("Z", "+00:00"))
         except ValueError:
             try:
                 return parsedate_to_datetime(published)
             except (TypeError, ValueError, IndexError):
-                return datetime.min.replace(tzinfo=timezone.utc)
+                return datetime.min.replace(tzinfo=UTC)
 
-    def _normalize_datetime(self, value: Optional[str]) -> Optional[str]:
+    def _normalize_datetime(self, value: str | None) -> str | None:
         if not value:
             return None
         try:
@@ -365,14 +366,14 @@ class NewsService:
             except (TypeError, ValueError, IndexError):
                 return None
         if dt.tzinfo is None:
-            dt = dt.replace(tzinfo=timezone.utc)
-        return dt.astimezone(timezone.utc).isoformat()
+            dt = dt.replace(tzinfo=UTC)
+        return dt.astimezone(UTC).isoformat()
 
     def _clean_html(self, text: str) -> str:
         cleaned = re.sub(r"<[^>]+>", "", text or "")
         return html.unescape(cleaned).strip()
 
-    def _extract_domain(self, url: Optional[str]) -> str:
+    def _extract_domain(self, url: str | None) -> str:
         if not url:
             return "Unknown"
         try:

--- a/backend/services/password_guard.py
+++ b/backend/services/password_guard.py
@@ -4,7 +4,6 @@ import hashlib
 import string
 from pathlib import Path
 from threading import RLock
-from typing import Optional, Set, Tuple
 
 from backend.utils.config import Config
 
@@ -12,21 +11,21 @@ from backend.utils.config import Config
 class PasswordBreachDetector:
     """Offline detector that checks passwords against a local dataset."""
 
-    def __init__(self, dataset_path: Optional[str] = None) -> None:
+    def __init__(self, dataset_path: str | None = None) -> None:
         self._dataset_path = dataset_path
-        self._plain_passwords: Optional[Set[str]] = None
-        self._sha1_passwords: Optional[Set[str]] = None
+        self._plain_passwords: set[str] | None = None
+        self._sha1_passwords: set[str] | None = None
         self._lock = RLock()
 
-    def configure(self, dataset_path: Optional[str]) -> None:
+    def configure(self, dataset_path: str | None) -> None:
         with self._lock:
             self._dataset_path = dataset_path
             self._plain_passwords = None
             self._sha1_passwords = None
 
-    def _load_dataset(self) -> Tuple[Set[str], Set[str]]:
-        plain: Set[str] = set()
-        hashed: Set[str] = set()
+    def _load_dataset(self) -> tuple[set[str], set[str]]:
+        plain: set[str] = set()
+        hashed: set[str] = set()
         if not self._dataset_path:
             return plain, hashed
 
@@ -75,10 +74,10 @@ class PasswordBreachDetector:
             return True
 
         sha1_hash = hashlib.sha1(candidate.encode("utf-8")).hexdigest()
-        if sha1_hash in self._sha1_passwords or sha1_hash.upper() in self._sha1_passwords:
-            return True
-
-        return False
+        return bool(
+            sha1_hash in self._sha1_passwords
+            or sha1_hash.upper() in self._sha1_passwords
+        )
 
 
 _default_dataset = Config.PASSWORD_BREACH_DATASET_PATH
@@ -90,7 +89,7 @@ if not _default_dataset:
 password_breach_detector = PasswordBreachDetector(_default_dataset)
 
 
-def configure_password_detector(dataset_path: Optional[str]) -> None:
+def configure_password_detector(dataset_path: str | None) -> None:
     password_breach_detector.configure(dataset_path)
 
 


### PR DESCRIPTION
## Summary
- modernize FastAPI routers by using `Annotated` dependencies, builtin type hints, and wrapped messages to resolve Ruff diagnostics
- refactor service modules to adopt simplified control flow, combined async contexts, builtin generics, and consistent timezone handling
- update auxiliary services and reporters to use modern typing, clearer logging strings, and safer cleanup patterns

## Testing
- `ruff check backend/routers`
- `ruff check backend/services`


------
https://chatgpt.com/codex/tasks/task_e_68deedb923008321ab5569e9bb4abd2c