### PR TITLE
Update linting configs to align Ruff and isort settings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.19.0
+    rev: v3.17.0
     hooks:
       - id: pyupgrade
         args: ["--py312-plus"]
@@ -10,17 +10,17 @@ repos:
     hooks:
       - id: black
 
-  - repo: https://github.com/charliermarsh/ruff-pre-commit
+  - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.6.9
     hooks:
       - id: ruff
         args: ["--fix"]
+      - id: ruff-format
 
   - repo: https://github.com/PyCQA/isort
     rev: 5.13.2
     hooks:
       - id: isort
-        args: ["--profile", "black"]
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,10 @@ profile = "black"
 line_length = 100
 src_paths = ["backend"]
 skip = [".venv"]
+combine_as_imports = true
+force_grid_wrap = 0
+known_first_party = ["backend", "frontend", "scripts"]
+known_third_party = ["fastapi", "sqlalchemy", "pytest"]
 
 [tool.ruff]
 line-length = 100
@@ -19,8 +23,8 @@ extend-exclude = [".venv"]
 
 [tool.ruff.lint]
 # mueve aquí lo que hoy tienes como "ignore" y "select"
-ignore = []
-select = ["E", "F", "I", "UP", "B", "SIM", "PIE"]
+ignore = ["E501"]
+select = ["E", "F", "B", "UP", "SIM", "I"]
 extend-select = ["I"]
 
 [tool.ruff.format]


### PR DESCRIPTION
## Summary
- align Black, Ruff, and isort settings for consistent import handling and linting targets
- update pre-commit hooks to include Ruff formatting and synced tool versions

## Testing
- ⚠️ `pre-commit clean` *(fails: `pre-commit` unavailable in container and installation is blocked by network proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68df2861e8fc8321970014dca9715e70