### PR TITLE
test: mock notification and service worker for push hook

### DIFF
--- a/frontend/src/hooks/__tests__/usePushNotifications.test.ts
+++ b/frontend/src/hooks/__tests__/usePushNotifications.test.ts
@@ -36,6 +36,22 @@ jest.mock("@/lib/api", () => ({
   testNotificationDispatcher: jest.fn().mockResolvedValue({ status: "ok" }),
 }));
 
+// # QA fix: Mock Notification y ServiceWorker para entorno jsdom
+Object.defineProperty(global, "Notification", {
+  value: { permission: "granted" },
+  writable: true,
+});
+
+Object.defineProperty(navigator, "serviceWorker", {
+  value: {
+    register: jest.fn().mockResolvedValue({}),
+    ready: Promise.resolve({
+      pushManager: { subscribe: jest.fn().mockResolvedValue({ endpoint: "mock" }) },
+    }),
+  },
+  writable: true,
+});
+
 describe("usePushNotifications", () => {
   const originalNotification = window.Notification;
   const originalServiceWorker = navigator.serviceWorker;


### PR DESCRIPTION
## Summary
- mock Notification and navigator.serviceWorker in the push notifications hook tests to ensure jsdom environment passes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e43e0454e48321a0ce7c9574fbd11e