### PR TITLE
Add websocket notifications channel with HTTP fallbacks

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -41,6 +41,7 @@ from backend.routers import (  # ✅ Codex fix: registrar gateway WebSocket real
     metrics,
     news,
     notifications,
+    notifications_ws,  # 🧩 Bloque 9A
     portfolio,
     push,
     realtime,
@@ -299,6 +300,8 @@ app.include_router(ai_context.router, prefix="/api/ai", tags=["ai"])
 app.include_router(ai_insights.router, prefix="/api/ai", tags=["ai"])
 app.include_router(ai_stream.router, prefix="/api/ai", tags=["ai"])
 app.include_router(notifications.router)
+# 🧩 Bloque 9A
+app.include_router(notifications_ws.router)
 app.include_router(push.router, prefix="/api/push", tags=["push"])
 app.include_router(portfolio.router, prefix="/api/portfolio", tags=["portfolio"])
 app.include_router(indicators.router)

--- a/backend/routers/notifications.py
+++ b/backend/routers/notifications.py
@@ -1,16 +1,48 @@
 # backend/routers/notifications.py
 from fastapi import APIRouter, Depends, Request, status
 from sqlalchemy.orm import Session
+from typing import List  # 🧩 Bloque 9A
 
 from backend.core.config import VAPID_PUBLIC_KEY
 from backend.database import get_db
 from backend.services.audit_service import AuditService
 from backend.services.notification_dispatcher import NotificationDispatcher
+from backend.services.notification_dispatcher import manager  # 🧩 Bloque 9A
 from backend.services.push_service import PushService
 from backend.services.realtime_service import RealtimeService
+from backend.schemas.notifications import NotificationEvent  # 🧩 Bloque 9A
 
 # 🧩 Bloque 8A
 router = APIRouter(prefix="/api/notifications", tags=["notifications"])
+
+
+# 🧩 Bloque 9A
+_LAST_EVENTS: list[NotificationEvent] = []
+
+
+# 🧩 Bloque 9A
+def _append_event(e: NotificationEvent, *, keep: int = 100) -> None:
+    _LAST_EVENTS.append(e)
+    if len(_LAST_EVENTS) > keep:
+        del _LAST_EVENTS[0 : len(_LAST_EVENTS) - keep]
+
+
+# 🧩 Bloque 9A
+@router.get("/logs", response_model=List[NotificationEvent])
+def get_recent_logs() -> list[NotificationEvent]:
+    # Fallback para polling en el frontend (SWR)
+    return _LAST_EVENTS
+
+
+# 🧩 Bloque 9A
+@router.post("/test/broadcast", response_model=NotificationEvent)
+async def post_test_broadcast() -> NotificationEvent:
+    # Utilidad para QA manual: crea evento y hace broadcast
+    e = NotificationEvent(title="Test broadcast", body="Mensaje de prueba (backend)")
+    _append_event(e)
+    # Como es ruta de prueba, hacemos broadcast directo en el canal WS
+    await manager.broadcast(e)
+    return e
 
 
 @router.get("/vapid-key")
@@ -57,4 +89,12 @@ async def broadcast_test(request: Request):
     )
 
     await dispatcher.broadcast_event("manual", payload)
+    # 🧩 Bloque 9A
+    event = NotificationEvent(
+        title=str(payload.get("title") or "Manual broadcast"),
+        body=str(payload.get("body") or payload.get("message") or ""),
+        meta={"source": "manual-broadcast"},
+    )
+    _append_event(event)
+    await manager.broadcast(event)
     return {"status": "ok", "sent": len(str(payload))}

--- a/backend/routers/notifications_ws.py
+++ b/backend/routers/notifications_ws.py
@@ -1,0 +1,66 @@
+# 🧩 Bloque 9A
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect, status
+from typing import Optional
+from backend.services.notification_dispatcher import manager
+from backend.schemas.notifications import NotificationEvent  # 🧩 Bloque 9A  # noqa: F401
+
+# Intenta importar el decoder de access token del proyecto.
+# Si el proyecto usa otro nombre, ajustarlo (sin duplicar lógica).
+try:
+    from backend.core.security import decode_access  # tipo: (str) -> dict | None
+except Exception:
+    decode_access = None  # fallback; deberá existir en el proyecto real
+
+router = APIRouter()
+
+
+async def _resolve_user_id_from_ws(websocket: WebSocket) -> Optional[str]:
+    """
+    Extrae el token de query (?token=) o header Authorization y retorna user_id (sub).
+    Cierra el socket con 1008 si no es válido.
+    """
+    # Query param ?token=
+    token = websocket.query_params.get("token")
+    if not token:
+        # Header Authorization: Bearer xxx
+        auth = websocket.headers.get("authorization") or websocket.headers.get("Authorization")
+        if auth and auth.lower().startswith("bearer "):
+            token = auth.split(" ", 1)[1]
+
+    if not token or decode_access is None:
+        await websocket.close(code=status.WS_1008_POLICY_VIOLATION)
+        return None
+
+    try:
+        payload = decode_access(token)  # debe devolver dict con 'sub' o user_id
+        user_id = str(payload.get("sub") or payload.get("user_id"))
+        if not user_id:
+            raise ValueError("no sub in token")
+        return user_id
+    except Exception:
+        await websocket.close(code=status.WS_1008_POLICY_VIOLATION)
+        return None
+
+
+@router.websocket("/ws/notifications")
+async def notifications_ws(websocket: WebSocket):
+    # Requiere conectarse con token válido
+    user_id = await _resolve_user_id_from_ws(websocket)
+    if not user_id:
+        return
+    await manager.connect(user_id, websocket)
+    try:
+        # Loop de escucha: recibimos pings del cliente, o eventos controlados.
+        while True:
+            _ = await websocket.receive_text()
+            # Opcional: podríamos soportar comandos del cliente (pong, ack, etc.)
+            # Por ahora, sólo ignoramos; el canal es "server -> client".
+    except WebSocketDisconnect:
+        await manager.disconnect(user_id, websocket)
+    except Exception:
+        # Cualquier error inesperado: cerrar conexión limpiamente
+        await manager.disconnect(user_id, websocket)
+        try:
+            await websocket.close()
+        except Exception:
+            pass

--- a/backend/schemas/notifications.py
+++ b/backend/schemas/notifications.py
@@ -1,0 +1,14 @@
+# 🧩 Bloque 9A
+from pydantic import BaseModel
+from typing import Any, Optional
+from datetime import datetime, timezone
+from uuid import UUID, uuid4
+
+
+class NotificationEvent(BaseModel):
+    id: UUID = uuid4()
+    title: str
+    body: str
+    timestamp: datetime = datetime.now(timezone.utc)
+    # Campo libre para metadatos opcionales (tipo, prioridad, etc.)
+    meta: Optional[dict[str, Any]] = None


### PR DESCRIPTION
## Summary
- add a reusable notification event schema and websocket router with token validation
- extend the notification dispatcher with a connection manager and register the websocket router
- provide HTTP fallback endpoints for broadcasting and retrieving notification events

## Testing
- pytest test_websocket_fixed.py

------
https://chatgpt.com/codex/tasks/task_e_68e2e856a5c48321968f2da0de703c64