### PR TITLE
Silence SVG and WebSocket console warnings in tests

### DIFF
--- a/frontend/jest.setup.ts
+++ b/frontend/jest.setup.ts
@@ -4,6 +4,33 @@ import "jest-axe/extend-expect";
 // Configura una URL de API por defecto para los tests del frontend
 process.env.NEXT_PUBLIC_API_URL ??= "http://localhost:8000";
 
+const originalError = console.error;
+
+beforeAll(() => {
+  console.error = (...args: any[]) => {
+    const [message] = args;
+
+    if (typeof message === "string") {
+      if (/Warning:.*(linearGradient|stop|defs)/.test(message)) {
+        return;
+      }
+
+      if (
+        message.includes("Mensaje WS no parseable") ||
+        message.includes("No se pudo construir la URL del WebSocket")
+      ) {
+        return;
+      }
+    }
+
+    originalError.call(console, ...args);
+  };
+});
+
+afterAll(() => {
+  console.error = originalError;
+});
+
 if (typeof (global as any).ResizeObserver === "undefined") {
   (global as any).ResizeObserver = class {
     observe() {}


### PR DESCRIPTION
## Summary
- add a console.error override in the Jest setup to silence SVG warning spam and WebSocket parsing errors during tests

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dfe70c8edc83219f828f5b0f364cae