### PR TITLE
Normalize lint configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,25 +7,13 @@ extend-exclude = """
 
 [tool.isort]
 profile = "black"
-line_length = 100
-src_paths = ["backend"]
-skip = [".venv"]
-combine_as_imports = true
-force_grid_wrap = 0
-known_first_party = ["backend", "frontend", "scripts"]
-known_third_party = ["fastapi", "sqlalchemy", "pytest"]
 
 [tool.ruff]
-line-length = 100
 target-version = "py312"
-src = ["backend"]
-extend-exclude = [".venv"]
 
 [tool.ruff.lint]
-# mueve aquí lo que hoy tienes como "ignore" y "select"
-ignore = ["E501"]
-select = ["E", "F", "B", "UP", "SIM", "I"]
-extend-select = ["I"]
+select = ["E", "F", "I"]
+ignore = []
 
 [tool.ruff.lint.per-file-ignores]
 "backend/tests/*" = ["E402"]


### PR DESCRIPTION
## Summary
- replace the isort configuration with the standard black profile
- reset Ruff settings to use the requested target version and lint rule set
- keep the per-file ignores aligned with the new lint configuration

## Testing
- pre-commit autoupdate *(fails: `pre-commit` is not installed and installation is blocked by proxy restrictions)*
- pre-commit clean *(not run: dependency installation failed)*
- pre-commit run --all-files *(not run: dependency installation failed)*

------
https://chatgpt.com/codex/tasks/task_e_68df383b8ca48321ac728a8c74958abf