### PR TITLE
🧩 QA fix: MSW unhandledRequest + ESM export interceptor

### DIFF
--- a/frontend/src/tests/msw/interceptors/RemoteHttpInterceptor.ts
+++ b/frontend/src/tests/msw/interceptors/RemoteHttpInterceptor.ts
@@ -1,5 +1,4 @@
 import { loadInterceptor } from "./resolve";
-
 const interceptor = loadInterceptor("RemoteHttpInterceptor");
-
-export = interceptor;
+// # QA fix: conversión a export default para compatibilidad con Babel/ESM
+export default interceptor;

--- a/frontend/src/tests/msw/server.ts
+++ b/frontend/src/tests/msw/server.ts
@@ -2,4 +2,9 @@ import { setupServer } from "msw/node";
 
 import { handlers } from "./handlers";
 
+// # QA fix: permitir requests no interceptadas sin abortar tests
 export const server = setupServer(...handlers);
+
+server.listen({
+  onUnhandledRequest: "warn", // evita errores en pruebas no mockeadas
+});


### PR DESCRIPTION
## Summary
- allow the MSW server to warn on unhandled requests during setup so tests with real network calls do not abort (# QA fix)
- convert the remote HTTP interceptor to a default export for compatibility with Babel/ESM consumers (# QA fix)

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68e4323f44bc8321abdff1cf9b7b005e