### PR TITLE
Add realtime WebSocket gateway with Prometheus metrics

### DIFF
--- a/backend/metrics/realtime_metrics.py
+++ b/backend/metrics/realtime_metrics.py
@@ -1,0 +1,27 @@
+"""Métricas Prometheus para el gateway de tiempo real."""
+
+from prometheus_client import Counter, Gauge
+
+# ✅ Codex fix: métricas para monitorear conexiones WebSocket en tiempo real
+ws_connections_active_total = Gauge(
+    "ws_connections_active_total",
+    "Conexiones WebSocket activas",
+)
+
+# ✅ Codex fix: métrica para contar mensajes emitidos a través del gateway
+ws_messages_sent_total = Counter(
+    "ws_messages_sent_total",
+    "Mensajes enviados por WebSocket",
+)
+
+# ✅ Codex fix: métrica para rastrear errores durante las sesiones WebSocket
+ws_errors_total = Counter(
+    "ws_errors_total",
+    "Errores en WebSocket",
+)
+
+__all__ = [
+    "ws_connections_active_total",
+    "ws_messages_sent_total",
+    "ws_errors_total",
+]

--- a/backend/routers/realtime.py
+++ b/backend/routers/realtime.py
@@ -1,0 +1,212 @@
+"""Gateway WebSocket para difundir precios e insights en tiempo real."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import random
+from contextlib import suppress
+from datetime import UTC, datetime
+from typing import Any
+
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+
+from backend.core.logging_config import get_logger, log_event
+from backend.metrics.realtime_metrics import ws_errors_total, ws_messages_sent_total
+from backend.services.ai_service import ai_service
+from backend.services.realtime_service import RealtimeService
+
+router = APIRouter()
+logger = get_logger(service="realtime_gateway")
+
+
+async def _ensure_price_task(app) -> None:
+    # ✅ Codex fix: arrancar tarea compartida de difusión de precios simulados
+    task = getattr(app.state, "realtime_price_task", None)
+    if task is None or task.done():
+        app.state.realtime_price_task = asyncio.create_task(_price_broadcast_loop(app))
+
+
+async def _ensure_insights_task(app) -> None:
+    # ✅ Codex fix: iniciar tarea de generación de insights IA bajo demanda
+    task = getattr(app.state, "realtime_insights_task", None)
+    if task is None or task.done():
+        app.state.realtime_insights_task = asyncio.create_task(_insights_broadcast_loop(app))
+
+
+async def _price_broadcast_loop(app) -> None:
+    service: RealtimeService = app.state.realtime_service
+    while True:
+        try:
+            await asyncio.sleep(1)
+            if await service.connection_count() == 0:
+                continue
+            payload = {
+                "type": "price",  # ✅ Codex fix: mensaje estándar de precios simulados
+                "symbol": "BBR",
+                "price": round(random.uniform(80.0, 120.0), 2),
+                "timestamp": datetime.now(UTC).isoformat(),
+            }
+            await service.broadcast(payload)
+        except asyncio.CancelledError:  # pragma: no cover - cancelación durante shutdown
+            break
+        except Exception as exc:  # pragma: no cover - resiliencia ante errores inesperados
+            ws_errors_total.inc()
+            log_event(
+                logger,
+                service="realtime_gateway",
+                event="price_loop_error",
+                level="warning",
+                error=str(exc),
+            )
+
+
+async def _insights_broadcast_loop(app) -> None:
+    service: RealtimeService = app.state.realtime_service
+    while True:
+        try:
+            if getattr(app.state, "realtime_insights_subscribers", 0) <= 0:
+                await asyncio.sleep(0.5)
+                continue
+
+            insight_chunks: list[str] = []
+            async for chunk in ai_service.stream_generate(
+                "Genera un insight breve del mercado actual"
+            ):
+                insight_chunks.append(chunk)
+
+            if insight_chunks:
+                message = {
+                    "type": "insight",  # ✅ Codex fix: difusión de insights IA
+                    "content": "".join(insight_chunks).strip(),
+                    "timestamp": datetime.now(UTC).isoformat(),
+                }
+                await service.broadcast(message)
+            await asyncio.sleep(1)
+        except asyncio.CancelledError:  # pragma: no cover - cancelación durante shutdown
+            break
+        except Exception as exc:  # pragma: no cover - resiliencia ante errores inesperados
+            ws_errors_total.inc()
+            log_event(
+                logger,
+                service="realtime_gateway",
+                event="insights_loop_error",
+                level="warning",
+                error=str(exc),
+            )
+            await asyncio.sleep(1)
+
+
+def _ensure_state_defaults(app) -> None:
+    # ✅ Codex fix: inicializar contadores y tareas compartidas en el estado de la app
+    if not hasattr(app.state, "realtime_insights_subscribers"):
+        app.state.realtime_insights_subscribers = 0
+
+
+def _parse_payload(raw_message: str) -> dict[str, Any] | None:
+    # ✅ Codex fix: validar y normalizar mensajes entrantes del cliente
+    try:
+        data = json.loads(raw_message)
+    except json.JSONDecodeError:
+        return None
+    if isinstance(data, dict):
+        return data
+    return None
+
+
+@router.websocket("/ws")
+async def websocket_endpoint(websocket: WebSocket) -> None:
+    """Punto de entrada WebSocket que gestiona suscripciones en tiempo real."""
+
+    await websocket.accept()
+    app = websocket.app
+    _ensure_state_defaults(app)
+    realtime_service: RealtimeService = app.state.realtime_service
+
+    await realtime_service.register(websocket)
+    await _ensure_price_task(app)
+
+    initial_message = {
+        "status": "connected",  # ✅ Codex fix: saludo inicial con timestamp ISO
+        "timestamp": datetime.now(UTC).isoformat(),
+    }
+    await websocket.send_json(initial_message)
+    ws_messages_sent_total.inc()  # ✅ Codex fix: contabilizar saludo inicial enviado
+
+    subscriptions: set[str] = set()
+
+    try:
+        while True:
+            raw = await websocket.receive_text()
+            payload = _parse_payload(raw)
+            if not payload:
+                ws_errors_total.inc()
+                await websocket.send_json({"error": "invalid_payload"})
+                ws_messages_sent_total.inc()
+                continue
+
+            action = payload.get("action")
+            if action == "subscribe":
+                channel = payload.get("channel")
+                if isinstance(channel, str):
+                    subscriptions.add(channel)
+                    if channel == "insights":
+                        app.state.realtime_insights_subscribers += 1  # ✅ Codex fix: registrar suscriptor a insights
+                        await _ensure_insights_task(app)
+                    response = {"status": "subscribed", "channel": channel}
+                    await websocket.send_json(response)
+                    ws_messages_sent_total.inc()
+                else:
+                    await websocket.send_json({"error": "invalid_channel"})
+                    ws_messages_sent_total.inc()
+            elif action == "unsubscribe":
+                channel = payload.get("channel")
+                if isinstance(channel, str) and channel in subscriptions:
+                    subscriptions.remove(channel)
+                    if channel == "insights":
+                        app.state.realtime_insights_subscribers = max(
+                            0,
+                            app.state.realtime_insights_subscribers - 1,
+                        )  # ✅ Codex fix: ajustar contador de suscriptores activos
+                    await websocket.send_json({"status": "unsubscribed", "channel": channel})
+                    ws_messages_sent_total.inc()
+                else:
+                    await websocket.send_json({"error": "unknown_subscription"})
+                    ws_messages_sent_total.inc()
+            elif action == "ping":
+                await websocket.send_json({"status": "pong"})
+                ws_messages_sent_total.inc()
+            else:
+                await websocket.send_json({"status": "ack", "received": action})
+                ws_messages_sent_total.inc()
+    except WebSocketDisconnect:
+        pass
+    except Exception as exc:  # pragma: no cover - robustez ante fallos no controlados
+        ws_errors_total.inc()
+        log_event(
+            logger,
+            service="realtime_gateway",
+            event="websocket_error",
+            level="warning",
+            error=str(exc),
+        )
+    finally:
+        if "insights" in subscriptions and app.state.realtime_insights_subscribers > 0:
+            app.state.realtime_insights_subscribers -= 1
+        await realtime_service.unregister(websocket)
+        if await realtime_service.connection_count() == 0:
+            task = getattr(app.state, "realtime_price_task", None)
+            if task is not None:
+                task.cancel()
+                with suppress(asyncio.CancelledError):
+                    await task
+                app.state.realtime_price_task = None  # ✅ Codex fix: liberar referencia a la tarea de precios
+        if (
+            getattr(app.state, "realtime_insights_subscribers", 0) <= 0
+            and getattr(app.state, "realtime_insights_task", None) is not None
+        ):
+            insights_task = app.state.realtime_insights_task
+            insights_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await insights_task
+            app.state.realtime_insights_task = None  # ✅ Codex fix: limpiar tarea de insights inactiva

--- a/backend/services/realtime_service.py
+++ b/backend/services/realtime_service.py
@@ -1,0 +1,113 @@
+"""Servicio centralizado para gestionar conexiones WebSocket en tiempo real."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+from fastapi import WebSocket
+
+from backend.core.logging_config import get_logger, log_event
+from backend.metrics.realtime_metrics import (
+    ws_connections_active_total,
+    ws_errors_total,
+    ws_messages_sent_total,
+)
+
+
+class RealtimeService:
+    """Administra clientes WebSocket y facilita envíos tipo broadcast."""
+
+    def __init__(self) -> None:
+        # ✅ Codex fix: estructura segura para compartir conexiones WebSocket
+        self._connections: set[WebSocket] = set()
+        self._lock = asyncio.Lock()
+        self._logger = get_logger(service="realtime_service")
+
+    async def register(self, websocket: WebSocket) -> None:
+        """Registra una conexión y actualiza métricas de actividad."""
+
+        # ✅ Codex fix: almacenar la conexión aceptada y reflejarla en las métricas
+        async with self._lock:
+            self._connections.add(websocket)
+            ws_connections_active_total.set(len(self._connections))
+
+    async def unregister(self, websocket: WebSocket) -> None:
+        """Elimina una conexión y ajusta el recuento de clientes activos."""
+
+        # ✅ Codex fix: eliminar conexiones cerradas y mantener el gauge sincronizado
+        async with self._lock:
+            self._connections.discard(websocket)
+            ws_connections_active_total.set(len(self._connections))
+
+    async def broadcast(self, message: dict[str, Any]) -> None:
+        """Envía un mensaje a todos los clientes registrados."""
+
+        recipients = await self._snapshot()
+        if not recipients:
+            return
+
+        preview = self._build_preview(message)
+        # ✅ Codex fix: log estructurado de cada broadcast con clientes y mensaje
+        self._logger.info({"event": "broadcast", "clients": len(recipients), "message": preview})
+
+        disconnected: list[WebSocket] = []
+        for connection in recipients:
+            try:
+                await connection.send_json(message)
+                ws_messages_sent_total.inc()
+            except Exception as exc:  # pragma: no cover - resiliencia ante errores inesperados
+                ws_errors_total.inc()
+                log_event(
+                    self._logger,
+                    service="realtime_service",
+                    event="broadcast_error",
+                    level="warning",
+                    error=str(exc),
+                )
+                disconnected.append(connection)
+
+        if disconnected:
+            # ✅ Codex fix: retirar conexiones que fallaron durante el envío
+            await asyncio.gather(*(self.unregister(connection) for connection in disconnected))
+
+    async def close_all(self) -> None:
+        """Cierra todas las conexiones activas (usado en shutdown/tests)."""
+
+        # ✅ Codex fix: cierre ordenado de conexiones en escenarios de apagado
+        recipients = await self._snapshot()
+        for connection in recipients:
+            try:
+                await connection.close()
+            except Exception:  # pragma: no cover - cierre tolerante a fallos
+                ws_errors_total.inc()
+        await self._clear_all()
+
+    async def connection_count(self) -> int:
+        """Devuelve el número de clientes activos actuales."""
+
+        # ✅ Codex fix: exponer número de conexiones para lógica de difusión periódica
+        async with self._lock:
+            return len(self._connections)
+
+    async def _snapshot(self) -> list[WebSocket]:
+        async with self._lock:
+            return list(self._connections)
+
+    async def _clear_all(self) -> None:
+        async with self._lock:
+            self._connections.clear()
+            ws_connections_active_total.set(0)
+
+    @staticmethod
+    def _build_preview(message: dict[str, Any]) -> str:
+        # ✅ Codex fix: generar un resumen compacto del mensaje para logs
+        try:
+            serialized = json.dumps(message, ensure_ascii=False)
+        except TypeError:
+            serialized = str(message)
+        return serialized[:200]
+
+
+__all__ = ["RealtimeService"]

--- a/backend/tests/test_realtime_endpoint.py
+++ b/backend/tests/test_realtime_endpoint.py
@@ -1,0 +1,143 @@
+"""Pruebas de integración para el gateway WebSocket de tiempo real."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+from collections.abc import AsyncIterator
+
+import httpx
+import pytest
+import pytest_asyncio
+import websockets
+import uvicorn
+
+from backend.main import app
+
+
+@pytest_asyncio.fixture()
+async def realtime_server(
+    unused_tcp_port: int, monkeypatch: pytest.MonkeyPatch
+) -> AsyncIterator[dict[str, str]]:
+    """Lanza un servidor Uvicorn para pruebas WebSocket en vivo."""
+
+    # ✅ Codex fix: stub de stream IA para respuestas deterministas durante los tests
+    async def fake_stream_generate(_prompt: str):  # noqa: ANN202
+        for chunk in ["Insight ", "de prueba"]:
+            await asyncio.sleep(0)
+            yield chunk
+
+    monkeypatch.setattr(
+        "backend.routers.realtime.ai_service.stream_generate",
+        fake_stream_generate,
+    )
+
+    async def fake_report() -> None:  # ✅ Codex fix: evitar llamadas externas en tests
+        return None
+
+    monkeypatch.setattr("backend.main.log_api_integration_report", fake_report)
+
+    port = unused_tcp_port
+    config = uvicorn.Config(
+        app,
+        host="127.0.0.1",
+        port=port,
+        log_level="warning",
+        loop="asyncio",
+        lifespan="on",
+    )
+    server = uvicorn.Server(config)
+
+    thread = threading.Thread(target=server.run, daemon=True)
+    thread.start()
+
+    while not server.started:
+        await asyncio.sleep(0.05)
+
+    try:
+        yield {"ws": f"ws://127.0.0.1:{port}", "http": f"http://127.0.0.1:{port}"}
+    finally:
+        server.should_exit = True
+        await asyncio.sleep(0)
+        thread.join(timeout=5)
+
+
+@pytest.mark.asyncio
+async def test_realtime_websocket_connects_and_disconnects(
+    realtime_server: dict[str, str]
+) -> None:
+    """Verifica handshake 101 y mensaje de bienvenida."""
+
+    async with websockets.connect(f"{realtime_server['ws']}/api/realtime/ws") as websocket:
+        status = getattr(websocket.response, "status_code", None) or getattr(
+            websocket.response, "status", None
+        )
+        assert status == 101  # ✅ Codex fix: validar handshake Switching Protocols
+        initial_raw = await asyncio.wait_for(websocket.recv(), timeout=2)
+        initial = json.loads(initial_raw)
+        assert initial["status"] == "connected"
+        assert "timestamp" in initial
+
+    await asyncio.sleep(0.2)
+
+    async with httpx.AsyncClient() as client:
+        metrics = await client.get(realtime_server["http"] + "/api/metrics")
+        assert metrics.status_code == 200
+        body = metrics.text
+        assert "ws_connections_active_total 0.0" in body
+
+
+@pytest.mark.asyncio
+async def test_realtime_streams_prices_and_insights(
+    realtime_server: dict[str, str]
+) -> None:
+    """Recibe precios periódicos y contenidos IA desde el gateway."""
+
+    async with websockets.connect(f"{realtime_server['ws']}/api/realtime/ws") as websocket:
+        await websocket.recv()  # mensaje inicial
+
+        price_message = json.loads(await asyncio.wait_for(websocket.recv(), timeout=3))
+        assert price_message["type"] == "price"
+        assert "price" in price_message
+
+        await websocket.send(json.dumps({"action": "subscribe", "channel": "insights"}))
+        ack_message = json.loads(await asyncio.wait_for(websocket.recv(), timeout=2))
+        assert ack_message == {"status": "subscribed", "channel": "insights"}
+
+        insight_message = None
+        for _ in range(5):
+            candidate = json.loads(await asyncio.wait_for(websocket.recv(), timeout=3))
+            if candidate.get("type") == "insight":
+                insight_message = candidate
+                break
+        assert insight_message is not None
+        assert "content" in insight_message
+
+        async with httpx.AsyncClient() as client:
+            metrics_response = await client.get(
+                realtime_server["http"] + "/api/metrics"
+            )
+        metrics_text = metrics_response.text
+        assert "ws_connections_active_total 1.0" in metrics_text
+        assert "ws_messages_sent_total" in metrics_text
+
+    await asyncio.sleep(0.2)
+
+
+@pytest.mark.asyncio
+async def test_realtime_handles_invalid_payload(
+    realtime_server: dict[str, str]
+) -> None:
+    """El gateway responde con error controlado ante cargas inválidas."""
+
+    async with websockets.connect(f"{realtime_server['ws']}/api/realtime/ws") as websocket:
+        await websocket.recv()
+
+        await websocket.send("not-json")
+        error_message = json.loads(await asyncio.wait_for(websocket.recv(), timeout=2))
+        assert error_message == {"error": "invalid_payload"}
+
+        await websocket.close()
+
+    await asyncio.sleep(0.1)


### PR DESCRIPTION
## Summary
- add Prometheus realtime metrics module and a connection manager service for WebSocket clients
- implement the `/api/realtime/ws` router to broadcast simulated prices and AI insights with structured logging
- register the realtime service in application startup and cover the gateway with pytest-based websocket tests

## Testing
- pytest backend/tests/test_realtime_endpoint.py -vv
- pytest backend/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68e1ff42cf448321864476d41900e671