### PR TITLE
Add unified notification dispatcher for realtime and push alerts

### DIFF
--- a/backend/metrics/ai_metrics.py
+++ b/backend/metrics/ai_metrics.py
@@ -96,3 +96,14 @@ ai_insight_failures_total = Counter(
     "ai_insight_failures_total",
     "Errores ocurridos durante la generación de insights IA",
 )
+
+
+ai_notifications_total = Counter(
+    "ai_notifications_total",
+    "Notificaciones emitidas por IA",
+)
+
+alert_notifications_total = Counter(
+    "alert_notifications_total",
+    "Alertas enviadas al usuario",
+)

--- a/backend/routers/notifications.py
+++ b/backend/routers/notifications.py
@@ -1,0 +1,20 @@
+"""Notification testing endpoints."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Request, status
+
+from backend.services.notification_dispatcher import notification_dispatcher
+
+
+router = APIRouter()
+
+
+@router.post("/broadcast", status_code=status.HTTP_202_ACCEPTED)
+async def broadcast_test(request: Request) -> dict[str, object]:
+    payload = await request.json()
+    await notification_dispatcher.broadcast_event("manual", payload)
+    return {"status": "ok", "sent": len(str(payload))}
+
+
+__all__ = ["router"]

--- a/backend/services/notification_dispatcher.py
+++ b/backend/services/notification_dispatcher.py
@@ -1,0 +1,191 @@
+"""Unified dispatcher to broadcast events across realtime and push channels."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any, Awaitable, Callable, Sequence
+
+from backend.core.logging_config import get_logger
+from backend.models.push_subscription import PushSubscription
+from backend.services.audit_service import AuditService
+from backend.services.push_service import push_service
+from backend.services.realtime_service import RealtimeService
+from backend.utils.config import ENV
+
+try:  # pragma: no cover - database may be optional in some contexts
+    from backend.database import SessionLocal
+except Exception:  # pragma: no cover - allow dispatcher to operate without DB
+    SessionLocal = None  # type: ignore[assignment]
+
+
+class PushBroadcastChannel:
+    """Asynchronous adapter to deliver payloads using ``PushService``."""
+
+    def __init__(
+        self,
+        push_service_impl: Any,
+        subscription_provider: Callable[[], Awaitable[Sequence[PushSubscription]]] | None = None,
+    ) -> None:
+        self._service = push_service_impl
+        self._subscription_provider = subscription_provider or self._load_subscriptions
+        self._logger = get_logger(service="push_broadcast_channel")
+
+    async def _load_subscriptions(self) -> Sequence[PushSubscription]:
+        if SessionLocal is None:
+            return []
+
+        def _query() -> Sequence[PushSubscription]:
+            with SessionLocal() as session:  # type: ignore[misc]
+                return session.query(PushSubscription).all()
+
+        return await asyncio.to_thread(_query)
+
+    async def broadcast(self, payload: dict[str, Any]) -> int:
+        subscriptions: Sequence[PushSubscription]
+        try:
+            subscriptions = await self._subscription_provider()
+        except Exception as exc:  # pragma: no cover - defensive guard
+            self._logger.warning(
+                {
+                    "service": "push_broadcast_channel",
+                    "event": "subscription_fetch_error",
+                    "error": str(exc),
+                }
+            )
+            return 0
+
+        if not subscriptions:
+            self._logger.info(
+                {
+                    "service": "push_broadcast_channel",
+                    "event": "no_subscriptions",
+                }
+            )
+            return 0
+
+        category = payload.get("category")
+
+        def _send() -> int:
+            return self._service.broadcast(subscriptions, payload, category=category)
+
+        try:
+            return await asyncio.to_thread(_send)
+        except Exception as exc:  # pragma: no cover - ensure dispatcher resilience
+            self._logger.warning(
+                {
+                    "service": "push_broadcast_channel",
+                    "event": "broadcast_error",
+                    "error": str(exc),
+                }
+            )
+            return 0
+
+
+class NotificationDispatcher:
+    """Dispatch structured events to realtime and push channels."""
+
+    def __init__(
+        self,
+        realtime_service: RealtimeService,
+        push_service_channel: Any,
+        audit_service: AuditService,
+    ) -> None:
+        self.realtime = realtime_service
+        self.push = push_service_channel
+        self.audit = audit_service
+        self._logger = get_logger(service="notification_dispatcher")
+
+    async def broadcast_event(self, event_type: str, payload: dict[str, Any]) -> None:
+        envelope = self._build_envelope(event_type, payload)
+        payload_size = len(json.dumps(envelope.get("payload", {}), default=str))
+
+        self._logger.info(
+            {
+                "service": "notification_dispatcher",
+                "event": "broadcast_start",
+                "type": event_type,
+                "payload_size": payload_size,
+            }
+        )
+
+        realtime_status = "skipped"
+        try:
+            await self.realtime.broadcast(envelope)
+            realtime_status = "sent"
+        except Exception as exc:  # pragma: no cover - defensive logging
+            realtime_status = f"error:{exc}"
+            self._logger.warning(
+                {
+                    "service": "notification_dispatcher",
+                    "event": "realtime_error",
+                    "type": event_type,
+                    "error": str(exc),
+                }
+            )
+
+        push_status = "skipped"
+        try:
+            push_result = await self.push.broadcast(envelope)
+            push_status = f"sent:{push_result}"
+        except Exception as exc:  # pragma: no cover - defensive logging
+            push_status = f"error:{exc}"
+            self._logger.warning(
+                {
+                    "service": "notification_dispatcher",
+                    "event": "push_error",
+                    "type": event_type,
+                    "error": str(exc),
+                }
+            )
+
+        self._logger.info(
+            {
+                "service": "notification_dispatcher",
+                "event": "broadcast_complete",
+                "type": event_type,
+                "realtime": realtime_status,
+                "push": push_status,
+                "env": ENV,
+            }
+        )
+
+        try:
+            self.audit.log_event(
+                None,
+                "notification_sent",
+                {"type": event_type, "size": len(str(payload))},
+            )
+        except Exception:  # pragma: no cover - avoid failing callers on audit issues
+            self._logger.warning(
+                {
+                    "service": "notification_dispatcher",
+                    "event": "audit_error",
+                    "type": event_type,
+                }
+            )
+
+    @staticmethod
+    def _build_envelope(event_type: str, payload: dict[str, Any]) -> dict[str, Any]:
+        summary = payload.get("text") or payload.get("message") or payload.get("body") or ""
+        title = payload.get("title") or f"BullBear {event_type.replace('_', ' ').title()}"
+        return {
+            "type": event_type,
+            "title": title,
+            "body": summary,
+            "payload": payload,
+        }
+
+
+_realtime_service = RealtimeService()
+_push_channel = PushBroadcastChannel(push_service)
+_audit_service = AuditService()
+
+notification_dispatcher = NotificationDispatcher(
+    _realtime_service,
+    _push_channel,
+    _audit_service,
+)
+
+
+__all__ = ["NotificationDispatcher", "notification_dispatcher"]

--- a/backend/tests/test_notification_dispatcher.py
+++ b/backend/tests/test_notification_dispatcher.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+from types import MethodType, SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import importlib
+import pytest
+
+ai_service_module = importlib.import_module("backend.services.ai_service")
+alert_service_module = importlib.import_module("backend.services.alert_service")
+from backend.services.ai_service import AIService
+from backend.services.alert_service import AlertService
+from backend.services.notification_dispatcher import NotificationDispatcher
+
+
+class CounterStub:
+    def __init__(self) -> None:
+        self.count = 0
+
+    def inc(self) -> None:
+        self.count += 1
+
+
+def _create_ai_service(
+    monkeypatch: pytest.MonkeyPatch,
+    counter: CounterStub,
+    *,
+    dispatcher_override: NotificationDispatcher | None = None,
+):
+    service = AIService()
+
+    if dispatcher_override is None:
+        broadcast_mock: AsyncMock = AsyncMock()
+        monkeypatch.setattr(
+            ai_service_module.notification_dispatcher,
+            "broadcast_event",
+            broadcast_mock,
+            raising=False,
+        )
+    else:
+        monkeypatch.setattr(ai_service_module, "notification_dispatcher", dispatcher_override, raising=False)
+        monkeypatch.setattr(
+            "backend.services.notification_dispatcher.notification_dispatcher",
+            dispatcher_override,
+            raising=False,
+        )
+        broadcast_mock = None
+
+    monkeypatch.setattr(ai_service_module, "ai_notifications_total", counter, raising=False)
+    monkeypatch.setattr(ai_service_module.Config, "HUGGINGFACE_API_KEY", "", raising=False)
+
+    def _analyze(self, _: str) -> dict[str, object]:
+        return {
+            "symbols": [],
+            "interval": None,
+            "use_market_data": False,
+            "need_indicators": False,
+            "need_news": False,
+            "need_alerts": False,
+            "forex_pairs": [],
+        }
+
+    async def _call_with_backoff(self, *_: object, **__: object) -> tuple[str, str]:
+        return ("Insight generada", "mistral")
+
+    service._analyze_message = MethodType(_analyze, service)
+    service._build_prompt = MethodType(lambda self, *_: None, service)
+    service._call_with_backoff = MethodType(_call_with_backoff, service)
+
+    return service, broadcast_mock
+
+
+def _create_alert_service(
+    monkeypatch: pytest.MonkeyPatch,
+    counter: CounterStub,
+    *,
+    dispatcher_override: NotificationDispatcher | None = None,
+):
+    service = AlertService(telegram_bot_token="token-fake")
+
+    if dispatcher_override is None:
+        broadcast_mock: AsyncMock = AsyncMock()
+        monkeypatch.setattr(
+            alert_service_module.notification_dispatcher,
+            "broadcast_event",
+            broadcast_mock,
+            raising=False,
+        )
+    else:
+        monkeypatch.setattr(alert_service_module, "notification_dispatcher", dispatcher_override, raising=False)
+        monkeypatch.setattr(
+            "backend.services.notification_dispatcher.notification_dispatcher",
+            dispatcher_override,
+            raising=False,
+        )
+        broadcast_mock = None
+
+    monkeypatch.setattr(alert_service_module, "alert_notifications_total", counter, raising=False)
+
+    async def _send_telegram_message(self, *_: object, **__: object) -> None:
+        return None
+
+    async def _send_discord_message(self, *_: object, **__: object) -> None:
+        return None
+
+    service._send_telegram_message = MethodType(_send_telegram_message, service)
+    service._send_discord_message = MethodType(_send_discord_message, service)
+
+    async def _notify_telegram(self, *_: object, **__: object) -> None:
+        return None
+
+    service._notify_telegram = MethodType(_notify_telegram, service)
+
+    return service, broadcast_mock
+
+
+@pytest.mark.asyncio
+async def test_broadcast_event_sends_to_all_channels() -> None:
+    realtime = SimpleNamespace(broadcast=AsyncMock())
+    push = SimpleNamespace(broadcast=AsyncMock(return_value=1))
+    audit = MagicMock()
+    dispatcher = NotificationDispatcher(realtime, push, audit)
+
+    payload = {"text": "Hola"}
+    await dispatcher.broadcast_event("ai_insight", payload)
+
+    realtime.broadcast.assert_awaited_once()
+    push.broadcast.assert_awaited_once()
+    audit.log_event.assert_called_once_with(
+        None, "notification_sent", {"type": "ai_insight", "size": len(str(payload))}
+    )
+
+    realtime_args = realtime.broadcast.await_args
+    assert realtime_args.args[0]["type"] == "ai_insight"
+    assert realtime_args.args[0]["payload"] == payload
+
+
+@pytest.mark.asyncio
+async def test_ai_service_triggers_broadcast_on_insight(monkeypatch: pytest.MonkeyPatch) -> None:
+    counter = CounterStub()
+    service, broadcast_mock = _create_ai_service(monkeypatch, counter)
+
+    response = await service.process_message("Genera insight")
+
+    assert response.text
+    assert broadcast_mock is not None
+    assert broadcast_mock.await_count == 1
+    broadcast_mock.assert_awaited_once()
+    call_args = broadcast_mock.await_args
+    assert call_args.args[0] == "ai_insight"
+    assert call_args.args[1]["source"] == "ai"
+    assert counter.count == 1
+
+
+@pytest.mark.asyncio
+async def test_alert_service_triggers_broadcast_on_alert(monkeypatch: pytest.MonkeyPatch) -> None:
+    counter = CounterStub()
+    service, broadcast_mock = _create_alert_service(monkeypatch, counter)
+
+    result = await service.send_external_alert(message="Precio en alza", telegram_chat_id="123")
+
+    assert "telegram" in result
+    assert broadcast_mock is not None
+    broadcast_mock.assert_awaited_once()
+    args = broadcast_mock.await_args
+    assert args.args[0] == "alert"
+    assert counter.count == 1
+
+
+@pytest.mark.asyncio
+async def test_broadcast_logs_and_metrics_increment(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    realtime = SimpleNamespace(broadcast=AsyncMock())
+    push = SimpleNamespace(broadcast=AsyncMock(return_value=2))
+    audit = MagicMock()
+    dispatcher = NotificationDispatcher(realtime, push, audit)
+
+    ai_counter = CounterStub()
+    alert_counter = CounterStub()
+
+    service, _ = _create_ai_service(
+        monkeypatch, ai_counter, dispatcher_override=dispatcher
+    )
+    alert_service, _ = _create_alert_service(
+        monkeypatch, alert_counter, dispatcher_override=dispatcher
+    )
+
+    caplog.set_level("INFO")
+
+    await service.process_message("Insight rapido")
+    await alert_service.send_external_alert(message="Caída del mercado", telegram_chat_id="321")
+    dummy_alert = SimpleNamespace(
+        asset="AAPL",
+        value=101.5,
+        condition=">",
+        title="AAPL alerta",
+    )
+    await alert_service._notify(dummy_alert, 102.3)
+    await dispatcher.broadcast_event("manual", {"text": "ping"})
+
+    assert ai_counter.count == 1
+    assert alert_counter.count == 2  # incluye alerta interna y externa
+
+    messages = [record.message for record in caplog.records if "notification_dispatcher" in record.message]
+    assert any("broadcast_complete" in message for message in messages)
+
+    audit.log_event.assert_called()


### PR DESCRIPTION
## Summary
- introduce a NotificationDispatcher service that broadcasts events to realtime websockets and web push while auditing deliveries
- invoke the dispatcher from AI and alert workflows, updating new Prometheus counters and wiring the manual notifications endpoint
- cover the dispatcher and service integrations with async pytest suites and local adapters

## Testing
- pytest backend/tests/test_notification_dispatcher.py -vv
- pytest backend/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68e28cf623848321ab3b1a511158a1f7