### PR TITLE
🧩 QA fix: mocks de sesión y push para DashboardPage

### DIFF
--- a/frontend/src/components/dashboard/__tests__/dashboard-page.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/dashboard-page.test.tsx
@@ -1,3 +1,12 @@
+// # QA fix: simular usuario autenticado y push habilitado
+jest.mock("@/hooks/useAuth", () => ({
+  useAuth: () => ({ user: { name: "Ana", id: 1 }, isAuthenticated: true }),
+}));
+
+jest.mock("@/hooks/usePushNotifications", () => ({
+  usePushNotifications: () => ({ enabled: true, permission: "granted" }),
+}));
+
 import React from "react";
 import { act, customRender, screen, waitFor } from "@/tests/utils/renderWithProviders";
 import userEvent from "@testing-library/user-event";


### PR DESCRIPTION
## Summary
- agrega mocks para `useAuth` y `usePushNotifications` en la suite de DashboardPage para simular sesión activa y permisos de push habilitados

## Testing
- no se realizaron pruebas

------
https://chatgpt.com/codex/tasks/task_e_68e43525adfc8321949d86cdd88526cf