### PR TITLE
Adjust Ruff configuration for linting exceptions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,14 +10,15 @@ profile = "black"
 
 [tool.ruff]
 target-version = "py312"
+line-length = 100
 
 [tool.ruff.lint]
 select = ["E", "F", "I"]
 ignore = []
 
 [tool.ruff.lint.per-file-ignores]
-"backend/tests/*" = ["E402"]
-"scripts/*" = ["E402"]
+"backend/tests/*" = ["E402", "E501"]
+"scripts/*" = ["E402", "E501"]
 
 [tool.ruff.format]
 indent-style = "space"


### PR DESCRIPTION
## Summary
- set Ruff to target Python 3.12 with a 100 character line length
- ensure lint checks focus on E, F, and I codes without global ignores
- allow tests and scripts to skip E402 and E501 violations while retaining Black isort profile

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df39ed9b1c832194c4990141f4c777