### PR TITLE
🧩 QA fix: mock Notification permission for usePushNotifications tests

### DIFF
--- a/frontend/src/hooks/__tests__/usePushNotifications.test.ts
+++ b/frontend/src/hooks/__tests__/usePushNotifications.test.ts
@@ -44,6 +44,12 @@ describe("usePushNotifications", () => {
   const mockedSubscribePush = subscribePush as jest.MockedFunction<typeof subscribePush>;
 
   beforeEach(() => {
+    // QA fix: forzar permisos de notificación para simular navegador con Push habilitado
+    Object.defineProperty(global, "Notification", {
+      value: { permission: "granted" },
+      writable: true,
+    });
+
     process.env.NEXT_PUBLIC_PUSH_VAPID_PUBLIC_KEY = "dGVzdA==";
     process.env.NEXT_PUBLIC_VAPID_KEY = "dGVzdA==";
 
@@ -72,7 +78,7 @@ describe("usePushNotifications", () => {
     });
 
     class MockNotification {
-      static permission: NotificationPermission = "default";
+      static permission: NotificationPermission = "granted";
       static async requestPermission(): Promise<NotificationPermission> {
         MockNotification.permission = "granted";
         return MockNotification.permission;


### PR DESCRIPTION
## Summary
- mock the global Notification permission inside the usePushNotifications tests to simulate push-enabled browsers
- ensure the mock Notification class starts with permission granted to align with the forced permission state

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68e43485c1148321961e1d17d9388e25