### PR TITLE
Add AI streaming endpoint with SSE support

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -22,7 +22,7 @@ from backend.models.base import Base
 
 # Routers de la app
 from backend.routers import health  # nuevo router de salud
-from backend.routers import ai, alerts, auth, indicators, markets, news, portfolio, push
+from backend.routers import ai, ai_stream, alerts, auth, indicators, markets, news, portfolio, push
 # ✅ Codex fix: Import Prometheus metrics router
 from backend.routers import metrics
 from backend.services.alert_service import alert_service
@@ -243,6 +243,7 @@ app.include_router(markets.router, prefix="/api/markets", tags=["markets"])
 app.include_router(news.router, prefix="/api/news", tags=["news"])
 app.include_router(auth.router)
 app.include_router(ai.router, prefix="/api/ai", tags=["ai"])
+app.include_router(ai_stream.router, prefix="/api/ai", tags=["ai"])
 app.include_router(push.router, prefix="/api/push", tags=["push"])
 app.include_router(portfolio.router, prefix="/api/portfolio", tags=["portfolio"])
 app.include_router(indicators.router)

--- a/backend/metrics/ai_metrics.py
+++ b/backend/metrics/ai_metrics.py
@@ -1,6 +1,6 @@
 """Métricas Prometheus para el servicio de IA."""
 
-from prometheus_client import Counter, Histogram
+from prometheus_client import Counter, Gauge, Histogram
 
 # ✅ Codex fix: métricas IA estructuradas
 ai_requests_total = Counter(
@@ -38,4 +38,19 @@ ai_cache_miss_total = Counter(
     "ai_cache_miss_total",
     "Fallos de caché IA",
     ["model"],
+)
+
+ai_stream_tokens_total = Counter(
+    "ai_stream_tokens_total",
+    "Tokens enviados por streaming",
+)
+
+ai_stream_duration_seconds = Histogram(
+    "ai_stream_duration_seconds",
+    "Duración del streaming IA",
+)
+
+ai_conversations_active_total = Gauge(
+    "ai_conversations_active_total",
+    "Conversaciones IA activas",
 )

--- a/backend/routers/ai_stream.py
+++ b/backend/routers/ai_stream.py
@@ -1,0 +1,40 @@
+"""Streaming responses for AI endpoints."""
+
+from __future__ import annotations
+
+from contextlib import suppress
+from typing import AsyncGenerator
+
+from fastapi import APIRouter, Request
+from fastapi.responses import StreamingResponse
+
+try:  # pragma: no cover - allow running from different entrypoints
+    from backend.services.ai_service import ai_service
+except ImportError:  # pragma: no cover
+    from services.ai_service import ai_service  # type: ignore
+
+router = APIRouter(tags=["AI"])
+
+
+@router.post("/stream")
+async def stream_message(request: Request, payload: dict) -> StreamingResponse:
+    """Stream AI generated responses using Server-Sent Events."""
+
+    message = payload.get("message", "") if isinstance(payload, dict) else ""
+
+    async def stream_generator() -> AsyncGenerator[str, None]:
+        stream = ai_service.stream_generate(message)
+        try:
+            async for chunk in stream:
+                yield f"data: {chunk}\n\n"
+                if await request.is_disconnected():
+                    break
+        finally:
+            with suppress(Exception):
+                await stream.aclose()
+
+    return StreamingResponse(
+        stream_generator(),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "Connection": "keep-alive"},
+    )

--- a/backend/tests/test_ai_stream_endpoint.py
+++ b/backend/tests/test_ai_stream_endpoint.py
@@ -1,0 +1,71 @@
+import json
+from typing import Any, Dict, List, Tuple
+
+import pytest
+from httpx import AsyncClient
+from prometheus_client import REGISTRY
+
+async def _consume_stream(
+    client: AsyncClient, payload: Dict[str, Any]
+) -> Tuple[int, Dict[str, str], List[str]]:
+    async with client.stream("POST", "/api/ai/stream", json=payload) as response:
+        status_code = response.status_code
+        headers = dict(response.headers)
+        chunks: List[str] = []
+        async for line in response.aiter_lines():
+            if line.startswith("data: "):
+                chunks.append(line[len("data: ") :])
+        return status_code, headers, chunks
+
+
+def _metric_value(name: str) -> float:
+    value = REGISTRY.get_sample_value(name)
+    return float(value) if value is not None else 0.0
+
+
+@pytest.mark.asyncio
+async def test_ai_stream_endpoint_returns_sse(async_client: AsyncClient) -> None:
+    status, headers, chunks = await _consume_stream(async_client, {"message": "hola mundo"})
+
+    assert status == 200
+    assert headers.get("content-type", "").startswith("text/event-stream")
+    assert any(chunk for chunk in chunks)
+
+
+@pytest.mark.asyncio
+async def test_ai_stream_endpoint_emits_chunks(async_client: AsyncClient) -> None:
+    _, _, chunks = await _consume_stream(async_client, {"message": "probando el stream"})
+
+    # Debe emitir al menos los tokens y un chunk de finalización
+    assert len(chunks) >= 2
+    for chunk in chunks:
+        assert chunk  # No debe haber chunks vacíos
+
+
+@pytest.mark.asyncio
+async def test_ai_stream_metrics_are_updated(async_client: AsyncClient) -> None:
+    tokens_before = _metric_value("ai_stream_tokens_total")
+    duration_before = _metric_value("ai_stream_duration_seconds_sum")
+    conversations_before = _metric_value("ai_conversations_active_total")
+
+    _, _, chunks = await _consume_stream(async_client, {"message": "metricas en streaming"})
+    total_chunk_length = sum(len(chunk) for chunk in chunks)
+
+    tokens_after = _metric_value("ai_stream_tokens_total")
+    duration_after = _metric_value("ai_stream_duration_seconds_sum")
+    conversations_after = _metric_value("ai_conversations_active_total")
+
+    assert tokens_after >= tokens_before + total_chunk_length
+    assert duration_after > duration_before
+    assert conversations_after == conversations_before
+
+
+@pytest.mark.asyncio
+async def test_ai_stream_handles_exceptions(async_client: AsyncClient) -> None:
+    status, _, chunks = await _consume_stream(async_client, {"message": ""})
+
+    assert status == 200
+    assert chunks, "El stream debe devolver al menos un chunk"
+    error_payload = json.loads(chunks[-1])
+    assert error_payload.get("error") is True
+    assert "vacío" in error_payload.get("message", "")


### PR DESCRIPTION
## Summary
- add a dedicated `/api/ai/stream` router that streams AI responses over Server-Sent Events
- implement `AIService.stream_generate` with simulated token streaming, structured logging, and new Prometheus metrics
- register streaming metrics and cover the new flow with async endpoint tests

## Testing
- pytest backend/tests/test_ai_stream_endpoint.py -vv
- pytest backend/tests -q *(fails: ValueError raised from `AIService._build_prompt` during existing test setup)*
- make lint *(fails: pip cannot download `pre-commit` in the sandboxed environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1cc6a35e88321a908c629343506cf