### PR TITLE
Add contextual AI endpoint with sentiment and persistence

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -22,7 +22,18 @@ from backend.models.base import Base
 
 # Routers de la app
 from backend.routers import health  # nuevo router de salud
-from backend.routers import ai, ai_stream, alerts, auth, indicators, markets, news, portfolio, push
+from backend.routers import (
+    ai,
+    ai_context,
+    ai_stream,
+    alerts,
+    auth,
+    indicators,
+    markets,
+    news,
+    portfolio,
+    push,
+)
 # ✅ Codex fix: Import Prometheus metrics router
 from backend.routers import metrics
 from backend.services.alert_service import alert_service
@@ -243,6 +254,7 @@ app.include_router(markets.router, prefix="/api/markets", tags=["markets"])
 app.include_router(news.router, prefix="/api/news", tags=["news"])
 app.include_router(auth.router)
 app.include_router(ai.router, prefix="/api/ai", tags=["ai"])
+app.include_router(ai_context.router, prefix="/api/ai", tags=["ai"])
 app.include_router(ai_stream.router, prefix="/api/ai", tags=["ai"])
 app.include_router(push.router, prefix="/api/push", tags=["push"])
 app.include_router(portfolio.router, prefix="/api/portfolio", tags=["portfolio"])

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -1,6 +1,7 @@
 from .alert import Alert
 from .base import Base
 from .chat import ChatMessage, ChatSession
+from .chat_context import ChatContext
 from .portfolio import PortfolioItem
 from .push_preference import PushNotificationPreference
 from .push_subscription import PushSubscription
@@ -17,6 +18,7 @@ __all__ = [
     "PortfolioItem",
     "ChatSession",
     "ChatMessage",
+    "ChatContext",
     "PushSubscription",
     "PushNotificationPreference",
 ]

--- a/backend/models/chat_context.py
+++ b/backend/models/chat_context.py
@@ -1,0 +1,19 @@
+from datetime import datetime, timezone
+
+from sqlalchemy import Column, DateTime, Integer, String, Text
+
+try:  # pragma: no cover - support multiple import paths
+    from .base import Base
+except ImportError:  # pragma: no cover
+    from backend.models.base import Base  # type: ignore[no-redef]
+
+
+class ChatContext(Base):
+    __tablename__ = "chat_context"
+
+    id = Column(Integer, primary_key=True, index=True)
+    session_id = Column(String, index=True)
+    user_id = Column(String, index=True, nullable=True)
+    message = Column(Text, nullable=False)
+    response = Column(Text, nullable=False)
+    created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))

--- a/backend/routers/ai_context.py
+++ b/backend/routers/ai_context.py
@@ -1,0 +1,13 @@
+from fastapi import APIRouter
+
+from backend.services.ai_service import ai_service
+
+router = APIRouter()
+
+
+@router.post("/context")
+async def ai_with_context(payload: dict):
+    session_id = payload.get("session_id", "default")
+    message = payload["message"]
+    result = await ai_service.process_with_context(session_id, message)
+    return result

--- a/backend/services/context_service.py
+++ b/backend/services/context_service.py
@@ -1,0 +1,29 @@
+from backend.core.logging_config import get_logger
+from backend.database import SessionLocal
+from backend.models.chat_context import ChatContext
+
+logger = get_logger(service="context_service")
+
+
+def save_message(session_id: str, message: str, response: str) -> None:
+    db = SessionLocal()
+    try:
+        record = ChatContext(session_id=session_id, message=message, response=response)
+        db.add(record)
+        db.commit()
+        logger.info({"event": "context_saved", "session": session_id, "length": len(message)})
+    finally:
+        db.close()
+
+
+def get_history(session_id: str):
+    db = SessionLocal()
+    try:
+        return (
+            db.query(ChatContext)
+            .filter(ChatContext.session_id == session_id)
+            .order_by(ChatContext.created_at)
+            .all()
+        )
+    finally:
+        db.close()

--- a/backend/tests/test_ai_context_endpoint.py
+++ b/backend/tests/test_ai_context_endpoint.py
@@ -1,0 +1,72 @@
+import importlib
+
+import pytest
+from httpx import AsyncClient
+
+sentiment_module = importlib.import_module("backend.services.sentiment_service")
+context_module = importlib.import_module("backend.services.context_service")
+
+
+@pytest.mark.asyncio
+async def test_ai_context_basic_flow(monkeypatch, async_client: AsyncClient):
+    async def fake_process_message(self, message, context=None):
+        class DummyResponse:
+            text = "Respuesta simulada"
+            provider = "test"
+
+        return DummyResponse()
+
+    monkeypatch.setattr(
+        sentiment_module,
+        "analyze_sentiment",
+        lambda text: {"label": "positive", "score": 0.9},
+    )
+    monkeypatch.setattr(context_module, "get_history", lambda session_id: [])
+    monkeypatch.setattr(context_module, "save_message", lambda *args, **kwargs: None)
+
+    from backend.services.ai_service import ai_service
+
+    monkeypatch.setattr(
+        ai_service,
+        "process_message",
+        fake_process_message.__get__(ai_service, ai_service.__class__),
+    )
+
+    payload = {"session_id": "s1", "message": "El mercado está en alza"}
+    response = await async_client.post("/api/ai/context", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["response"] == "Respuesta simulada"
+    assert data["sentiment"]["label"] == "positive"
+    assert data["history_len"] == 0
+
+
+@pytest.mark.asyncio
+async def test_ai_context_handles_sentiment_error(monkeypatch, async_client: AsyncClient):
+    monkeypatch.setattr(
+        sentiment_module,
+        "analyze_sentiment",
+        lambda text: {"label": "unknown", "score": 0.0},
+    )
+    monkeypatch.setattr(context_module, "get_history", lambda session_id: [])
+    monkeypatch.setattr(context_module, "save_message", lambda *args, **kwargs: None)
+
+    from backend.services.ai_service import ai_service
+
+    async def fake_process_message(self, message, context=None):
+        class DummyResponse:
+            text = "Otra respuesta"
+            provider = "test"
+
+        return DummyResponse()
+
+    monkeypatch.setattr(
+        ai_service,
+        "process_message",
+        fake_process_message.__get__(ai_service, ai_service.__class__),
+    )
+
+    payload = {"session_id": "error", "message": "Prueba de fallo"}
+    response = await async_client.post("/api/ai/context", json=payload)
+    assert response.status_code == 200
+    assert response.json()["sentiment"]["label"] == "unknown"


### PR DESCRIPTION
## Summary
- add a ChatContext model and persistence service to store conversational history
- extend the AI service with contextual processing, sentiment analysis, and empty-prompt fallback
- expose a new /api/ai/context endpoint and tests covering the contextual workflow

## Testing
- pytest backend/tests/test_ai_context_endpoint.py -vv
- pytest backend/tests -q *(fails: TypeError serializing ValueError in existing alerts tests)*
- make lint *(fails: cannot download pre-commit due to proxy 403)*

------
https://chatgpt.com/codex/tasks/task_e_68e1d10c8fbc832194b653c0c0c97480