### PR TITLE
Fix optional import resolver indentation

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -52,14 +52,16 @@ def _resolve_risk_profile_backfill() -> Callable[[object], None] | None:
     for module_name, attr_name in module_candidates:
         try:
             module = importlib.import_module(module_name)
-        except ModuleNotFoundError:  # pragma: no cover - optional dependency
-            continue
-        except Exception:  # pragma: no cover - defensively ignore import issues
-            continue
-
-        candidate = getattr(module, attr_name, None)
-        if callable(candidate):
-            return candidate
+        except ModuleNotFoundError:
+            continue  # dependencia opcional ausente
+        except ImportError:
+            continue  # nosec B110: módulo presente pero no usable en este entorno
+        except Exception:
+            continue  # nosec B110: import inesperado falla; seguimos con el siguiente
+        else:
+            candidate = getattr(module, attr_name, None)
+            if callable(candidate):
+                return candidate
 
     return None
 


### PR DESCRIPTION
## Summary
- update the optional import resolver helper in backend/database.py to use a safe try/except/else structure
- ensure callable resolution only happens when the import succeeds, keeping optional backfill logic unchanged

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e07fadca808321925d347ca89da704