### PR TITLE
Add circuit breakers and metrics to AI service

### DIFF
--- a/backend/metrics/ai_metrics.py
+++ b/backend/metrics/ai_metrics.py
@@ -1,0 +1,29 @@
+"""Métricas Prometheus para el servicio de IA."""
+
+from prometheus_client import Counter, Histogram
+
+# ✅ Codex fix: métricas IA estructuradas
+ai_requests_total = Counter(
+    "ai_requests_total",
+    "Total de requests IA",
+    ["provider", "status"],
+)
+
+ai_latency_seconds = Histogram(
+    "ai_latency_seconds",
+    "Latencia IA por proveedor",
+    ["provider"],
+)
+
+ai_fallbacks_total = Counter(
+    "ai_fallbacks_total",
+    "Número de fallbacks IA",
+    ["from_provider", "to_provider"],
+)
+
+ai_failures_total = Counter(
+    "ai_failures_total",
+    "Errores IA",
+    ["provider", "error_type"],
+)
+

--- a/backend/middleware/logging_middleware.py
+++ b/backend/middleware/logging_middleware.py
@@ -15,6 +15,7 @@ from starlette.responses import Response
 from starlette.types import ASGIApp
 
 # ✅ Codex fix: Import Prometheus metrics for HTTP instrumentation
+from backend.metrics.ai_metrics import ai_requests_total
 from backend.routers.metrics import http_requests_total, request_latency_seconds
 
 
@@ -69,6 +70,12 @@ class LoggingMiddleware(BaseHTTPMiddleware):
                 "timestamp": timestamp,
             }
             logging.info(json.dumps(log_data))
+            # ✅ Codex fix: registrar métrica genérica HTTP→IA
+            if "/api/ai" in request.url.path:
+                ai_requests_total.labels(
+                    provider="unknown",
+                    status=str(status_code),
+                ).inc()
 
         if response is None:
             # ✅ Codex fix: Defensive guard for unexpected middleware behavior

--- a/backend/tests/test_ai_service_resilience_extended.py
+++ b/backend/tests/test_ai_service_resilience_extended.py
@@ -1,0 +1,159 @@
+"""Pruebas extendidas de resiliencia para el servicio de IA."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+
+import pytest
+
+from backend.metrics.ai_metrics import (
+    ai_failures_total,
+    ai_fallbacks_total,
+    ai_latency_seconds,
+    ai_requests_total,
+)
+from backend.services.ai_service import AIService, PROVIDER_TIMEOUTS
+
+
+@pytest.fixture(autouse=True)
+def reset_ai_metrics() -> None:
+    """Reinicia los contadores Prometheus entre pruebas."""
+
+    # ✅ Codex fix: asegurar aislamiento métrico
+    ai_requests_total._metrics.clear()  # type: ignore[attr-defined]
+    ai_failures_total._metrics.clear()  # type: ignore[attr-defined]
+    ai_fallbacks_total._metrics.clear()  # type: ignore[attr-defined]
+    ai_latency_seconds._metrics.clear()  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_mistral_circuit_breaker_triggers(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Los fallos consecutivos de Mistral activan el circuit breaker y hacen fallback."""
+
+    service = AIService()
+
+    async def fast_sleep(_: float) -> None:  # noqa: D401 - helper interno
+        return None
+
+    monkeypatch.setattr(asyncio, "sleep", fast_sleep)
+
+    calls = {"mistral": 0, "hugging": 0}
+
+    async def mistral_failure() -> str:
+        calls["mistral"] += 1
+        raise RuntimeError("mistral down")
+
+    async def huggingface_success() -> str:
+        calls["hugging"] += 1
+        return "ok"
+
+    result, provider = await service._call_with_backoff(
+        [
+            ("mistral", mistral_failure),
+            ("huggingface", huggingface_success),
+        ]
+    )
+
+    assert result == "ok"
+    assert provider == "huggingface"
+    assert calls["mistral"] == service._max_retries
+
+    circuit = service._get_circuit("mistral")
+    assert circuit.state == "open"
+
+    calls_before_second = calls["mistral"]
+    result_repeat, provider_repeat = await service._call_with_backoff(
+        [
+            ("mistral", mistral_failure),
+            ("huggingface", huggingface_success),
+        ]
+    )
+
+    assert result_repeat == "ok"
+    assert provider_repeat == "huggingface"
+    assert calls["mistral"] == calls_before_second  # saltado por circuit breaker
+
+
+@pytest.mark.asyncio
+async def test_provider_timeout_respected(monkeypatch: pytest.MonkeyPatch) -> None:
+    """El timeout adaptativo limita la espera por proveedor."""
+
+    service = AIService()
+    service._max_retries = 1  # ejecutar una sola vez para medir tiempo
+    monkeypatch.setitem(PROVIDER_TIMEOUTS, "mistral", 0.2)
+
+    async def slow_provider() -> str:
+        await asyncio.sleep(1)
+        return "never"
+
+    start = time.perf_counter()
+    with pytest.raises(asyncio.TimeoutError):
+        await service._call_with_backoff([("mistral", slow_provider)])
+    elapsed = time.perf_counter() - start
+
+    assert elapsed <= PROVIDER_TIMEOUTS["mistral"] + 0.2
+
+
+@pytest.mark.asyncio
+async def test_structured_logs_emitted(caplog: pytest.LogCaptureFixture) -> None:
+    """Las llamadas generan logs JSON con ai_event."""
+
+    service = AIService()
+    caplog.set_level(logging.INFO)
+
+    async def ok_provider() -> str:
+        return "done"
+
+    await service._call_with_backoff([("mistral", ok_provider)])
+
+    structured = [
+        json.loads(record.message)
+        for record in caplog.records
+        if record.levelno == logging.INFO
+        and record.message.startswith("{")
+        and "ai_event" in record.message
+    ]
+
+    assert structured, "Debe existir al menos un log estructurado ai_event"
+    assert any(entry.get("ai_event") == "provider_call" for entry in structured)
+
+
+@pytest.mark.asyncio
+async def test_ai_metrics_increment_on_calls() -> None:
+    """Las métricas de requests y fallos se actualizan tras las llamadas."""
+
+    service = AIService()
+
+    async def failing_provider() -> str:
+        raise ValueError("provider down")
+
+    async def successful_provider() -> str:
+        return "all good"
+
+    result, provider = await service._call_with_backoff(
+        [
+            ("mistral", failing_provider),
+            ("huggingface", successful_provider),
+        ]
+    )
+
+    assert result == "all good"
+    assert provider == "huggingface"
+
+    failure_metric = ai_failures_total.labels(
+        provider="mistral", error_type="ValueError"
+    )._value.get()  # type: ignore[attr-defined]
+    assert failure_metric >= 1
+
+    success_metric = ai_requests_total.labels(
+        provider="huggingface", status="success"
+    )._value.get()  # type: ignore[attr-defined]
+    assert success_metric == 1
+
+    failure_requests = ai_requests_total.labels(
+        provider="mistral", status="failure"
+    )._value.get()  # type: ignore[attr-defined]
+    assert failure_requests >= 1


### PR DESCRIPTION
## Summary
- add provider-level circuit breaker, adaptive timeouts, and structured logs to the AI service
- introduce dedicated Prometheus metrics for AI requests, failures, latency, and fallbacks
- wire middleware metric for /api/ai traffic and add extended resilience test coverage

## Testing
- `pytest backend/tests/test_ai_service_resilience_extended.py`


------
https://chatgpt.com/codex/tasks/task_e_68e1c2f481a4832184fd7611472412f9