### PR TITLE
Log alert dispatch rate limit violations and stabilize portfolio tests

### DIFF
--- a/backend/routers/alerts.py
+++ b/backend/routers/alerts.py
@@ -294,12 +294,16 @@ async def send_alert_notification(
 async def _dispatch_alert_rate_limit(request: Request, response: Response) -> None:
     del response  # el helper replica la firma del dependency original
     client_ip = request.client.host if request.client else "testclient"
-    await rate_limiter.record_hit(
-        key="alerts:dispatch",
-        client_ip=client_ip,
-        weight=1,
-        detail="Demasiadas solicitudes de envío de alertas",
-    )
+    try:
+        await rate_limiter.record_hit(
+            key="alerts:dispatch",
+            client_ip=client_ip,
+            weight=1,
+            detail="Demasiadas solicitudes de envío de alertas",
+        )
+    except HTTPException:
+        _record_alert_rate_limit(request, action="dispatch")
+        raise
 
 
 __all__ = [

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,6 +1,8 @@
 import os
 from pathlib import Path
 
+os.environ.setdefault("TESTING", "1")
+
 import pytest
 import pytest_asyncio
 from httpx import ASGITransport, AsyncClient


### PR DESCRIPTION
## Summary
- ensure the alert dispatch rate limit helper records metrics when the limit is exceeded by wrapping the rate limiter call
- avoid hitting live market data providers when the test suite runs by enabling the testing flag and skipping the default MarketService instance so portfolio endpoints respond immediately under test

## Testing
- pytest backend/tests/test_push_notifications.py::test_push_subscription_and_send -vv
- pytest backend/tests/test_rate_limits.py::test_alert_dispatch_rate_limit -vv
- pytest backend/tests/test_alert_service.py::test_fetch_alerts_returns_persisted_alert -vv
- pytest backend/tests/test_alerts.py -vv
- pytest backend/tests/test_alerts_endpoints.py -vv
- pytest backend/tests/test_portfolio.py -vv

------
https://chatgpt.com/codex/tasks/task_e_68e0492bb56483218077a6d16467982e