### PR TITLE
Configure Ruff per-file E402 ignores

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,10 @@ ignore = ["E501"]
 select = ["E", "F", "B", "UP", "SIM", "I"]
 extend-select = ["I"]
 
+[tool.ruff.lint.per-file-ignores]
+"backend/tests/*" = ["E402"]
+"scripts/*" = ["E402"]
+
 [tool.ruff.format]
 indent-style = "space"
 quote-style = "double"


### PR DESCRIPTION
## Summary
- add Ruff per-file ignores to allow non-top-level imports in tests and scripts while keeping existing lint rules intact

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df34bc78b0832199fccd8565691fcc