### PR TITLE
feat(frontend): add websocket live notifications fallback

### DIFF
--- a/frontend/src/components/dashboard/__tests__/notification-center-card.integration.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/notification-center-card.integration.test.tsx
@@ -1,6 +1,27 @@
 // 🧩 Bloque 8B
 import { render, screen, fireEvent } from "@testing-library/react";
 
+// 🧩 Bloque 9B
+jest.mock("@/components/providers/auth-provider", () => ({
+  useAuth: jest.fn(() => ({ token: null })),
+}));
+// 🧩 Bloque 9B
+const { useAuth: mockUseAuth } = jest.requireMock(
+  "@/components/providers/auth-provider"
+) as {
+  useAuth: jest.Mock;
+};
+// 🧩 Bloque 9B
+jest.mock("@/hooks/useLiveNotifications", () => ({
+  useLiveNotifications: jest.fn(() => ({ events: [], status: "fallback" })),
+}));
+// 🧩 Bloque 9B
+const { useLiveNotifications: mockUseLiveNotifications } = jest.requireMock(
+  "@/hooks/useLiveNotifications"
+) as {
+  useLiveNotifications: jest.Mock;
+};
+
 import NotificationCenterCard from "../notification-center-card";
 
 describe("NotificationCenterCard", () => {
@@ -8,6 +29,8 @@ describe("NotificationCenterCard", () => {
 
   beforeEach(() => {
     localStorage.clear();
+    mockUseAuth.mockReturnValue({ token: null });
+    mockUseLiveNotifications.mockReturnValue({ events: [], status: "fallback" });
     class MockNotification {
       static permission: NotificationPermission = "granted";
       static async requestPermission() {
@@ -32,5 +55,11 @@ describe("NotificationCenterCard", () => {
 
     fireEvent.click(screen.getByText("🧹 Limpiar"));
     expect(screen.getByText(/Sin notificaciones aún/i)).toBeInTheDocument();
+  });
+
+  // 🧩 Bloque 9B
+  it("shows live connection state indicator", () => {
+    render(<NotificationCenterCard />);
+    expect(screen.getByText(/🟡 Fallback \(Polling\)/i)).toBeInTheDocument();
   });
 });

--- a/frontend/src/hooks/useLiveNotifications.ts
+++ b/frontend/src/hooks/useLiveNotifications.ts
@@ -1,0 +1,96 @@
+// 🧩 Bloque 9B
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import useSWR from "swr";
+
+const fetcher = (url: string) => fetch(url).then((res) => res.json());
+
+export function useLiveNotifications(token?: string | null) {
+  const [events, setEvents] = useState<NotificationEvent[]>([]);
+  const [status, setStatus] = useState<"connected" | "fallback">("fallback");
+  const socketRef = useRef<WebSocket | null>(null);
+
+  const wsUrl = useMemo(() => {
+    if (!token || typeof window === "undefined") {
+      return null;
+    }
+    const origin = window.location.origin.replace("http", "ws");
+    const encodedToken = encodeURIComponent(token);
+    return `${origin}/ws/notifications?token=${encodedToken}`;
+  }, [token]);
+
+  const { data: fallbackData } = useSWR<NotificationEvent[]>(
+    status === "fallback" ? "/api/notifications/logs" : null,
+    fetcher,
+    { refreshInterval: 5000 }
+  );
+
+  useEffect(() => {
+    if (status !== "fallback") {
+      return;
+    }
+    if (!fallbackData) {
+      return;
+    }
+    if (!Array.isArray(fallbackData)) {
+      console.warn("Invalid fallback payload for notifications");
+      return;
+    }
+    setEvents(fallbackData);
+  }, [fallbackData, status]);
+
+  useEffect(() => {
+    if (!wsUrl) {
+      setStatus("fallback");
+      return;
+    }
+
+    const ws = new WebSocket(wsUrl);
+    socketRef.current = ws;
+    let active = true;
+
+    ws.onopen = () => {
+      if (!active) return;
+      setStatus("connected");
+    };
+
+    ws.onmessage = (event) => {
+      if (!active) {
+        return;
+      }
+      try {
+        const data = JSON.parse(event.data) as NotificationEvent;
+        setEvents((prev) => [...prev, data]);
+      } catch (error) {
+        console.warn("Invalid WS message:", error);
+      }
+    };
+
+    const handleFallback = () => {
+      if (!active) return;
+      setStatus("fallback");
+    };
+
+    ws.onerror = handleFallback;
+    ws.onclose = handleFallback;
+
+    return () => {
+      active = false;
+      ws.close();
+      if (socketRef.current === ws) {
+        socketRef.current = null;
+      }
+    };
+  }, [wsUrl]);
+
+  return { events, status };
+}
+
+export interface NotificationEvent {
+  id: string;
+  title: string;
+  body: string;
+  timestamp: string | number;
+  meta?: Record<string, unknown>;
+}


### PR DESCRIPTION
## Summary
- add a `useLiveNotifications` hook that connects to the `/ws/notifications` channel and falls back to polling
- integrate the live event stream into `NotificationCenterCard` with a realtime/fallback status indicator
- extend the integration test to cover the live connection status rendering

## Testing
- pnpm test -- notification-center-card

------
https://chatgpt.com/codex/tasks/task_e_68e2ebc7ec088321ab941a7ffda57d18