### PR TITLE
Fix Babel preset configuration for Next.js 15 ESM runtime

### DIFF
--- a/frontend/babel.config.js
+++ b/frontend/babel.config.js
@@ -1,12 +1,17 @@
 const config = {
   presets: [
+    "next/babel",
     [
       "@babel/preset-env",
-      { targets: { node: "current" }, modules: "commonjs" },
+      // Keep modules disabled so that Babel preserves native ESM output for Next.js tooling.
+      { targets: { node: "current" }, modules: false },
+    ],
+    [
+      "@babel/preset-react",
+      // Ensure the automatic JSX runtime so that React imports remain implicit across the app.
+      { runtime: "automatic" },
     ],
     "@babel/preset-typescript",
-    "@babel/preset-react",
-    "next/babel",
   ],
   ignore: [],
 };


### PR DESCRIPTION
## Summary
- reorder and consolidate the frontend Babel presets to align with Next.js 15 expectations while preserving ESM output
- enable the automatic JSX runtime so React imports remain implicit during the build

## Testing
- CI=1 npm --prefix frontend run build
- CI=1 npm --prefix frontend run test:dev -- --coverage

------
https://chatgpt.com/codex/tasks/task_e_68e17ff5c4548321bdf6401fdfc5dcf5