### PR TITLE
Fix alerts resilience tests to use shared client fixture

### DIFF
--- a/backend/tests/test_alerts_resilience.py
+++ b/backend/tests/test_alerts_resilience.py
@@ -21,14 +21,8 @@ from backend.tests.test_alerts_endpoints import (  # noqa: E402
     DummyUserService,
     _auth_header,
     _register_and_login,
-    client as async_client_fixture,
     dummy_user_service,
 )
-
-
-@pytest.fixture(name="client")
-def _client_fixture(async_client_fixture):  # noqa: ANN001
-    return async_client_fixture
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- remove the redundant client fixture wrapper from alerts resilience tests
- rely on the shared client fixture provided by conftest

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68df45b4a69083219773685aa2e083dd