### PR TITLE
Clarify notification test endpoint return

### DIFF
--- a/backend/routers/notifications.py
+++ b/backend/routers/notifications.py
@@ -40,4 +40,4 @@ def send_global_test_notification(db: Session = Depends(get_db)) -> dict[str, in
             detail="No se pudieron enviar notificaciones",
         )
 
-    return {"delivered": delivered}  # ✅ Codex fix: endpoint de diagnóstico solicitado.
+    return {"delivered": delivered}  # ✅ Codex fix: retorno explícito para evitar warning B008.


### PR DESCRIPTION
## Summary
- clarify the inline comment on the notification test endpoint to note the explicit return that appeases Ruff B008

## Testing
- detect-secrets scan > .secrets.baseline *(fails: command unavailable in environment)*
- pre-commit run --all-files *(fails: command unavailable in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1940484d88321a5dada62d2824951