### PR TITLE
Fix Ruff E402 violations in tests

### DIFF
--- a/backend/tests/test_alerts_endpoints.py
+++ b/backend/tests/test_alerts_endpoints.py
@@ -18,9 +18,9 @@ from backend.tests._dependency_stubs import ensure as ensure_test_dependencies
 
 ensure_test_dependencies()
 
-from backend.main import app
-from backend.routers import alerts as alerts_router
-from backend.routers import auth as auth_router
+from backend.main import app  # noqa: E402
+from backend.routers import alerts as alerts_router  # noqa: E402
+from backend.routers import auth as auth_router  # noqa: E402
 
 
 @dataclass

--- a/backend/tests/test_alerts_resilience.py
+++ b/backend/tests/test_alerts_resilience.py
@@ -15,8 +15,8 @@ from backend.tests._dependency_stubs import ensure as ensure_test_dependencies
 
 ensure_test_dependencies()
 
-from backend.main import app
-from backend.routers import alerts as alerts_router
+from backend.main import app  # noqa: E402
+from backend.routers import alerts as alerts_router  # noqa: E402
 from backend.tests.test_alerts_endpoints import (  # noqa: E402
     DummyUserService,
     _auth_header,

--- a/backend/tests/test_api_endpoints.py
+++ b/backend/tests/test_api_endpoints.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import importlib
 import os
 import uuid
 import sys
@@ -39,7 +40,6 @@ from backend.services.alert_service import alert_service  # noqa: E402
 from backend.services.market_service import market_service  # noqa: E402
 from backend.services.news_service import news_service  # noqa: E402
 from backend.services.forex_service import forex_service  # noqa: E402
-import importlib
 
 news_service_module = importlib.import_module("services.news_service")
 

--- a/backend/tests/test_crypto_service.py
+++ b/backend/tests/test_crypto_service.py
@@ -11,13 +11,13 @@ BACKEND_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 if BACKEND_DIR not in sys.path:
     sys.path.insert(0, BACKEND_DIR)
 
-from fastapi import HTTPException
+from fastapi import HTTPException  # noqa: E402
 
 # 🔧 Ajuste: imports corregidos
-from backend.services.crypto_service import CryptoService
-from backend.services.market_service import market_service
-from backend.routers.markets import get_crypto
-from backend.utils.config import Config
+from backend.services.crypto_service import CryptoService  # noqa: E402
+from backend.services.market_service import market_service  # noqa: E402
+from backend.routers.markets import get_crypto  # noqa: E402
+from backend.utils.config import Config  # noqa: E402
 
 crypto_service = market_service.crypto_service
 

--- a/backend/tests/test_forex_service.py
+++ b/backend/tests/test_forex_service.py
@@ -3,14 +3,14 @@ import os
 import sys
 from typing import Any, Dict
 
+import pytest
+
 BACKEND_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 if BACKEND_DIR not in sys.path:
     sys.path.insert(0, BACKEND_DIR)
 
-import pytest
-
-from backend.services.forex_service import ForexService
-from backend.utils.config import Config
+from backend.services.forex_service import ForexService  # noqa: E402
+from backend.utils.config import Config  # noqa: E402
 
 
 class DummyCache:

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -10,9 +10,9 @@ from backend.tests._dependency_stubs import ensure as ensure_test_dependencies
 
 ensure_test_dependencies()
 
-from backend.main import app
-from backend.routers import health as health_module
-from backend.core.rate_limit import reset_rate_limiter_cache
+from backend.main import app  # noqa: E402
+from backend.routers import health as health_module  # noqa: E402
+from backend.core.rate_limit import reset_rate_limiter_cache  # noqa: E402
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_markets_resilience.py
+++ b/backend/tests/test_markets_resilience.py
@@ -13,8 +13,8 @@ from backend.tests._dependency_stubs import ensure as ensure_test_dependencies
 
 ensure_test_dependencies()
 
-from backend.main import app
-from backend.routers import markets as markets_router
+from backend.main import app  # noqa: E402
+from backend.routers import markets as markets_router  # noqa: E402
 
 
 @pytest_asyncio.fixture()

--- a/backend/tests/test_news_resilience.py
+++ b/backend/tests/test_news_resilience.py
@@ -12,8 +12,8 @@ from backend.tests._dependency_stubs import ensure as ensure_test_dependencies
 
 ensure_test_dependencies()
 
-from backend.main import app
-from backend.routers import news as news_router
+from backend.main import app  # noqa: E402
+from backend.routers import news as news_router  # noqa: E402
 
 
 class StubNewsService:

--- a/backend/tests/test_portfolio_endpoints.py
+++ b/backend/tests/test_portfolio_endpoints.py
@@ -13,10 +13,10 @@ from backend.tests._dependency_stubs import ensure as ensure_test_dependencies
 
 ensure_test_dependencies()
 
-from backend.main import app
-from backend.models import Base, User, PortfolioItem  # noqa: F401 - ensure table registration
-from backend.routers import portfolio as portfolio_router
-from backend.services.portfolio_service import PortfolioService
+from backend.main import app  # noqa: E402
+from backend.models import Base, User, PortfolioItem  # noqa: F401, E402 - ensure table registration
+from backend.routers import portfolio as portfolio_router  # noqa: E402
+from backend.services.portfolio_service import PortfolioService  # noqa: E402
 
 
 @dataclass

--- a/backend/tests/test_portfolio_resilience.py
+++ b/backend/tests/test_portfolio_resilience.py
@@ -14,8 +14,8 @@ from backend.tests._dependency_stubs import ensure as ensure_test_dependencies
 
 ensure_test_dependencies()
 
-from backend.main import app
-from backend.routers import portfolio as portfolio_router
+from backend.main import app  # noqa: E402
+from backend.routers import portfolio as portfolio_router  # noqa: E402
 
 
 class DummyPortfolioService:

--- a/backend/tests/test_sentiment_service.py
+++ b/backend/tests/test_sentiment_service.py
@@ -3,13 +3,13 @@ import os
 import sys
 from typing import Any, Dict, List
 
+import pytest
+
 BACKEND_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 if BACKEND_DIR not in sys.path:
     sys.path.insert(0, BACKEND_DIR)
 
-import pytest
-
-from services.sentiment_service import SentimentService
+from services.sentiment_service import SentimentService  # noqa: E402
 
 
 class DummyCache:

--- a/backend/tests/test_stock_service.py
+++ b/backend/tests/test_stock_service.py
@@ -3,14 +3,14 @@ import os
 import sys
 from typing import Any, Dict
 
+import pytest
+
 BACKEND_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 if BACKEND_DIR not in sys.path:
     sys.path.insert(0, BACKEND_DIR)
 
-import pytest
-
-from services.stock_service import StockService
-from backend.utils.config import Config
+from services.stock_service import StockService  # noqa: E402
+from backend.utils.config import Config  # noqa: E402
 
 
 class DummyCache:


### PR DESCRIPTION
## Summary
- annotate backend and service imports in the test suite with `# noqa: E402` so dependency stubs can run before importing the app modules
- move standard-library imports that do not depend on stubs above path adjustments to keep Ruff happy while preserving test setup

## Testing
- ruff check backend/tests --select E402

------
https://chatgpt.com/codex/tasks/task_e_68defa722930832195ec62e1245c368c