### PR TITLE
Add notification center card with persistent history

### DIFF
--- a/frontend/src/components/dashboard/__tests__/notification-center-card.integration.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/notification-center-card.integration.test.tsx
@@ -1,0 +1,36 @@
+// 🧩 Bloque 8B
+import { render, screen, fireEvent } from "@testing-library/react";
+
+import NotificationCenterCard from "../notification-center-card";
+
+describe("NotificationCenterCard", () => {
+  const originalNotification = window.Notification;
+
+  beforeEach(() => {
+    localStorage.clear();
+    class MockNotification {
+      static permission: NotificationPermission = "granted";
+      static async requestPermission() {
+        return this.permission;
+      }
+    }
+    // @ts-expect-error - mock constructor
+    window.Notification = MockNotification;
+  });
+
+  afterEach(() => {
+    window.Notification = originalNotification;
+  });
+
+  it("renders and handles push actions", async () => {
+    render(<NotificationCenterCard />);
+
+    expect(screen.getByText("Centro de Notificaciones")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("🧪 Enviar Test"));
+    expect(await screen.findByText(/Notificación de prueba/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("🧹 Limpiar"));
+    expect(screen.getByText(/Sin notificaciones aún/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/dashboard/dashboard-page.tsx
+++ b/frontend/src/components/dashboard/dashboard-page.tsx
@@ -16,6 +16,8 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { getIndicators, sendChatMessage } from "@/lib/api"; // [Codex] nuevo
 import { usePushNotifications } from "@/hooks/usePushNotifications";
+// 🧩 Bloque 8B
+import NotificationCenterCard from "@/components/dashboard/notification-center-card";
 import { useHistoricalData } from "@/hooks/useHistoricalData"; // [Codex] nuevo
 import { useRealtime } from "@/hooks/useRealtime"; // ✅ Codex fix: integración realtime en dashboard
 import { ErrorBoundary } from "@/components/common/ErrorBoundary";
@@ -238,95 +240,99 @@ function DashboardPageContent() {
               {pushError}
             </div>
           )}
-          <Card data-testid="notification-center" className="border-dashed">
-            <CardHeader className="flex flex-col gap-1 pb-3">
-              <CardTitle className="text-base font-semibold">Centro de notificaciones</CardTitle>
-              <CardDescription>
-                Gestiona las alertas en tiempo real provenientes del dispatcher.
-              </CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <div className="flex flex-wrap items-center gap-2">
-                <Badge variant={pushEnabled ? "default" : "secondary"}>
-                  {pushEnabled ? "Suscripción activa" : pushLoading ? "Sincronizando..." : "Suscripción inactiva"}
-                </Badge>
-                {pushPermission !== "unsupported" && pushPermission !== "granted" && (
+          // 🧩 Bloque 8B
+          <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+            <NotificationCenterCard />
+            <Card data-testid="notification-center" className="border-dashed">
+              <CardHeader className="flex flex-col gap-1 pb-3">
+                <CardTitle className="text-base font-semibold">Centro de notificaciones</CardTitle>
+                <CardDescription>
+                  Gestiona las alertas en tiempo real provenientes del dispatcher.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div className="flex flex-wrap items-center gap-2">
+                  <Badge variant={pushEnabled ? "default" : "secondary"}>
+                    {pushEnabled ? "Suscripción activa" : pushLoading ? "Sincronizando..." : "Suscripción inactiva"}
+                  </Badge>
+                  {pushPermission !== "unsupported" && pushPermission !== "granted" && (
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() => void requestPushPermission()}
+                      disabled={pushLoading}
+                    >
+                      Activar notificaciones
+                    </Button>
+                  )}
                   <Button
                     size="sm"
-                    variant="outline"
-                    onClick={() => void requestPushPermission()}
-                    disabled={pushLoading}
+                    variant="ghost"
+                    onClick={() => void sendTestNotification()}
+                    disabled={!pushEnabled || pushTesting}
                   >
-                    Activar notificaciones
+                    {pushTesting ? "Enviando prueba..." : "Enviar prueba"}
                   </Button>
-                )}
-                <Button
-                  size="sm"
-                  variant="ghost"
-                  onClick={() => void sendTestNotification()}
-                  disabled={!pushEnabled || pushTesting}
-                >
-                  {pushTesting ? "Enviando prueba..." : "Enviar prueba"}
-                </Button>
-              </div>
-              <div className="space-y-2" aria-live="polite">
-                {pushEvents.length === 0 ? (
-                  <p className="text-sm text-muted-foreground">
-                    Aún no se reciben notificaciones. Envía una prueba para verificar el canal.
-                  </p>
-                ) : (
-                  pushEvents
-                    .slice()
-                    .reverse()
-                    .map((event) => (
-                      <div
-                        key={event.id}
-                        className="flex items-start justify-between gap-3 rounded-md border border-border/60 bg-muted/40 p-3"
-                      >
-                        <div className="space-y-1">
-                          <p className="text-sm font-medium text-foreground">{event.title}</p>
-                          {event.body && (
-                            <p className="text-sm text-muted-foreground">{event.body}</p>
-                          )}
-                          <p className="text-xs text-muted-foreground">
-                            {new Date(event.receivedAt).toLocaleString()}
-                          </p>
-                        </div>
-                        <Button
-                          size="sm"
-                          variant="ghost"
-                          className="-mr-1"
-                          onClick={() => dismissPushEvent(event.id)}
-                        >
-                          Cerrar
-                        </Button>
-                      </div>
-                    ))
-                )}
-              </div>
-              <div>
-                <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                  Registro de eventos
-                </p>
-                <ScrollArea className="h-32 rounded-md border border-border/60 bg-muted/20 p-2">
-                  {pushLogs.length === 0 ? (
-                    <p className="text-xs text-muted-foreground">
-                      Esperando eventos auditables del dispatcher...
+                </div>
+                <div className="space-y-2" aria-live="polite">
+                  {pushEvents.length === 0 ? (
+                    <p className="text-sm text-muted-foreground">
+                      Aún no se reciben notificaciones. Envía una prueba para verificar el canal.
                     </p>
                   ) : (
-                    <ul className="space-y-1 text-xs text-foreground">
-                      {pushLogs
-                        .slice()
-                        .reverse()
-                        .map((log, index) => (
-                          <li key={`${log}-${index}`}>{log}</li>
-                        ))}
-                    </ul>
+                    pushEvents
+                      .slice()
+                      .reverse()
+                      .map((event) => (
+                        <div
+                          key={event.id}
+                          className="flex items-start justify-between gap-3 rounded-md border border-border/60 bg-muted/40 p-3"
+                        >
+                          <div className="space-y-1">
+                            <p className="text-sm font-medium text-foreground">{event.title}</p>
+                            {event.body && (
+                              <p className="text-sm text-muted-foreground">{event.body}</p>
+                            )}
+                            <p className="text-xs text-muted-foreground">
+                              {new Date(event.receivedAt).toLocaleString()}
+                            </p>
+                          </div>
+                          <Button
+                            size="sm"
+                            variant="ghost"
+                            className="-mr-1"
+                            onClick={() => dismissPushEvent(event.id)}
+                          >
+                            Cerrar
+                          </Button>
+                        </div>
+                      ))
                   )}
-                </ScrollArea>
-              </div>
-            </CardContent>
-          </Card>
+                </div>
+                <div>
+                  <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                    Registro de eventos
+                  </p>
+                  <ScrollArea className="h-32 rounded-md border border-border/60 bg-muted/20 p-2">
+                    {pushLogs.length === 0 ? (
+                      <p className="text-xs text-muted-foreground">
+                        Esperando eventos auditables del dispatcher...
+                      </p>
+                    ) : (
+                      <ul className="space-y-1 text-xs text-foreground">
+                        {pushLogs
+                          .slice()
+                          .reverse()
+                          .map((log, index) => (
+                            <li key={`${log}-${index}`}>{log}</li>
+                          ))}
+                      </ul>
+                    )}
+                  </ScrollArea>
+                </div>
+              </CardContent>
+            </Card>
+          </div>
         </div>
         <div className="p-2 text-xs">
           <span className={realtimeConnected ? "text-green-500" : "text-red-500"}>

--- a/frontend/src/components/dashboard/notification-center-card.tsx
+++ b/frontend/src/components/dashboard/notification-center-card.tsx
@@ -1,0 +1,138 @@
+// 🧩 Bloque 8B
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { usePushNotifications } from "@/hooks/usePushNotifications";
+
+export interface NotificationLog {
+  id: string;
+  title: string;
+  body: string;
+  timestamp: number;
+}
+
+const STORAGE_KEY = "notificationHistory";
+
+export default function NotificationCenterCard() {
+  const {
+    permission,
+    requestPermission,
+    sendTestNotification,
+    notificationHistory,
+    clearLogs,
+  } = usePushNotifications();
+
+  const [history, setHistory] = useState<NotificationLog[]>(() => {
+    if (typeof window === "undefined") {
+      return notificationHistory;
+    }
+    try {
+      const stored = window.localStorage.getItem(STORAGE_KEY);
+      if (!stored) {
+        return notificationHistory;
+      }
+      const parsed = JSON.parse(stored) as NotificationLog[];
+      if (!Array.isArray(parsed)) {
+        return notificationHistory;
+      }
+      return parsed;
+    } catch (err) {
+      console.error("No se pudo cargar el historial de notificaciones", err);
+      return notificationHistory;
+    }
+  });
+
+  // 🧩 Bloque 8B
+  useEffect(() => {
+    if (!notificationHistory.length) {
+      setHistory([]);
+      return;
+    }
+    setHistory((prev) => {
+      const map = new Map<string, NotificationLog>();
+      for (const entry of prev) {
+        map.set(entry.id, entry);
+      }
+      let changed = false;
+      for (const entry of notificationHistory) {
+        const existing = map.get(entry.id);
+        if (
+          !existing ||
+          existing.timestamp !== entry.timestamp ||
+          existing.body !== entry.body ||
+          existing.title !== entry.title
+        ) {
+          map.set(entry.id, entry);
+          changed = true;
+        }
+      }
+      if (!changed && map.size === prev.length) {
+        return prev;
+      }
+      const ordered = Array.from(map.values()).sort((a, b) => a.timestamp - b.timestamp);
+      return ordered;
+    });
+  }, [notificationHistory]);
+
+  // 🧩 Bloque 8B
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+    if (history.length === 0) {
+      window.localStorage.removeItem(STORAGE_KEY);
+      return;
+    }
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(history));
+  }, [history]);
+
+  return (
+    <Card className="p-4 shadow-md rounded-2xl">
+      <CardHeader>
+        <CardTitle className="text-lg font-semibold">Centro de Notificaciones</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="flex gap-2">
+          <Button onClick={() => void requestPermission()}>🔔 Activar Push</Button>
+          <Button onClick={() => void sendTestNotification()} variant="secondary">
+            🧪 Enviar Test
+          </Button>
+          <Button
+            onClick={() => {
+              clearLogs();
+              setHistory([]);
+            }}
+            variant="destructive"
+          >
+            🧹 Limpiar
+          </Button>
+        </div>
+
+        <div className="max-h-64 overflow-y-auto border rounded-lg p-2 bg-muted/40">
+          {history.length === 0 ? (
+            <p className="text-sm text-muted-foreground">Sin notificaciones aún.</p>
+          ) : (
+            history
+              .slice()
+              .reverse()
+              .map((n) => (
+                <div key={n.id} className="border-b last:border-0 py-1 text-sm leading-tight">
+                  <span className="font-semibold">{n.title}</span> — {n.body}{" "}
+                  <span className="text-xs text-muted-foreground">
+                    ({new Date(n.timestamp).toLocaleTimeString()})
+                  </span>
+                </div>
+              ))
+          )}
+        </div>
+
+        <p className="text-xs text-muted-foreground">
+          Estado: <strong>{permission}</strong>
+        </p>
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
## Summary
- add a NotificationCenterCard component to surface persisted notification history with push helpers
- extend usePushNotifications with notification history, local test support, and log clearing
- integrate the new card into the dashboard layout and cover it with an integration test

## Testing
- pnpm test -- notification-center-card

------
https://chatgpt.com/codex/tasks/task_e_68e2df32b5ac8321b0b4b4cfe83bbce8