### PR TITLE
Improve indicator data normalization and tagging

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -181,6 +181,10 @@ OPENAPI_TAGS = [
         "description": "Suscripciones y preferencias de notificaciones push.",
     },
     {
+        "name": "indicators",
+        "description": "Cálculo de indicadores técnicos basados en datos OHLCV.",
+    },
+    {
         "name": "portfolio",
         "description": "Importación, exportación y consulta de portafolios.",
     },


### PR DESCRIPTION
## Summary
- normalize and validate candle inputs in the indicators service before computing ATR, RSI, Ichimoku and VWAP
- harden the indicators router by coercing metadata to sequences, accepting open prices and sanitizing close values
- document the indicators API in the OpenAPI tag list for better discoverability

## Testing
- pytest backend/tests/test_indicators.py -vv
- pytest backend/tests/test_push_notifications.py -vv

------
https://chatgpt.com/codex/tasks/task_e_68dffa5b79bc8321a50b6d5a7e0c24f5