### PR TITLE
Add async client fixtures for backend tests

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,21 @@
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from backend.main import app
+
+
+@pytest_asyncio.fixture()
+async def async_client() -> AsyncClient:
+    """Create an AsyncClient bound to the FastAPI app for integration tests."""
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+        yield client
+
+
+@pytest.fixture(name="client")
+def client_fixture(async_client: AsyncClient) -> AsyncClient:
+    """
+    Wrapper para compatibilidad.
+    Permite que los tests usen `client` aunque internamente siga siendo `async_client`.
+    """
+    return async_client


### PR DESCRIPTION
## Summary
- add a shared `async_client` fixture for backend tests and expose a compatibility `client` alias

## Testing
- pytest backend/tests/test_alerts_resilience.py -vv

------
https://chatgpt.com/codex/tasks/task_e_68df4e464ef483218824986af55b98b9