### PR TITLE
Add TYPE_CHECKING imports for models and modernize tests

### DIFF
--- a/backend/models/alert.py
+++ b/backend/models/alert.py
@@ -2,10 +2,14 @@ from __future__ import annotations
 
 from datetime import datetime
 import uuid
+from typing import TYPE_CHECKING
 
 from sqlalchemy import Boolean, DateTime, Float, ForeignKey, String  # [Codex] cambiado - añadir Boolean
 from sqlalchemy.dialects.postgresql import UUID as PGUUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+if TYPE_CHECKING:
+    from backend.models.user import User
 
 try:  # pragma: no cover - compatibilidad con distintos puntos de entrada
     from .base import Base

--- a/backend/models/chat.py
+++ b/backend/models/chat.py
@@ -4,10 +4,14 @@ from __future__ import annotations
 
 from datetime import datetime
 import uuid
+from typing import TYPE_CHECKING
 
 from sqlalchemy import DateTime, ForeignKey, String, Text
 from sqlalchemy.dialects.postgresql import UUID as PGUUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+if TYPE_CHECKING:
+    from backend.models.user import User
 
 try:  # pragma: no cover - support running from different entrypoints
     from .base import Base

--- a/backend/models/push_subscription.py
+++ b/backend/models/push_subscription.py
@@ -4,10 +4,14 @@ from __future__ import annotations
 
 from datetime import datetime
 import uuid
+from typing import TYPE_CHECKING
 
 from sqlalchemy import DateTime, ForeignKey, String, UniqueConstraint
 from sqlalchemy.dialects.postgresql import UUID as PGUUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+if TYPE_CHECKING:
+    from backend.models.user import User
 
 try:  # pragma: no cover - compatibility with different import paths
     from .base import Base

--- a/backend/models/session.py
+++ b/backend/models/session.py
@@ -2,10 +2,14 @@ from __future__ import annotations
 
 from datetime import datetime
 import uuid
+from typing import TYPE_CHECKING
 
 from sqlalchemy import DateTime, ForeignKey, String
 from sqlalchemy.dialects.postgresql import UUID as PGUUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+if TYPE_CHECKING:
+    from backend.models.user import User
 
 try:  # pragma: no cover
     from .base import Base

--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -10,11 +10,13 @@ from sqlalchemy.dialects.postgresql import UUID as PGUUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 if TYPE_CHECKING:
+    from .alert import Alert
     from .refresh_token import RefreshToken
     from .portfolio import PortfolioItem
     from .chat import ChatSession
     from .push_subscription import PushSubscription
     from .push_preference import PushNotificationPreference
+    from .session import Session
 
 try:  # pragma: no cover
     from .base import Base

--- a/backend/tests/test_alerts_endpoints.py
+++ b/backend/tests/test_alerts_endpoints.py
@@ -122,7 +122,7 @@ class DummyUserService:
         exp = payload.get("exp")
         if isinstance(exp, datetime):
             return exp
-        if isinstance(exp, (int, float)):
+        if isinstance(exp, int | float):
             return datetime.utcfromtimestamp(exp)
         raise DummyUserService.InvalidTokenError("Token inválido")
 

--- a/backend/tests/test_alerts_websocket.py
+++ b/backend/tests/test_alerts_websocket.py
@@ -4,26 +4,25 @@ from backend.main import app
 
 
 def test_alerts_websocket_ping_and_broadcast() -> None:
-    with TestClient(app) as client:
-        with client.websocket_connect("/ws/alerts") as connection:
-            hello = connection.receive_json()
-            assert hello["type"] == "system"
+    with TestClient(app) as client, client.websocket_connect("/ws/alerts") as connection:
+        hello = connection.receive_json()
+        assert hello["type"] == "system"
 
-            connection.send_json({"type": "ping"})
-            pong = connection.receive_json()
-            assert pong == {"type": "pong"}
+        connection.send_json({"type": "ping"})
+        pong = connection.receive_json()
+        assert pong == {"type": "pong"}
 
-            connection.send_json({"type": "custom", "value": 42})
-            ack = connection.receive_json()
-            assert ack["type"] == "ack"
-            assert ack["received"] == "custom"
+        connection.send_json({"type": "custom", "value": 42})
+        ack = connection.receive_json()
+        assert ack["type"] == "ack"
+        assert ack["received"] == "custom"
 
-            payload = {
-                "type": "alert",
-                "symbol": "BTCUSDT",
-                "price": 42000.0,
-            }
+        payload = {
+            "type": "alert",
+            "symbol": "BTCUSDT",
+            "price": 42000.0,
+        }
 
-            client.portal.call(client.app.state.alerts_ws_manager.broadcast, payload)
-            broadcast = connection.receive_json()
-            assert broadcast == payload
+        client.portal.call(client.app.state.alerts_ws_manager.broadcast, payload)
+        broadcast = connection.receive_json()
+        assert broadcast == payload

--- a/backend/tests/test_api_endpoints.py
+++ b/backend/tests/test_api_endpoints.py
@@ -171,7 +171,7 @@ class DummyUserService:
         exp = payload.get("exp")
         if isinstance(exp, datetime):
             return exp
-        if isinstance(exp, (int, float)):
+        if isinstance(exp, int | float):
             return datetime.utcfromtimestamp(exp)
         raise DummyUserService.InvalidTokenError("Token inválido")
 


### PR DESCRIPTION
## Summary
- add TYPE_CHECKING imports to SQLAlchemy models to satisfy forward references
- update alert-related tests to use modern isinstance unions and flattened context manager

## Testing
- pytest backend/tests/test_alerts_websocket.py

------
https://chatgpt.com/codex/tasks/task_e_68df01138c548321848e11885bcf7096