### PR TITLE
Add structured logging middleware and global error handlers

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -14,6 +14,10 @@ from backend.core.http_logging import RequestLogMiddleware
 from backend.core.logging_config import get_logger, log_event
 from backend.core.metrics import MetricsMiddleware, metrics_router
 from backend.core.tracing import configure_tracing
+# ✅ Codex fix: Import structured logging middleware
+from backend.middleware.logging_middleware import LoggingMiddleware
+# ✅ Codex fix: Import global error handlers
+from backend.middleware.error_handler import register_error_handlers
 from backend.models.base import Base
 
 # Routers de la app
@@ -216,6 +220,11 @@ app.add_middleware(
 )
 app.add_middleware(MetricsMiddleware)
 app.add_middleware(RequestLogMiddleware)
+# ✅ Codex fix: Register structured logging middleware
+app.add_middleware(LoggingMiddleware)
+
+# ✅ Codex fix: Enable global error handlers
+register_error_handlers(app)
 
 
 # Endpoint raíz (health básico de la API)

--- a/backend/middleware/__init__.py
+++ b/backend/middleware/__init__.py
@@ -1,0 +1,3 @@
+"""Middleware package for backend utilities."""
+
+# ✅ Codex fix: Initialize middleware package

--- a/backend/middleware/error_handler.py
+++ b/backend/middleware/error_handler.py
@@ -1,0 +1,66 @@
+"""Global error handling utilities for the FastAPI backend."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
+
+
+def register_error_handlers(app: FastAPI) -> None:
+    """Attach custom exception handlers to the provided FastAPI application."""
+
+    # ✅ Codex fix: Handle FastAPI HTTP exceptions with structured logging
+    @app.exception_handler(HTTPException)
+    async def handle_http_exception(
+        request: Request,
+        exc: HTTPException,
+    ) -> JSONResponse:
+        log_data: dict[str, Any] = {
+            "service": "backend",
+            "event": "http_error",
+            "method": request.method,
+            "path": request.url.path,
+            "status": exc.status_code,
+            "detail": exc.detail,
+        }
+        logging.error(json.dumps(log_data))
+        return JSONResponse({"detail": exc.detail}, status_code=exc.status_code)
+
+    # ✅ Codex fix: Provide consistent validation error responses
+    @app.exception_handler(RequestValidationError)
+    async def handle_validation_error(
+        request: Request,
+        exc: RequestValidationError,
+    ) -> JSONResponse:
+        log_data: dict[str, Any] = {
+            "service": "backend",
+            "event": "validation_error",
+            "method": request.method,
+            "path": request.url.path,
+            "status": 422,
+            "errors": exc.errors(),
+        }
+        logging.error(json.dumps(log_data))
+        return JSONResponse({"error": "Validation Error"}, status_code=422)
+
+    # ✅ Codex fix: Capture unexpected exceptions globally
+    @app.exception_handler(Exception)
+    async def handle_unexpected_exception(
+        request: Request,
+        exc: Exception,
+    ) -> JSONResponse:
+        log_data: dict[str, Any] = {
+            "service": "backend",
+            "event": "internal_error",
+            "method": request.method,
+            "path": request.url.path,
+            "status": 500,
+            "error": str(exc),
+        }
+        logging.error(json.dumps(log_data))
+        return JSONResponse({"error": "Internal Server Error"}, status_code=500)

--- a/backend/middleware/logging_middleware.py
+++ b/backend/middleware/logging_middleware.py
@@ -1,0 +1,64 @@
+"""Structured logging middleware for FastAPI requests."""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from datetime import datetime, timezone
+from typing import Awaitable, Callable
+from uuid import uuid4
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+from starlette.types import ASGIApp
+
+
+class LoggingMiddleware(BaseHTTPMiddleware):
+    """Middleware that records structured JSON logs for each HTTP request."""
+
+    # ✅ Codex fix: Initialize logging middleware
+    def __init__(self, app: ASGIApp) -> None:
+        super().__init__(app)
+
+    async def dispatch(
+        self,
+        request: Request,
+        call_next: Callable[[Request], Awaitable[Response]],
+    ) -> Response:
+        """Process the request and emit structured logs when completed."""
+
+        # ✅ Codex fix: Capture request metadata for structured logging
+        start_time = time.monotonic()
+        request_id = str(uuid4())
+        response: Response | None = None
+        status_code = 500
+
+        try:
+            response = await call_next(request)
+            status_code = response.status_code
+        except Exception:
+            # ✅ Codex fix: Preserve original exception while ensuring logging occurs
+            status_code = 500
+            raise
+        finally:
+            duration_ms = (time.monotonic() - start_time) * 1000
+            timestamp = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+            log_data = {
+                "service": "backend",
+                "event": "http_request",
+                "method": request.method,
+                "path": request.url.path,
+                "status": status_code,
+                "duration_ms": round(duration_ms, 2),
+                "request_id": request_id,
+                "timestamp": timestamp,
+            }
+            logging.info(json.dumps(log_data))
+
+        if response is None:
+            # ✅ Codex fix: Defensive guard for unexpected middleware behavior
+            raise RuntimeError("LoggingMiddleware received no response from downstream application")
+
+        return response

--- a/backend/tests/test_middleware_logging_and_errors.py
+++ b/backend/tests/test_middleware_logging_and_errors.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+import pytest
+# ✅ Codex fix: HTTPX utilities for exercising middleware behavior
+from httpx import ASGITransport, AsyncClient
+
+from backend.main import app
+
+
+@pytest.mark.asyncio
+async def test_logging_middleware_logs_request(
+    monkeypatch: pytest.MonkeyPatch,
+    client: Any,
+) -> None:
+    """Ensure the structured logging middleware emits the expected log entry."""
+
+    # ✅ Codex fix: Capture logging output for assertions
+    logged_messages: list[str] = []
+
+    def fake_info(message: str, *args: object, **kwargs: object) -> None:
+        logged_messages.append(message)
+
+    monkeypatch.setattr(logging, "info", fake_info)
+
+    response = await client.get("/api/health")
+
+    assert response.status_code == 200
+
+    parsed_events = []
+    for entry in logged_messages:
+        try:
+            data = json.loads(entry)
+        except (TypeError, json.JSONDecodeError):
+            continue
+        if data.get("event") == "http_request":
+            parsed_events.append(data)
+
+    assert parsed_events, "Expected at least one structured log entry for the request"
+    assert any(item.get("status") == 200 for item in parsed_events)
+
+
+@pytest.mark.asyncio
+async def test_unknown_route_returns_structured_error(client: Any) -> None:
+    """Unknown routes should return a JSON error payload with a 404 status code."""
+
+    # ✅ Codex fix: Trigger FastAPI's default 404 handling
+    response = await client.get("/api/unknown")
+
+    assert response.status_code == 404
+    body = response.json()
+    assert isinstance(body, dict)
+    assert "detail" in body
+
+
+@pytest.mark.asyncio
+async def test_generic_exception_handled_globally() -> None:
+    """Global exception handler should convert unexpected errors into 500 responses."""
+
+    # ✅ Codex fix: Register a temporary route that raises an exception
+    async def force_error() -> None:
+        raise ValueError("forced error")
+
+    route_count = len(app.router.routes)
+    app.router.add_api_route("/api/force_error", force_error, methods=["GET"])
+
+    # ✅ Codex fix: Use transport that preserves exception responses
+    transport = ASGITransport(app=app, raise_app_exceptions=False)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as async_client:
+        try:
+            response = await async_client.get("/api/force_error")
+        finally:
+            # ✅ Codex fix: Clean up temporary test route
+            while len(app.router.routes) > route_count:
+                app.router.routes.pop()
+
+    assert response.status_code == 500
+    assert response.json() == {"error": "Internal Server Error"}


### PR DESCRIPTION
## Summary
- add a structured logging middleware that records request metadata
- register global error handlers for HTTP, validation, and unexpected exceptions
- add middleware-focused tests covering logging, 404 responses, and generic errors

## Testing
- pytest backend/tests/test_middleware_logging_and_errors.py

------
https://chatgpt.com/codex/tasks/task_e_68e1b38dad04832190a6be7d7770f606