### PR TITLE
Add AI insights endpoint and metrics integration

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -25,6 +25,7 @@ from backend.routers import health  # nuevo router de salud
 from backend.routers import (
     ai,
     ai_context,
+    ai_insights,
     ai_stream,
     alerts,
     auth,
@@ -255,6 +256,7 @@ app.include_router(news.router, prefix="/api/news", tags=["news"])
 app.include_router(auth.router)
 app.include_router(ai.router, prefix="/api/ai", tags=["ai"])
 app.include_router(ai_context.router, prefix="/api/ai", tags=["ai"])
+app.include_router(ai_insights.router, prefix="/api/ai", tags=["ai"])
 app.include_router(ai_stream.router, prefix="/api/ai", tags=["ai"])
 app.include_router(push.router, prefix="/api/push", tags=["push"])
 app.include_router(portfolio.router, prefix="/api/portfolio", tags=["portfolio"])

--- a/backend/metrics/ai_metrics.py
+++ b/backend/metrics/ai_metrics.py
@@ -84,3 +84,15 @@ ai_adaptive_timeouts_total = Counter(
     "ai_adaptive_timeouts_total",
     "Timeouts adaptativos activados",
 )
+
+
+ai_insights_generated_total = Counter(
+    "ai_insights_generated_total", "Número total de insights generados por IA"
+)
+ai_insight_duration_seconds = Histogram(
+    "ai_insight_duration_seconds", "Duración de generación de insights de IA"
+)
+ai_insight_failures_total = Counter(
+    "ai_insight_failures_total",
+    "Errores ocurridos durante la generación de insights IA",
+)

--- a/backend/routers/ai_insights.py
+++ b/backend/routers/ai_insights.py
@@ -1,0 +1,58 @@
+"""Router para insights generados por IA."""
+
+from __future__ import annotations
+
+import json
+import logging
+
+from fastapi import APIRouter, HTTPException, Request, status
+
+from backend.services.ai_service import AIService
+
+router = APIRouter()
+logger = logging.getLogger(__name__)
+
+
+@router.post("/insights")
+async def generate_insights(request: Request, payload: dict):
+    """Genera insights automatizados sobre un símbolo financiero."""
+
+    if not isinstance(payload, dict):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Payload inválido",
+        )
+
+    symbol = payload.get("symbol")
+    timeframe = payload.get("timeframe", "1d")
+    profile = payload.get("profile", "investor")
+
+    if not symbol:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="El campo 'symbol' es requerido",
+        )
+
+    ai = AIService()
+    result = await ai.generate_insight(symbol=symbol, timeframe=timeframe, profile=profile)
+
+    if isinstance(result, dict) and result.get("error"):
+        logger.error(
+            json.dumps(
+                {
+                    "ai_event": "insight_generation_failed",
+                    "symbol": symbol,
+                    "error": result["error"],
+                }
+            )
+        )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=result["error"],
+        )
+
+    correlation_id = getattr(request.state, "correlation_id", None)
+    if correlation_id and isinstance(result, dict):
+        result.setdefault("correlation_id", correlation_id)
+
+    return result

--- a/backend/services/market_service.py
+++ b/backend/services/market_service.py
@@ -170,6 +170,30 @@ class MarketService:
         await self.history_cache.set(cache_key, data)
         return data
 
+    async def get_historical(
+        self,
+        symbol: str,
+        *,
+        timeframe: str = "1d",
+        limit: int = 120,
+        market: str = "auto",
+    ) -> list[dict[str, Any]]:
+        """Compatibilidad para obtener históricos simplificados."""
+
+        payload = await self.get_historical_ohlc(
+            symbol,
+            interval=timeframe,
+            limit=limit,
+            market=market,
+        )
+        if isinstance(payload, dict):
+            values = payload.get("values", [])
+            if isinstance(values, list):
+                return values
+        if isinstance(payload, list):
+            return payload
+        return []
+
     async def _fetch_binance_history(
         self, symbol: str, interval: str, limit: int
     ) -> dict[str, Any]:

--- a/backend/tests/test_ai_insights_endpoint.py
+++ b/backend/tests/test_ai_insights_endpoint.py
@@ -1,0 +1,67 @@
+import importlib
+
+import pytest
+
+from backend.metrics.ai_metrics import (
+    ai_insight_failures_total,
+    ai_insights_generated_total,
+)
+from backend.services.ai_service import AIResponsePayload, AIService
+from backend.services.market_service import MarketService
+
+
+@pytest.mark.asyncio
+async def test_ai_insights_endpoint_success(async_client, monkeypatch):
+    async def fake_get_historical(self, symbol, *, timeframe="1d", limit=120, market="auto"):
+        return [
+            {"timestamp": "2024-01-01T00:00:00Z", "close": 100.0},
+            {"timestamp": "2024-01-02T00:00:00Z", "close": 101.0},
+        ]
+
+    monkeypatch.setattr(MarketService, "get_historical", fake_get_historical)
+
+    def fake_analyze_sentiment(_: str):
+        return {"label": "positive", "score": 0.85}
+
+    sentiment_module = importlib.import_module("backend.services.sentiment_service")
+    monkeypatch.setattr(sentiment_module, "analyze_sentiment", fake_analyze_sentiment)
+
+    async def fake_process_message(self, prompt: str):
+        return AIResponsePayload(text="Recomendamos compra", provider="mock")
+
+    monkeypatch.setattr(AIService, "process_message", fake_process_message)
+
+    baseline = ai_insights_generated_total._value.get()
+
+    response = await async_client.post(
+        "/api/ai/insights",
+        json={"symbol": "AAPL", "timeframe": "1d", "profile": "investor"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["symbol"] == "AAPL"
+    assert payload["profile"] == "investor"
+    assert "insight" in payload and payload["insight"]
+
+    updated = ai_insights_generated_total._value.get()
+    assert updated >= baseline + 1
+
+
+@pytest.mark.asyncio
+async def test_ai_insights_endpoint_handles_failure(async_client, monkeypatch):
+    async def failing_get_historical(self, symbol, *, timeframe="1d", limit=120, market="auto"):
+        raise RuntimeError("provider failure")
+
+    monkeypatch.setattr(MarketService, "get_historical", failing_get_historical)
+
+    failures_before = ai_insight_failures_total._value.get()
+
+    response = await async_client.post("/api/ai/insights", json={"symbol": "TSLA"})
+
+    assert response.status_code == 500
+    detail = response.json().get("detail")
+    assert "provider failure" in detail
+
+    failures_after = ai_insight_failures_total._value.get()
+    assert failures_after >= failures_before + 1


### PR DESCRIPTION
## Summary
- add a dedicated /api/ai/insights router backed by AIService insight generation
- extend AIService, metrics, and alert/market services to support insight workflows and structured logging
- cover the new endpoint with async pytest scenarios including success, metrics, and failure handling

## Testing
- pytest backend/tests/test_ai_insights_endpoint.py -vv
- pytest backend/tests -q
- make lint *(fails: unable to install pre-commit via proxy in CI sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68e1fbb179048321bea35f4595455364