### PR TITLE
Fix import structure for Postman utility scripts

### DIFF
--- a/scripts/generate_postman.py
+++ b/scripts/generate_postman.py
@@ -4,14 +4,11 @@ import json
 import sys
 from pathlib import Path
 
+from backend.main import app
 from fastapi.openapi.utils import get_openapi
 
 ROOT = Path(__file__).resolve().parents[1]
-if str(ROOT) not in sys.path:
-    # Allow importing the backend package when running the script directly.
-    sys.path.insert(0, str(ROOT))
-
-from backend.main import app  # si no existe aquí, ajusta a la ruta real sin romper el proyecto
+sys.path.insert(0, str(ROOT))
 
 def export_openapi(dest: Path) -> dict:
     schema = get_openapi(

--- a/scripts/generate_postman_collection.py
+++ b/scripts/generate_postman_collection.py
@@ -9,16 +9,14 @@ from collections import defaultdict
 from pathlib import Path
 from typing import Any, Dict, List
 
+from backend.main import app
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
 os.environ.setdefault("ENV", "testing")
 os.environ.setdefault("TESTING", "True")
 os.environ.setdefault("BULLBEAR_SKIP_AUTOCREATE", "1")
-
-ROOT_DIR = Path(__file__).resolve().parents[1]
-if str(ROOT_DIR) not in sys.path:
-    # Ensure the backend package can be imported when invoking the script directly.
-    sys.path.insert(0, str(ROOT_DIR))
-
-from backend.main import app
 
 def _build_url(path: str) -> Dict[str, Any]:
     parts = [segment for segment in path.strip("/").split("/") if segment]


### PR DESCRIPTION
## Summary
- move the backend application import to the top of `generate_postman.py` and set the project root path immediately after the import block
- reorder imports in `generate_postman_collection.py`, relocating the backend import with the other imports and moving the root path setup directly beneath them

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df18aa700c832196492bff7d6b8fa2