### PR TITLE
Fix risk profile backfill import handling

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -54,11 +54,9 @@ def _resolve_risk_profile_backfill() -> Callable[[object], None] | None:
     for module_name, attr_name in module_candidates:
         try:
             module = importlib.import_module(module_name)
-        except ModuleNotFoundError:
-            continue  # dependencia opcional ausente
         except ImportError:
-            continue  # nosec B110: módulo presente pero no usable en este entorno
-        except Exception:
+            continue  # nosec B110: dependencia opcional ausente o no usable
+        except Exception:  # noqa: BLE001
             continue  # nosec B110: import inesperado falla; seguimos con el siguiente
         else:
             candidate = getattr(module, attr_name, None)


### PR DESCRIPTION
## Summary
- simplify `_resolve_risk_profile_backfill` import error handling by collapsing the redundant except chain and keeping security guidance
- maintain module structure with the future import first and logger defined after imports without changing runtime behavior

## Testing
- ruff check backend/database.py
- black backend/database.py
- pytest backend/tests/test_alert_service.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e08a5e0dc48321ba0739e27b7d33fd