### PR TITLE
Align web push endpoints and env usage

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -241,6 +241,11 @@ app.include_router(news.router, prefix="/api/news", tags=["news"])
 app.include_router(auth.router)
 app.include_router(ai.router, prefix="/api/ai", tags=["ai"])
 app.include_router(push.router, prefix="/api/push", tags=["push"])
+app.include_router(
+    push.router,
+    prefix="/api/notifications",
+    tags=["notifications"],
+)  # ✅ Codex fix: exponemos el nuevo alias definitivo para el flujo de Web Push.
 app.include_router(notifications.router)  # ✅ Codex fix: exposición del endpoint /api/notify/test.
 app.include_router(portfolio.router)
 app.include_router(indicators.router)

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -516,7 +516,7 @@ export function subscribePush(
   token: string
 ) {
   return request<PushSubscriptionResponse>(
-    "/api/push/subscribe",
+    "/api/notifications/subscribe", // ✅ Codex fix: usamos el endpoint final consolidado para las suscripciones push.
     {
       method: "POST",
       body: JSON.stringify(payload),


### PR DESCRIPTION
## Summary
- expose the push router through the final /api/notifications prefix while keeping existing routes
- prioritize environment-provided VAPID keys and claims inside the push service setup
- point the frontend push subscription helper at the consolidated notifications endpoint

## Testing
- pytest backend/tests/test_push_notifications.py

------
https://chatgpt.com/codex/tasks/task_e_68e167323f948321ae41921e8a8daf8f