### PR TITLE
feat: enable realtime dashboard and ai insights

### DIFF
--- a/frontend/jest.config.base.ts
+++ b/frontend/jest.config.base.ts
@@ -20,6 +20,7 @@ const baseConfig: Config = {
     "^@mswjs/interceptors/WebSocket$":
       "<rootDir>/src/tests/msw/websocket-interceptor.ts",
     "^@mswjs/interceptors/(.*)$": "<rootDir>/src/tests/msw/interceptors/$1.ts",
+    "^jest-websocket-mock$": "<rootDir>/src/tests/mocks/jest-websocket-mock.ts", // ✅ Codex fix: mock consistente para WebSocket
   },
   transform: {
     "^.+\\.(ts|tsx|js|jsx)$": [

--- a/frontend/src/hooks/__tests__/useRealtime.test.tsx
+++ b/frontend/src/hooks/__tests__/useRealtime.test.tsx
@@ -1,0 +1,86 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { Server } from "jest-websocket-mock";
+
+import { useRealtime } from "../useRealtime";
+
+describe("useRealtime", () => {
+  let server: Server;
+
+  beforeEach(() => {
+    server = new Server("ws://localhost:8000/api/realtime/ws");
+  });
+
+  afterEach(() => {
+    if (server) {
+      act(() => {
+        server.close();
+      });
+    }
+    Server.clean();
+  });
+
+  it("establece connected=true cuando la conexión abre", async () => {
+    const { result } = renderHook(() => useRealtime());
+
+    await act(async () => {
+      await server.connected;
+    });
+
+    await waitFor(() => {
+      expect(result.current.connected).toBe(true);
+    });
+  });
+
+  it("actualiza el estado data con los mensajes recibidos", async () => {
+    const { result } = renderHook(() => useRealtime());
+
+    await act(async () => {
+      await server.connected;
+    });
+
+    act(() => {
+      server.send({ type: "price", symbol: "BTCUSDT", price: 12345.67 });
+    });
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual(
+        expect.objectContaining({ type: "price", symbol: "BTCUSDT" })
+      );
+    });
+  });
+
+  it("marca connected=false cuando el servidor cierra", async () => {
+    const { result } = renderHook(() => useRealtime());
+
+    await act(async () => {
+      await server.connected;
+    });
+
+    act(() => {
+      server.close();
+    });
+
+    await waitFor(() => {
+      expect(result.current.connected).toBe(false);
+    });
+  });
+
+  it("maneja mensajes corruptos sin lanzar errores", async () => {
+    const consoleSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    const { result } = renderHook(() => useRealtime());
+
+    await act(async () => {
+      await server.connected;
+    });
+
+    act(() => {
+      server.send("not-json");
+    });
+
+    expect(result.current.data).toBeNull();
+    expect(consoleSpy).toHaveBeenCalled();
+
+    consoleSpy.mockRestore();
+  });
+});

--- a/frontend/src/hooks/useAIStream.ts
+++ b/frontend/src/hooks/useAIStream.ts
@@ -1,0 +1,178 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export interface AIInsight {
+  id: string;
+  message: string;
+  timestamp: string;
+  source: "stream" | "realtime" | "manual";
+  raw?: unknown;
+}
+
+interface UseAIStreamOptions {
+  enabled?: boolean;
+  token?: string;
+  realtimePayload?: unknown;
+  onInsight?: (insight: AIInsight) => void;
+}
+
+// ✅ Codex fix: hook para gestionar el stream SSE y los insights provenientes del WebSocket
+export function useAIStream({
+  enabled = true,
+  token,
+  realtimePayload,
+  onInsight,
+}: UseAIStreamOptions = {}) {
+  const [connected, setConnected] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [insights, setInsights] = useState<AIInsight[]>([]);
+  const eventSourceRef = useRef<EventSource | null>(null);
+
+  const pushInsight = useCallback(
+    (payload: { message: string; source: AIInsight["source"]; raw?: unknown; timestamp?: string }) => {
+      if (!payload.message) {
+        return;
+      }
+
+      const insight: AIInsight = {
+        id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+        message: payload.message,
+        timestamp: payload.timestamp ?? new Date().toISOString(),
+        source: payload.source,
+        raw: payload.raw,
+      };
+
+      setInsights((previous) => [...previous, insight]);
+      onInsight?.(insight);
+    },
+    [onInsight]
+  );
+
+  useEffect(() => {
+    if (!enabled) {
+      if (eventSourceRef.current) {
+        eventSourceRef.current.close();
+        eventSourceRef.current = null;
+      }
+      setConnected(false);
+      return;
+    }
+
+    if (typeof window === "undefined" || typeof window.EventSource === "undefined") {
+      return;
+    }
+
+    const baseUrl = new URL("/api/ai/stream", window.location.origin);
+    if (token) {
+      baseUrl.searchParams.set("token", token);
+    }
+
+    const eventSource = new EventSource(baseUrl.toString());
+    eventSourceRef.current = eventSource;
+
+    eventSource.onopen = () => {
+      setConnected(true);
+      setError(null);
+    };
+
+    eventSource.onmessage = (event) => {
+      const rawData = event.data;
+      if (!rawData) {
+        return;
+      }
+
+      let message: string | null = null;
+      let raw: unknown = rawData;
+
+      try {
+        const parsed = JSON.parse(rawData);
+        raw = parsed;
+        if (parsed && typeof parsed === "object") {
+          const candidate =
+            typeof (parsed as Record<string, unknown>).message === "string"
+              ? (parsed as Record<string, unknown>).message
+              : typeof (parsed as Record<string, unknown>).content === "string"
+              ? (parsed as Record<string, unknown>).content
+              : null;
+          if (candidate) {
+            message = candidate;
+          }
+        } else if (typeof parsed === "string") {
+          message = parsed;
+        }
+      } catch (error) {
+        message = rawData;
+      }
+
+      if (message) {
+        pushInsight({ message, source: "stream", raw });
+      }
+    };
+
+    eventSource.onerror = () => {
+      setConnected(false);
+      setError("stream_error");
+      eventSource.close();
+      eventSourceRef.current = null;
+    };
+
+    return () => {
+      setConnected(false);
+      eventSource.close();
+      eventSourceRef.current = null;
+    };
+  }, [enabled, pushInsight, token]);
+
+  useEffect(() => {
+    if (!realtimePayload || typeof realtimePayload !== "object") {
+      return;
+    }
+
+    const payload = realtimePayload as Record<string, unknown>;
+    if (payload.type !== "insight") {
+      return;
+    }
+
+    const message =
+      typeof payload.content === "string"
+        ? payload.content
+        : typeof payload.message === "string"
+        ? payload.message
+        : null;
+
+    if (!message) {
+      return;
+    }
+
+    pushInsight({
+      message,
+      source: "realtime",
+      raw: realtimePayload,
+      timestamp: typeof payload.timestamp === "string" ? payload.timestamp : undefined,
+    });
+
+    if (typeof process !== "undefined" && process.env.NODE_ENV !== "production") {
+      console.log("AI Insight recibido:", message);
+    }
+  }, [pushInsight, realtimePayload]);
+
+  const addInsight = useCallback(
+    (message: string, options?: { timestamp?: string }) => {
+      pushInsight({
+        message,
+        source: "manual",
+        raw: { message },
+        timestamp: options?.timestamp,
+      });
+    },
+    [pushInsight]
+  );
+
+  return {
+    connected,
+    error,
+    insights,
+    addInsight,
+  } as const;
+}

--- a/frontend/src/hooks/useRealtime.ts
+++ b/frontend/src/hooks/useRealtime.ts
@@ -1,0 +1,47 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+// ✅ Codex fix: hook para gestionar conexión WebSocket en tiempo real
+export function useRealtime() {
+  const socketRef = useRef<WebSocket | null>(null);
+  const [connected, setConnected] = useState(false);
+  const [data, setData] = useState<any>(null); // ✅ Codex fix: estado flexible para payloads dinámicos
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return undefined;
+    }
+
+    const ws = new WebSocket("ws://localhost:8000/api/realtime/ws");
+    socketRef.current = ws;
+
+    ws.onopen = () => {
+      setConnected(true);
+    };
+
+    ws.onmessage = (event) => {
+      try {
+        const msg = JSON.parse(event.data as string);
+        setData(msg);
+      } catch (error) {
+        console.error("Invalid WS message", error);
+      }
+    };
+
+    ws.onerror = () => {
+      setConnected(false);
+    };
+
+    ws.onclose = () => {
+      setConnected(false);
+    };
+
+    return () => {
+      socketRef.current = null; // ✅ Codex fix: limpiar referencia cuando se desmonta el hook
+      ws.close();
+    };
+  }, []);
+
+  return { connected, data } as const;
+}

--- a/frontend/src/tests/mocks/jest-websocket-mock.ts
+++ b/frontend/src/tests/mocks/jest-websocket-mock.ts
@@ -1,0 +1,157 @@
+// ✅ Codex fix: mock simplificado de jest-websocket-mock para entorno de pruebas
+
+type WebSocketEventHandler<T> = ((event: T) => void) | null;
+
+class MockWebSocket {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSING = 2;
+  static readonly CLOSED = 3;
+
+  static __isMock = true;
+
+  url: string;
+  readyState = MockWebSocket.CONNECTING;
+  onopen: WebSocketEventHandler<Event> = null;
+  onclose: WebSocketEventHandler<CloseEvent> = null;
+  onmessage: WebSocketEventHandler<MessageEvent<string>> = null;
+  onerror: WebSocketEventHandler<Event> = null;
+
+  private server: Server | null = null;
+
+  constructor(url: string) {
+    this.url = url;
+    const found = Server.lookup(url);
+    if (!found) {
+      throw new Error(`No mock server listening on ${url}`);
+    }
+    this.server = found;
+    found.attach(this);
+  }
+
+  send(data: string) {
+    this.server?.receive(this, data);
+  }
+
+  close() {
+    if (this.readyState === MockWebSocket.CLOSED) {
+      return;
+    }
+    this.readyState = MockWebSocket.CLOSING;
+    this.server?.detach(this);
+    this.readyState = MockWebSocket.CLOSED;
+    this.onclose?.(
+      new CloseEvent("close", {
+        wasClean: true,
+        code: 1000,
+        reason: "client_close",
+      })
+    );
+  }
+
+  _open() {
+    if (this.readyState === MockWebSocket.OPEN) return;
+    this.readyState = MockWebSocket.OPEN;
+    this.onopen?.(new Event("open"));
+  }
+
+  _emitMessage(payload: string) {
+    if (this.readyState !== MockWebSocket.OPEN) return;
+    this.onmessage?.(
+      new MessageEvent("message", {
+        data: payload,
+      })
+    );
+  }
+
+  _emitError() {
+    this.readyState = MockWebSocket.CLOSED;
+    this.onerror?.(new Event("error"));
+  }
+
+  _emitClose(reason = "server_close") {
+    if (this.readyState === MockWebSocket.CLOSED) return;
+    this.readyState = MockWebSocket.CLOSED;
+    this.onclose?.(
+      new CloseEvent("close", {
+        wasClean: true,
+        code: 1000,
+        reason,
+      })
+    );
+  }
+}
+
+class Server {
+  private static registry = new Map<string, Server>();
+
+  readonly url: string;
+  private clients = new Set<MockWebSocket>();
+  private resolveConnected?: () => void;
+  readonly connected: Promise<void>;
+
+  constructor(url: string) {
+    this.url = url;
+    Server.registry.set(url, this);
+    this.connected = new Promise((resolve) => {
+      this.resolveConnected = resolve;
+    });
+    const scope = typeof window !== "undefined" ? window : globalThis;
+    // @ts-expect-error asignación deliberada para test
+    scope.WebSocket = MockWebSocket;
+  }
+
+  static lookup(url: string) {
+    return Server.registry.get(url) ?? null;
+  }
+
+  static clean() {
+    for (const server of Server.registry.values()) {
+      server.close();
+    }
+    Server.registry.clear();
+  }
+
+  attach(client: MockWebSocket) {
+    this.clients.add(client);
+    queueMicrotask(() => {
+      client._open();
+      this.resolveConnected?.();
+      this.resolveConnected = undefined;
+    });
+  }
+
+  detach(client: MockWebSocket) {
+    this.clients.delete(client);
+  }
+
+  receive(_client: MockWebSocket, _data: string) {
+    // Intencionalmente vacío: los tests pueden inspeccionar si fuese necesario
+  }
+
+  send(data: string | Record<string, unknown>) {
+    const payload = typeof data === "string" ? data : JSON.stringify(data);
+    for (const client of this.clients) {
+      client._emitMessage(payload);
+    }
+  }
+
+  error() {
+    for (const client of this.clients) {
+      client._emitError();
+    }
+    this.clients.clear();
+    Server.registry.delete(this.url);
+  }
+
+  close() {
+    for (const client of this.clients) {
+      client._emitClose();
+    }
+    this.clients.clear();
+    Server.registry.delete(this.url);
+  }
+}
+
+export { Server };
+export default Server;


### PR DESCRIPTION
## Summary
- add a reusable `useRealtime` WebSocket hook and show its status/data in the dashboard
- connect the chat experience to realtime AI insights through the new `useAIStream` hook
- provide a jest-websocket-mock shim and targeted hook tests to keep realtime behaviour covered

## Testing
- npm --prefix frontend run test:dev -- src/hooks/__tests__/useRealtime.test.tsx --verbose

------
https://chatgpt.com/codex/tasks/task_e_68e2037a9ec88321805a0d76ec585987