### PR TITLE
Remove ruff-format hook from pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,6 @@ repos:
     hooks:
       - id: ruff
         args: ["--fix"]
-      - id: ruff-format
 
   - repo: https://github.com/PyCQA/isort
     rev: 5.13.2


### PR DESCRIPTION
## Summary
- update the pre-commit configuration to disable the `ruff-format` hook while keeping automatic fixes enabled via `ruff`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df417a869c8321aca87c01945754a7