### PR TITLE
Fix import ordering for postman utilities

### DIFF
--- a/backend/tests/test_api_endpoints.py
+++ b/backend/tests/test_api_endpoints.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import importlib
+import importlib  # Standard library module used for dynamic imports.
 import asyncio
 import os
 import uuid

--- a/scripts/generate_postman.py
+++ b/scripts/generate_postman.py
@@ -1,17 +1,17 @@
 #!/usr/bin/env python3
+import argparse
+import json
 import sys
 from pathlib import Path
 
+from fastapi.openapi.utils import get_openapi
+
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
+    # Allow importing the backend package when running the script directly.
     sys.path.insert(0, str(ROOT))
 
 from backend.main import app  # si no existe aquí, ajusta a la ruta real sin romper el proyecto
-
-import argparse
-import json
-
-from fastapi.openapi.utils import get_openapi
 
 def export_openapi(dest: Path) -> dict:
     schema = get_openapi(

--- a/scripts/generate_postman_collection.py
+++ b/scripts/generate_postman_collection.py
@@ -15,6 +15,7 @@ os.environ.setdefault("BULLBEAR_SKIP_AUTOCREATE", "1")
 
 ROOT_DIR = Path(__file__).resolve().parents[1]
 if str(ROOT_DIR) not in sys.path:
+    # Ensure the backend package can be imported when invoking the script directly.
     sys.path.insert(0, str(ROOT_DIR))
 
 from backend.main import app


### PR DESCRIPTION
## Summary
- reorganize imports in the Postman export scripts and explain the sys.path adjustments needed for backend imports
- document the dynamic import usage in the API endpoint tests to keep linting clean

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68df12c9012c8321ab600ac82e487c5b