### PR TITLE
Update Ruff lint configuration for lint rule grouping

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,9 +18,10 @@ src = ["backend"]
 extend-exclude = [".venv"]
 
 [tool.ruff.lint]
-extend-select = ["I"]
-select = ["E", "F", "I", "UP", "B", "SIM", "PIE"]
+# mueve aquí lo que hoy tienes como "ignore" y "select"
 ignore = []
+select = ["E", "F", "I", "UP", "B", "SIM", "PIE"]
+extend-select = ["I"]
 
 [tool.ruff.format]
 indent-style = "space"


### PR DESCRIPTION
## Summary
- add guidance comment to the Ruff lint section and keep select/ignore lists there
- ensure the Ruff lint block explicitly sets extend-select to include the I rules

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df2534b0a88321b2dc833e657721bb