### PR TITLE
Fix import ordering for Postman scripts and format AsyncMock

### DIFF
--- a/backend/tests/test_market_service_extended.py
+++ b/backend/tests/test_market_service_extended.py
@@ -867,7 +867,13 @@ async def test_get_crypto_price_returns_none_when_no_data(monkeypatch: pytest.Mo
 @pytest.mark.asyncio
 async def test_get_stock_price_handles_non_numeric_change(monkeypatch: pytest.MonkeyPatch) -> None:
     service = MarketService()
-    service.stock_service.get_price = AsyncMock(return_value={"price": 200.0, "change": "bad", "source": "Test"})  # type: ignore[assignment]
+    service.stock_service.get_price = AsyncMock(
+        return_value={
+            "price": 200.0,
+            "change": "bad",
+            "source": "Test",
+        }
+    )  # type: ignore[assignment]
 
     result = await service.get_stock_price("aapl")
     assert result["raw_change"] is None

--- a/scripts/generate_postman.py
+++ b/scripts/generate_postman.py
@@ -1,18 +1,17 @@
 #!/usr/bin/env python3
-import argparse
-import json
 import sys
 from pathlib import Path
-
-from fastapi.openapi.utils import get_openapi
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-# Importa la app principal
 from backend.main import app  # si no existe aquí, ajusta a la ruta real sin romper el proyecto
 
+import argparse
+import json
+
+from fastapi.openapi.utils import get_openapi
 
 def export_openapi(dest: Path) -> dict:
     schema = get_openapi(

--- a/scripts/generate_postman_collection.py
+++ b/scripts/generate_postman_collection.py
@@ -19,7 +19,6 @@ if str(ROOT_DIR) not in sys.path:
 
 from backend.main import app
 
-
 def _build_url(path: str) -> Dict[str, Any]:
     parts = [segment for segment in path.strip("/").split("/") if segment]
     return {


### PR DESCRIPTION
## Summary
- move the backend app import to the top of the Postman generation scripts while keeping their path bootstrapping
- wrap the stock price AsyncMock configuration across multiple lines to satisfy linting requirements

## Testing
- python scripts/generate_postman.py --export-openapi --openapi-out /tmp/openapi.json
- python scripts/generate_postman_collection.py --out /tmp/collection.json

------
https://chatgpt.com/codex/tasks/task_e_68df0fbd9e888321941735be3c78bd90