### PR TITLE
chore: reorder imports and move loggers

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -15,10 +15,8 @@ from backend.core.logging_config import get_logger, log_event
 from backend.core.metrics import MetricsMiddleware, metrics_router
 from backend.core.tracing import configure_tracing
 from backend.models.base import Base
-
-# Routers de la app
-from backend.routers import health  # nuevo router de salud
 from backend.routers import ai, alerts, auth, indicators, markets, news, portfolio, push
+from backend.routers import health  # nuevo router de salud
 from backend.services.alert_service import alert_service
 from backend.services.integration_reporter import log_api_integration_report
 from backend.services.websocket_manager import AlertWebSocketManager

--- a/backend/routers/alerts.py
+++ b/backend/routers/alerts.py
@@ -31,9 +31,9 @@ except Exception:  # pragma: no cover - tests may inject a stub
     user_service = None  # type: ignore[assignment]
 
 
+logger = get_logger(service="alerts_router")
 router = APIRouter(tags=["alerts"])
 security = HTTPBearer(auto_error=True)
-logger = get_logger(service="alerts_router")
 USER_SERVICE_ERROR: dict[str, str] | None = None
 
 _REVERSE_CONDITION_OP = {

--- a/backend/routers/markets.py
+++ b/backend/routers/markets.py
@@ -10,11 +10,16 @@ from fastapi import APIRouter, HTTPException, Query
 
 from backend.core.logging_config import get_logger, log_event
 from backend.services.timeseries_service import get_closes
-from backend.utils.indicators import average_true_range  # [Codex] nuevo
-from backend.utils.indicators import ichimoku_cloud  # [Codex] nuevo
-from backend.utils.indicators import stochastic_rsi  # [Codex] nuevo
-from backend.utils.indicators import volume_weighted_average_price  # [Codex] nuevo
-from backend.utils.indicators import bollinger, ema, macd, rsi
+from backend.utils.indicators import (
+    average_true_range,  # [Codex] nuevo
+    bollinger,
+    ema,
+    ichimoku_cloud,  # [Codex] nuevo
+    macd,
+    rsi,
+    stochastic_rsi,  # [Codex] nuevo
+    volume_weighted_average_price,  # [Codex] nuevo
+)
 
 try:  # pragma: no cover - allow running from different entrypoints
     from services.forex_service import forex_service
@@ -23,8 +28,8 @@ except ImportError:  # pragma: no cover - fallback for package-based imports
     from backend.services.forex_service import forex_service  # type: ignore
     from backend.services.market_service import market_service  # type: ignore
 
-router = APIRouter(tags=["Markets"])
 logger = get_logger(service="markets_router")
+router = APIRouter(tags=["Markets"])
 
 
 def _parse_symbols(raw: Sequence[str] | str) -> list[str]:

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,11 +1,11 @@
 import os
 from pathlib import Path
 
-os.environ.setdefault("TESTING", "1")
-
 import pytest
 import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
+
+os.environ.setdefault("TESTING", "1")
 
 TEST_DB_PATH = Path("/tmp/test_suite.db")
 os.environ["DATABASE_URL"] = f"sqlite:///{TEST_DB_PATH}"  # ensure isolated DB for tests


### PR DESCRIPTION
## Summary
- reorder imports in the backend entrypoint and routers to satisfy Ruff ordering rules
- consolidate indicator imports and ensure logger initialization occurs after imports
- normalize test fixtures by placing imports before environment setup for Ruff compliance

## Testing
- ruff check backend/main.py backend/models/alert.py backend/routers/ai.py backend/routers/markets.py backend/routers/alerts.py backend/services/user_service.py backend/tests/conftest.py backend/tests/test_alerts_endpoints.py backend/tests/test_api_endpoints.py backend/tests/test_rate_limits.py backend/tests/test_user_service_tokens_rotation.py

------
https://chatgpt.com/codex/tasks/task_e_68e0851719608321aafd2b8379e6b648