### PR TITLE
chore: refresh dashboard styling and polish UI

### DIFF
--- a/frontend/src/components/dashboard/dashboard-page.tsx
+++ b/frontend/src/components/dashboard/dashboard-page.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
+import { Activity, BellRing, Bot, LineChart, Radio, SignalHigh } from "lucide-react";
 
 import { useAuth } from "@/components/providers/auth-provider";
 import { ChatPanel } from "@/components/chat/chat-panel";
@@ -215,17 +216,24 @@ function DashboardPageContent() {
       className="grid min-h-screen bg-background text-foreground md:grid-cols-[280px_1fr]"
       data-testid="dashboard-shell"
     >
-      <aside className="border-r bg-card/50">
+      <aside className="border-r border-border/60 bg-card/60 backdrop-blur">
         <MarketSidebar token={sidebarToken} user={user} onLogout={logout} />
       </aside>
-      <main className="flex flex-col gap-6 p-4 lg:p-6" data-testid="dashboard-content">
-        <header className="flex flex-col gap-4 rounded-lg border bg-card p-4 shadow-sm md:flex-row md:items-center md:justify-between">
+      <main className="flex flex-col gap-6 p-4 md:p-6" data-testid="dashboard-content">
+        <header
+          className="surface-card flex flex-col gap-4 animate-in fade-in-50 slide-in-from-bottom-2 md:flex-row md:items-center md:justify-between"
+        >
           <div>
             <p className="text-sm text-muted-foreground">Bienvenido de vuelta</p>
-            <h1 className="text-2xl font-semibold">{user.name || user.email}</h1>
+            <h1 className="text-2xl font-sans font-semibold tracking-tight">
+              {user.name || user.email}
+            </h1>
           </div>
-          <div className="flex items-center gap-3">
-            <Badge variant={pushEnabled ? "outline" : "secondary"} className="hidden md:inline-flex">
+          <div className="flex flex-wrap items-center gap-3">
+            <Badge
+              variant={pushEnabled ? "outline" : "secondary"}
+              className="hidden rounded-full px-3 py-1 text-xs font-medium md:inline-flex"
+            >
               {pushEnabled ? "Push activo" : "Push inactivo"}
             </Badge>
             <ThemeToggle />
@@ -234,184 +242,235 @@ function DashboardPageContent() {
             </Button>
           </div>
         </header>
-        <div className="flex flex-col gap-3">
+        <div className="flex flex-col gap-4">
           {pushError && (
-            <div className="rounded-lg border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive">
+            <div
+              className="rounded-2xl border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive animate-in fade-in-50"
+              style={{ animationDelay: "120ms" }}
+            >
               {pushError}
             </div>
           )}
-          // 🧩 Bloque 8B
-          <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
-            <NotificationCenterCard />
-            <Card data-testid="notification-center" className="border-dashed">
-              <CardHeader className="flex flex-col gap-1 pb-3">
-                <CardTitle className="text-base font-semibold">Centro de notificaciones</CardTitle>
-                <CardDescription>
-                  Gestiona las alertas en tiempo real provenientes del dispatcher.
-                </CardDescription>
-              </CardHeader>
-              <CardContent className="space-y-4">
-                <div className="flex flex-wrap items-center gap-2">
-                  <Badge variant={pushEnabled ? "default" : "secondary"}>
-                    {pushEnabled ? "Suscripción activa" : pushLoading ? "Sincronizando..." : "Suscripción inactiva"}
-                  </Badge>
-                  {pushPermission !== "unsupported" && pushPermission !== "granted" && (
+          {/* 🧩 Bloque 8B */}
+          <section className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+            <div className="h-full animate-in fade-in-50" style={{ animationDelay: "80ms" }}>
+              <NotificationCenterCard />
+            </div>
+            <div className="h-full animate-in fade-in-50" style={{ animationDelay: "120ms" }}>
+              <Card data-testid="notification-center" className="surface-card">
+                <CardHeader className="space-y-2 pb-4">
+                  <CardTitle className="flex items-center gap-2 text-lg font-sans font-medium tracking-tight">
+                    <BellRing className="h-5 w-5 text-primary" /> Preferencias de alerta
+                  </CardTitle>
+                  <CardDescription>
+                    Gestiona las alertas en tiempo real provenientes del dispatcher.
+                  </CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-4">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <Badge
+                      variant={pushEnabled ? "outline" : "secondary"}
+                      className="rounded-full px-3 py-1 text-xs font-medium"
+                    >
+                      {pushEnabled
+                        ? "Suscripción activa"
+                        : pushLoading
+                        ? "Sincronizando..."
+                        : "Suscripción inactiva"}
+                    </Badge>
+                    {pushPermission !== "unsupported" && pushPermission !== "granted" && (
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={() => void requestPushPermission()}
+                        disabled={pushLoading}
+                        className="flex items-center gap-2"
+                      >
+                        <BellRing className="h-4 w-4" />
+                        Activar notificaciones
+                      </Button>
+                    )}
                     <Button
                       size="sm"
-                      variant="outline"
-                      onClick={() => void requestPushPermission()}
-                      disabled={pushLoading}
+                      variant="ghost"
+                      onClick={() => void sendTestNotification()}
+                      disabled={!pushEnabled || pushTesting}
+                      className="flex items-center gap-2"
                     >
-                      Activar notificaciones
+                      <Radio className="h-4 w-4" />
+                      {pushTesting ? "Enviando prueba..." : "Enviar prueba"}
                     </Button>
-                  )}
-                  <Button
-                    size="sm"
-                    variant="ghost"
-                    onClick={() => void sendTestNotification()}
-                    disabled={!pushEnabled || pushTesting}
-                  >
-                    {pushTesting ? "Enviando prueba..." : "Enviar prueba"}
-                  </Button>
-                </div>
-                <div className="space-y-2" aria-live="polite">
-                  {pushEvents.length === 0 ? (
-                    <p className="text-sm text-muted-foreground">
-                      Aún no se reciben notificaciones. Envía una prueba para verificar el canal.
-                    </p>
-                  ) : (
-                    pushEvents
-                      .slice()
-                      .reverse()
-                      .map((event) => (
-                        <div
-                          key={event.id}
-                          className="flex items-start justify-between gap-3 rounded-md border border-border/60 bg-muted/40 p-3"
-                        >
-                          <div className="space-y-1">
-                            <p className="text-sm font-medium text-foreground">{event.title}</p>
-                            {event.body && (
-                              <p className="text-sm text-muted-foreground">{event.body}</p>
-                            )}
-                            <p className="text-xs text-muted-foreground">
-                              {new Date(event.receivedAt).toLocaleString()}
-                            </p>
-                          </div>
-                          <Button
-                            size="sm"
-                            variant="ghost"
-                            className="-mr-1"
-                            onClick={() => dismissPushEvent(event.id)}
-                          >
-                            Cerrar
-                          </Button>
-                        </div>
-                      ))
-                  )}
-                </div>
-                <div>
-                  <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                    Registro de eventos
-                  </p>
-                  <ScrollArea className="h-32 rounded-md border border-border/60 bg-muted/20 p-2">
-                    {pushLogs.length === 0 ? (
-                      <p className="text-xs text-muted-foreground">
-                        Esperando eventos auditables del dispatcher...
+                  </div>
+                  <div className="space-y-2" aria-live="polite">
+                    {pushEvents.length === 0 ? (
+                      <p className="text-sm text-muted-foreground">
+                        Aún no se reciben notificaciones. Envía una prueba para verificar el canal.
                       </p>
                     ) : (
-                      <ul className="space-y-1 text-xs text-foreground">
-                        {pushLogs
-                          .slice()
-                          .reverse()
-                          .map((log, index) => (
-                            <li key={`${log}-${index}`}>{log}</li>
-                          ))}
-                      </ul>
+                      pushEvents
+                        .slice()
+                        .reverse()
+                        .map((event) => (
+                          <div
+                            key={event.id}
+                            className="flex items-start justify-between gap-3 rounded-xl border border-border/50 bg-[hsl(var(--surface-muted))] p-3"
+                          >
+                            <div className="space-y-1">
+                              <p className="text-sm font-medium text-card-foreground">{event.title}</p>
+                              {event.body && (
+                                <p className="text-sm text-muted-foreground">{event.body}</p>
+                              )}
+                              <p className="text-xs text-muted-foreground">
+                                {new Date(event.receivedAt).toLocaleString()}
+                              </p>
+                            </div>
+                            <Button
+                              size="sm"
+                              variant="ghost"
+                              className="-mr-1"
+                              onClick={() => dismissPushEvent(event.id)}
+                            >
+                              Cerrar
+                            </Button>
+                          </div>
+                        ))
                     )}
-                  </ScrollArea>
-                </div>
-              </CardContent>
-            </Card>
-          </div>
-        </div>
-        <div className="p-2 text-xs">
-          <span className={realtimeConnected ? "text-green-500" : "text-red-500"}>
-            {realtimeConnected ? "🟢 Conectado a Realtime" : "🔴 Desconectado"}
-          </span>
-          {realtimeHighlight && (
-            <p className="mt-1 text-foreground">{realtimeHighlight}</p>
-          )}
-          {realtimeData && (
-            <pre className="text-gray-400 mt-2">
-              {JSON.stringify(realtimeData, null, 2)}
-            </pre>
-          )}
+                  </div>
+                  <div>
+                    <p className="mb-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                      Registro de eventos
+                    </p>
+                    <ScrollArea className="h-32 rounded-xl border border-border/40 bg-[hsl(var(--surface))] p-2">
+                      {pushLogs.length === 0 ? (
+                        <p className="text-xs text-muted-foreground">
+                          Esperando eventos auditables del dispatcher...
+                        </p>
+                      ) : (
+                        <ul className="space-y-1 text-xs text-card-foreground">
+                          {pushLogs
+                            .slice()
+                            .reverse()
+                            .map((log, index) => (
+                              <li key={`${log}-${index}`}>{log}</li>
+                            ))}
+                        </ul>
+                      )}
+                    </ScrollArea>
+                  </div>
+                </CardContent>
+              </Card>
+            </div>
+            <div className="h-full animate-in fade-in-50" style={{ animationDelay: "160ms" }}>
+              <Card className="surface-card h-full">
+                <CardHeader className="space-y-1 pb-4">
+                  <CardTitle className="flex items-center gap-2 text-lg font-sans font-medium tracking-tight">
+                    <Activity className="h-5 w-5 text-primary" /> Estado de la sesión
+                  </CardTitle>
+                  <CardDescription>
+                    Mantén el pulso de la conexión en vivo y los últimos eventos del mercado.
+                  </CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-3 text-sm">
+                  <div className="flex items-center gap-2 text-xs font-medium">
+                    <span className={realtimeConnected ? "text-success" : "text-destructive"}>
+                      {realtimeConnected ? "Conectado a Realtime" : "Conexión inactiva"}
+                    </span>
+                    {realtimeHighlight && (
+                      <span className="text-muted-foreground">•</span>
+                    )}
+                    {realtimeHighlight && (
+                      <span className="text-card-foreground">{realtimeHighlight}</span>
+                    )}
+                  </div>
+                  {realtimeData && (
+                    <pre className="max-h-40 overflow-auto rounded-xl border border-border/50 bg-[hsl(var(--surface))] p-3 text-xs text-muted-foreground">
+                      {JSON.stringify(realtimeData, null, 2)}
+                    </pre>
+                  )}
+                </CardContent>
+              </Card>
+            </div>
+          </section>
         </div>
         <section
-          className="grid flex-1 gap-6 lg:grid-cols-2 xl:grid-cols-[2fr_1fr]"
+          className="grid flex-1 gap-4 lg:grid-cols-2 xl:grid-cols-[2fr_1fr]"
           data-testid="dashboard-modules"
         >
-          <div className="grid auto-rows-min gap-6">
-            <PortfolioPanel token={token ?? undefined} />
+          <div className="grid auto-rows-min gap-4">
+            <div className="h-full animate-in fade-in-50" style={{ animationDelay: "80ms" }}>
+              <PortfolioPanel token={token ?? undefined} />
+            </div>
             {/* [Codex] nuevo - tarjeta de indicadores con insights AI */}
-            <Card className="flex flex-col" data-testid="dashboard-indicators">
-              <CardHeader className="flex items-center justify-between space-y-0 pb-2">
-                <CardTitle className="text-lg font-medium">
-                  Indicadores clave ({indicatorSymbol})
-                </CardTitle>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={handleRefreshIndicators}
-                  disabled={indicatorLoading || historicalLoading || historicalValidating}
-                >
-                  {indicatorLoading || historicalLoading || historicalValidating
-                    ? "Actualizando..."
-                    : "Actualizar"}
-                </Button>
-              </CardHeader>
-              <CardContent className="pt-4">
-                {indicatorError && (
-                  <p className="text-sm text-destructive">{indicatorError}</p>
-                )}
-                {indicatorData && (
-                  <IndicatorsChart
-                    symbol={indicatorData.symbol}
-                    interval={indicatorData.interval}
-                    indicators={indicatorData.indicators}
-                    series={indicatorData.series}
-                    insights={indicatorInsights}
-                    loading={indicatorLoading}
-                    error={indicatorError}
-                    history={historicalData}
-                    historyError={historicalError?.message ?? null}
-                    historyLoading={historicalLoading || historicalValidating}
-                  />
-                )}
-                {!indicatorData && !indicatorError && (
-                  <p className="text-sm text-muted-foreground">
-                    {indicatorLoading
-                      ? "Cargando indicadores en tiempo real..."
-                      : "Aún no se han cargado indicadores."}
-                  </p>
-                )}
-              </CardContent>
-            </Card>
-            <Card className="flex flex-col" data-testid="dashboard-chat">
-              <CardHeader className="pb-2">
-                <CardTitle className="text-lg font-medium">Asistente estratégico</CardTitle>
-                <CardDescription>
-                  Conversa con el bot para contextualizar las señales del mercado.
-                </CardDescription>
-              </CardHeader>
-              <CardContent className="flex h-full flex-col gap-4">
-                <ChatPanel token={token ?? undefined} />
-              </CardContent>
-            </Card>
+            <div className="h-full animate-in fade-in-50" style={{ animationDelay: "120ms" }}>
+              <Card className="surface-card flex flex-col" data-testid="dashboard-indicators">
+                <CardHeader className="flex flex-wrap items-center justify-between gap-3 pb-4">
+                  <CardTitle className="flex items-center gap-2 text-lg font-sans font-medium tracking-tight">
+                    <SignalHigh className="h-5 w-5 text-primary" /> Indicadores clave ({indicatorSymbol})
+                  </CardTitle>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={handleRefreshIndicators}
+                    disabled={indicatorLoading || historicalLoading || historicalValidating}
+                    className="flex items-center gap-2"
+                  >
+                    <LineChart className="h-4 w-4" />
+                    {indicatorLoading || historicalLoading || historicalValidating
+                      ? "Actualizando..."
+                      : "Actualizar"}
+                  </Button>
+                </CardHeader>
+                <CardContent className="pt-0">
+                  {indicatorError && (
+                    <p className="text-sm text-destructive">{indicatorError}</p>
+                  )}
+                  {indicatorData && (
+                    <IndicatorsChart
+                      symbol={indicatorData.symbol}
+                      interval={indicatorData.interval}
+                      indicators={indicatorData.indicators}
+                      series={indicatorData.series}
+                      insights={indicatorInsights}
+                      loading={indicatorLoading}
+                      error={indicatorError}
+                      history={historicalData}
+                      historyError={historicalError?.message ?? null}
+                      historyLoading={historicalLoading || historicalValidating}
+                    />
+                  )}
+                  {!indicatorData && !indicatorError && (
+                    <p className="text-sm text-muted-foreground">
+                      {indicatorLoading
+                        ? "Cargando indicadores en tiempo real..."
+                        : "Aún no se han cargado indicadores."}
+                    </p>
+                  )}
+                </CardContent>
+              </Card>
+            </div>
+            <div className="h-full animate-in fade-in-50" style={{ animationDelay: "160ms" }}>
+              <Card className="surface-card flex flex-col" data-testid="dashboard-chat">
+                <CardHeader className="pb-4">
+                  <CardTitle className="flex items-center gap-2 text-lg font-sans font-medium tracking-tight">
+                    <Bot className="h-5 w-5 text-primary" /> Asistente estratégico
+                  </CardTitle>
+                  <CardDescription>
+                    Conversa con el bot para contextualizar las señales del mercado.
+                  </CardDescription>
+                </CardHeader>
+                <CardContent className="flex h-full flex-col gap-4">
+                  <ChatPanel token={token ?? undefined} />
+                </CardContent>
+              </Card>
+            </div>
           </div>
-          <div className="grid auto-rows-min gap-6">
-            <AlertsPanel token={token ?? undefined} />
-            <NewsPanel token={token ?? undefined} />
+          <div className="grid auto-rows-min gap-4">
+            <div className="h-full animate-in fade-in-50" style={{ animationDelay: "80ms" }}>
+              <AlertsPanel token={token ?? undefined} />
+            </div>
+            <div className="h-full animate-in fade-in-50" style={{ animationDelay: "120ms" }}>
+              <NewsPanel token={token ?? undefined} />
+            </div>
           </div>
         </section>
       </main>

--- a/frontend/src/components/dashboard/notification-center-card.tsx
+++ b/frontend/src/components/dashboard/notification-center-card.tsx
@@ -2,9 +2,12 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { BellRing, Beaker, History, Inbox, Trash2 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { ScrollArea } from "@/components/ui/scroll-area";
 import { usePushNotifications } from "@/hooks/usePushNotifications";
 // 🧩 Bloque 9B
 import { useLiveNotifications } from "@/hooks/useLiveNotifications";
@@ -142,57 +145,110 @@ export default function NotificationCenterCard() {
     });
   }, [events]);
 
+  const isRealtime = status === "connected";
+
   return (
-    <Card className="p-4 shadow-md rounded-2xl">
-      <CardHeader>
-        <CardTitle className="text-lg font-semibold">Centro de Notificaciones</CardTitle>
+    <Card className="surface-card">
+      <CardHeader className="space-y-3 pb-4">
+        <div className="flex flex-col gap-2">
+          <CardTitle className="flex items-center gap-2 text-lg font-sans font-medium tracking-tight">
+            <BellRing className="h-5 w-5 text-primary" />
+            Notificaciones en vivo
+          </CardTitle>
+          <CardDescription className="text-sm text-muted-foreground">
+            Gestiona la suscripción push y consulta el historial consolidado de eventos.
+          </CardDescription>
+        </div>
+        <Badge
+          variant={isRealtime ? "outline" : "secondary"}
+          className="w-fit rounded-full px-3 py-1 text-xs font-medium"
+        >
+          {isRealtime ? "Canal en tiempo real" : "Canal en modo seguro"}
+        </Badge>
       </CardHeader>
       <CardContent className="space-y-4">
-        <div className="flex gap-2">
-          <Button onClick={() => void requestPermission()}>🔔 Activar Push</Button>
-          <Button onClick={() => void sendTestNotification()} variant="secondary">
-            🧪 Enviar Test
+        <div className="grid gap-2 md:grid-cols-3">
+          <Button
+            type="button"
+            variant="secondary"
+            className="flex items-center justify-center gap-2"
+            onClick={() => void requestPermission()}
+          >
+            <BellRing className="h-4 w-4" />
+            Activar push
           </Button>
           <Button
+            type="button"
+            variant="outline"
+            className="flex items-center justify-center gap-2"
+            onClick={() => void sendTestNotification()}
+          >
+            <Beaker className="h-4 w-4" />
+            Enviar prueba
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            className="flex items-center justify-center gap-2"
             onClick={() => {
               clearLogs();
               setHistory([]);
             }}
-            variant="destructive"
           >
-            🧹 Limpiar
+            <Trash2 className="h-4 w-4" />
+            Limpiar
           </Button>
         </div>
 
-        <div className="max-h-64 overflow-y-auto border rounded-lg p-2 bg-muted/40">
-          {history.length === 0 ? (
-            <p className="text-sm text-muted-foreground">Sin notificaciones aún.</p>
-          ) : (
-            history
-              .slice()
-              .reverse()
-              .map((n) => (
-                <div key={n.id} className="border-b last:border-0 py-1 text-sm leading-tight">
-                  <span className="font-semibold">{n.title}</span> — {n.body}{" "}
-                  <span className="text-xs text-muted-foreground">
-                    ({new Date(n.timestamp).toLocaleTimeString()})
-                  </span>
-                </div>
-              ))
-          )}
+        <div className="space-y-2 rounded-xl border border-border/50 bg-[hsl(var(--surface))] p-3">
+          <div className="flex items-center justify-between">
+            <p className="flex items-center gap-2 text-sm font-medium text-card-foreground">
+              <History className="h-4 w-4 text-primary" /> Historial reciente
+            </p>
+            <span className="text-xs text-muted-foreground">{history.length} eventos</span>
+          </div>
+          <ScrollArea className="max-h-56">
+            <div className="space-y-2 pr-2">
+              {history.length === 0 ? (
+                <p className="text-sm text-muted-foreground">Sin notificaciones aún.</p>
+              ) : (
+                history
+                  .slice()
+                  .reverse()
+                  .map((n) => (
+                    <div
+                      key={n.id}
+                      className="rounded-lg border border-border/40 bg-[hsl(var(--surface-muted))] p-3 text-sm text-card-foreground"
+                    >
+                      <div className="flex items-center justify-between gap-3">
+                        <p className="font-medium">{n.title}</p>
+                        <span className="text-xs text-muted-foreground">
+                          {new Date(n.timestamp).toLocaleTimeString()}
+                        </span>
+                      </div>
+                      {n.body && (
+                        <p className="mt-1 text-xs text-muted-foreground leading-relaxed">{n.body}</p>
+                      )}
+                    </div>
+                  ))
+              )}
+            </div>
+          </ScrollArea>
         </div>
 
-        <p className="text-xs text-muted-foreground">
-          Estado: <strong>{permission}</strong>
-        </p>
-        <p className="text-xs text-muted-foreground">
-          Estado:{" "}
-          <strong>
-            {status === "connected"
-              ? "🟢 Conectado (Tiempo real)"
-              : "🟡 Fallback (Polling)"}
-          </strong>
-        </p>
+        <div className="grid gap-2 rounded-xl border border-border/40 bg-[hsl(var(--surface))] p-3 text-xs text-muted-foreground">
+          <div className="flex items-center justify-between gap-2">
+            <span className="flex items-center gap-2 font-medium text-card-foreground">
+              <Inbox className="h-4 w-4 text-primary" /> Estado de permisos
+            </span>
+            <Badge variant="outline" className="rounded-full px-2 py-0.5 text-[10px] uppercase">
+              {permission}
+            </Badge>
+          </div>
+          <p>
+            Canal actual: <span className="font-medium text-card-foreground">{isRealtime ? "Tiempo real" : "Fallback"}</span>
+          </p>
+        </div>
       </CardContent>
     </Card>
   );

--- a/frontend/src/components/indicators/IndicatorsChart.tsx
+++ b/frontend/src/components/indicators/IndicatorsChart.tsx
@@ -16,7 +16,30 @@ import {
   YAxis,
 } from "recharts";
 
+import { Sparkles } from "lucide-react";
+
 import type { HistoricalDataResponse } from "@/lib/api";
+
+const chartPalette = {
+  price: "hsl(var(--card-foreground))",
+  emaFast: "hsl(var(--primary))",
+  emaSlow: "hsl(var(--info))",
+  bollingerUpper: "hsl(var(--info))",
+  bollingerLower: "hsl(var(--success))",
+  bollingerMiddle: "hsl(var(--muted-foreground))",
+  vwap: "hsl(var(--warning))",
+  rsi: "hsl(var(--warning))",
+  rsiLower: "hsl(var(--destructive))",
+  rsiUpper: "hsl(var(--success))",
+  atr: "hsl(var(--info))",
+  ichimokuTenkan: "hsl(var(--warning))",
+  ichimokuKijun: "hsl(var(--primary))",
+  ichimokuSpanA: "hsl(var(--accent-foreground))",
+  ichimokuSpanB: "hsl(var(--success))",
+  macd: "hsl(var(--info))",
+  macdSignal: "hsl(var(--destructive))",
+  macdHistogram: "hsl(var(--success))",
+};
 
 interface IndicatorsChartProps {
   symbol: string;
@@ -341,7 +364,7 @@ export function IndicatorsChart({
     typeof window.SVGStopElement !== "undefined";
   const atrFill = supportsSvgGradients
     ? "url(#atrGradient)"
-    : "rgba(56, 189, 248, 0.24)";
+    : "hsl(var(--info) / 0.24)";
 
   const emaFast = computeEMA(closes, emaFastPeriod);
   const emaSlow = computeEMA(closes, emaSlowPeriod);
@@ -418,8 +441,8 @@ export function IndicatorsChart({
   return (
     <div className="grid gap-6 xl:grid-cols-[2fr_1fr]" data-testid="technical-analysis">
       <div className="space-y-6">
-        <header className="space-y-1">
-          <h2 className="text-xl font-semibold">
+        <header className="space-y-2">
+          <h2 className="text-xl font-sans font-semibold tracking-tight text-card-foreground">
             {symbol} · {interval.toUpperCase()}
           </h2>
           <p className="text-sm text-muted-foreground">
@@ -436,8 +459,10 @@ export function IndicatorsChart({
         </header>
 
         <section className="space-y-4">
-          <div className="rounded-lg border bg-card p-4">
-            <h3 className="text-sm font-medium">Precio, EMAs y Bandas de Bollinger</h3>
+          <div className="rounded-2xl border border-border/40 bg-[hsl(var(--surface))] p-4 transition-all duration-300 hover:border-border hover:bg-[hsl(var(--surface-hover))]">
+            <h3 className="text-sm font-sans font-medium tracking-tight text-card-foreground">
+              Precio, EMAs y Bandas de Bollinger
+            </h3>
             <div className="mt-3 h-72 w-full">
               {historyLoading && !priceChartData.length ? (
                 <p className="text-sm text-muted-foreground">Cargando serie histórica...</p>
@@ -451,14 +476,14 @@ export function IndicatorsChart({
                       labelFormatter={(value) => priceChartData[value as number]?.label ?? String(value)}
                     />
                     <Legend />
-                    <Line type="monotone" dataKey="close" stroke="#0f172a" dot={false} name="Precio" strokeWidth={1.5} />
-                    <Line type="monotone" dataKey="emaFast" stroke="#ec4899" dot={false} name={`EMA ${emaFastPeriod}`} strokeWidth={1.2} />
-                    <Line type="monotone" dataKey="emaSlow" stroke="#6366f1" dot={false} name={`EMA ${emaSlowPeriod}`} strokeWidth={1.2} />
-                    <Line type="monotone" dataKey="bollingerUpper" stroke="#38bdf8" dot={false} name="Bollinger Sup" strokeDasharray="5 5" />
-                    <Line type="monotone" dataKey="bollingerLower" stroke="#22c55e" dot={false} name="Bollinger Inf" strokeDasharray="5 5" />
-                    <Line type="monotone" dataKey="bollingerMiddle" stroke="#94a3b8" dot={false} name="Bollinger Media" strokeDasharray="3 3" />
+                    <Line type="monotone" dataKey="close" stroke={chartPalette.price} dot={false} name="Precio" strokeWidth={1.5} />
+                    <Line type="monotone" dataKey="emaFast" stroke={chartPalette.emaFast} dot={false} name={`EMA ${emaFastPeriod}`} strokeWidth={1.2} />
+                    <Line type="monotone" dataKey="emaSlow" stroke={chartPalette.emaSlow} dot={false} name={`EMA ${emaSlowPeriod}`} strokeWidth={1.2} />
+                    <Line type="monotone" dataKey="bollingerUpper" stroke={chartPalette.bollingerUpper} dot={false} name="Bollinger Sup" strokeDasharray="5 5" />
+                    <Line type="monotone" dataKey="bollingerLower" stroke={chartPalette.bollingerLower} dot={false} name="Bollinger Inf" strokeDasharray="5 5" />
+                    <Line type="monotone" dataKey="bollingerMiddle" stroke={chartPalette.bollingerMiddle} dot={false} name="Bollinger Media" strokeDasharray="3 3" />
                     {showVWAP && (
-                      <Line type="monotone" dataKey="vwap" stroke="#f97316" dot={false} name="VWAP" strokeWidth={1.5} />
+                      <Line type="monotone" dataKey="vwap" stroke={chartPalette.vwap} dot={false} name="VWAP" strokeWidth={1.5} />
                     )}
                   </LineChart>
                 </ResponsiveContainer>
@@ -467,8 +492,10 @@ export function IndicatorsChart({
           </div>
 
           <div className="grid gap-4 lg:grid-cols-2">
-            <div className="rounded-lg border bg-card p-4">
-              <h3 className="text-sm font-medium">Índice de Fuerza Relativa (RSI)</h3>
+            <div className="rounded-2xl border border-border/40 bg-[hsl(var(--surface))] p-4 transition-all duration-300 hover:border-border hover:bg-[hsl(var(--surface-hover))]">
+              <h3 className="text-sm font-sans font-medium tracking-tight text-card-foreground">
+                Índice de Fuerza Relativa (RSI)
+              </h3>
               <div className="mt-3 h-56 w-full">
                 {showRSI ? (
                   <ResponsiveContainer>
@@ -478,9 +505,9 @@ export function IndicatorsChart({
                       <YAxis domain={[0, 100]} width={50} />
                       <Tooltip labelFormatter={(value) => rsiChartData[value as number]?.label ?? String(value)} />
                       <Legend />
-                      <ReferenceLine y={30} stroke="#ef4444" strokeDasharray="4 4" />
-                      <ReferenceLine y={70} stroke="#22c55e" strokeDasharray="4 4" />
-                      <Line type="monotone" dataKey="value" stroke="#f59e0b" dot={false} name={`RSI ${rsiPeriod}`} strokeWidth={1.5} />
+                      <ReferenceLine y={30} stroke={chartPalette.rsiLower} strokeDasharray="4 4" />
+                      <ReferenceLine y={70} stroke={chartPalette.rsiUpper} strokeDasharray="4 4" />
+                      <Line type="monotone" dataKey="value" stroke={chartPalette.rsi} dot={false} name={`RSI ${rsiPeriod}`} strokeWidth={1.5} />
                     </LineChart>
                   </ResponsiveContainer>
                 ) : (
@@ -489,8 +516,10 @@ export function IndicatorsChart({
               </div>
             </div>
 
-            <div className="rounded-lg border bg-card p-4">
-              <h3 className="text-sm font-medium">Average True Range (ATR)</h3>
+            <div className="rounded-2xl border border-border/40 bg-[hsl(var(--surface))] p-4 transition-all duration-300 hover:border-border hover:bg-[hsl(var(--surface-hover))]">
+              <h3 className="text-sm font-sans font-medium tracking-tight text-card-foreground">
+                Average True Range (ATR)
+              </h3>
               <div className="mt-3 h-56 w-full">
                 {showATR ? (
                   <ResponsiveContainer>
@@ -498,8 +527,8 @@ export function IndicatorsChart({
                       {supportsSvgGradients && (
                         <defs>
                           <linearGradient id="atrGradient" x1="0" y1="0" x2="0" y2="1">
-                            <stop offset="5%" stopColor="#38bdf8" stopOpacity={0.3} />
-                            <stop offset="95%" stopColor="#38bdf8" stopOpacity={0} />
+                            <stop offset="5%" stopColor={chartPalette.atr} stopOpacity={0.28} />
+                            <stop offset="95%" stopColor={chartPalette.atr} stopOpacity={0} />
                           </linearGradient>
                         </defs>
                       )}
@@ -511,7 +540,7 @@ export function IndicatorsChart({
                       <Area
                         type="monotone"
                         dataKey="value"
-                        stroke="#38bdf8"
+                        stroke={chartPalette.atr}
                         fillOpacity={supportsSvgGradients ? 1 : 0.32}
                         fill={atrFill}
                         name={`ATR ${atrPeriod}`}
@@ -526,8 +555,8 @@ export function IndicatorsChart({
           </div>
 
           <div className="grid gap-4 lg:grid-cols-2">
-            <div className="rounded-lg border bg-card p-4">
-              <h3 className="text-sm font-medium">Ichimoku</h3>
+            <div className="rounded-2xl border border-border/40 bg-[hsl(var(--surface))] p-4 transition-all duration-300 hover:border-border hover:bg-[hsl(var(--surface-hover))]">
+              <h3 className="text-sm font-sans font-medium tracking-tight text-card-foreground">Ichimoku</h3>
               <div className="mt-3 h-56 w-full">
                 {showIchimoku && ichimokuSeries ? (
                   <ResponsiveContainer>
@@ -537,10 +566,10 @@ export function IndicatorsChart({
                       <YAxis width={60} />
                       <Tooltip labelFormatter={(value) => ichimokuChartData[value as number]?.label ?? String(value)} />
                       <Legend />
-                      <Line type="monotone" dataKey="tenkan" stroke="#f97316" dot={false} name="Tenkan" />
-                      <Line type="monotone" dataKey="kijun" stroke="#22d3ee" dot={false} name="Kijun" />
-                      <Line type="monotone" dataKey="spanA" stroke="#6366f1" dot={false} name="Span A" strokeDasharray="5 5" />
-                      <Line type="monotone" dataKey="spanB" stroke="#10b981" dot={false} name="Span B" strokeDasharray="5 5" />
+                      <Line type="monotone" dataKey="tenkan" stroke={chartPalette.ichimokuTenkan} dot={false} name="Tenkan" />
+                      <Line type="monotone" dataKey="kijun" stroke={chartPalette.ichimokuKijun} dot={false} name="Kijun" />
+                      <Line type="monotone" dataKey="spanA" stroke={chartPalette.ichimokuSpanA} dot={false} name="Span A" strokeDasharray="5 5" />
+                      <Line type="monotone" dataKey="spanB" stroke={chartPalette.ichimokuSpanB} dot={false} name="Span B" strokeDasharray="5 5" />
                     </LineChart>
                   </ResponsiveContainer>
                 ) : (
@@ -549,8 +578,8 @@ export function IndicatorsChart({
               </div>
             </div>
 
-            <div className="rounded-lg border bg-card p-4">
-              <h3 className="text-sm font-medium">MACD</h3>
+            <div className="rounded-2xl border border-border/40 bg-[hsl(var(--surface))] p-4 transition-all duration-300 hover:border-border hover:bg-[hsl(var(--surface-hover))]">
+              <h3 className="text-sm font-sans font-medium tracking-tight text-card-foreground">MACD</h3>
               <div className="mt-3 h-56 w-full">
                 <ResponsiveContainer>
                   <ComposedChart data={macdChartData} margin={{ left: 12, right: 12, top: 16, bottom: 8 }}>
@@ -559,9 +588,9 @@ export function IndicatorsChart({
                     <YAxis width={60} />
                     <Tooltip labelFormatter={(value) => macdChartData[value as number]?.label ?? String(value)} />
                     <Legend />
-                    <Line type="monotone" dataKey="macd" stroke="#0ea5e9" dot={false} name="MACD" />
-                    <Line type="monotone" dataKey="signal" stroke="#ef4444" dot={false} name="Signal" />
-                    <Bar dataKey="histogram" fill="#22c55e" name="Histograma" />
+                    <Line type="monotone" dataKey="macd" stroke={chartPalette.macd} dot={false} name="MACD" />
+                    <Line type="monotone" dataKey="signal" stroke={chartPalette.macdSignal} dot={false} name="Signal" />
+                    <Bar dataKey="histogram" fill={chartPalette.macdHistogram} name="Histograma" />
                   </ComposedChart>
                 </ResponsiveContainer>
               </div>
@@ -570,8 +599,10 @@ export function IndicatorsChart({
         </section>
       </div>
 
-      <aside className="flex flex-col gap-4 rounded-lg border bg-muted/20 p-4" data-testid="analysis-insights">
-        <h3 className="text-lg font-semibold">🧠 Insights del asistente</h3>
+      <aside className="surface-card flex flex-col gap-4 p-4" data-testid="analysis-insights">
+        <h3 className="flex items-center gap-2 text-lg font-sans font-medium tracking-tight text-card-foreground">
+          <Sparkles className="h-5 w-5 text-primary" /> Insights del asistente
+        </h3>
         {loading && <p className="text-sm text-muted-foreground">Analizando indicadores...</p>}
         {error && <p className="text-sm text-destructive">{error}</p>}
         {!loading && !error && insightBlocks.length === 0 && (
@@ -579,7 +610,10 @@ export function IndicatorsChart({
         )}
         <ul className="space-y-2 text-sm">
           {insightBlocks.map((line, idx) => (
-            <li key={idx} className="rounded-md bg-background p-2 shadow-sm">
+            <li
+              key={idx}
+              className="rounded-xl border border-border/40 bg-[hsl(var(--surface))] p-3 text-card-foreground shadow-sm"
+            >
               {line}
             </li>
           ))}

--- a/frontend/src/components/news/news-panel.tsx
+++ b/frontend/src/components/news/news-panel.tsx
@@ -8,7 +8,7 @@ import { listNews, NewsItem } from "@/lib/api";
 import { ErrorBoundary } from "@/components/common/ErrorBoundary";
 import { EmptyState } from "@/components/common/EmptyState";
 import { Skeleton } from "@/components/common/Skeleton";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 
 interface NewsPanelProps {
@@ -30,19 +30,23 @@ function NewsPanelContent({ token }: NewsPanelProps) {
     });
 
   return (
-    <Card className="flex flex-col">
-      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-3">
-        <CardTitle className="text-lg font-medium">Noticias</CardTitle>
-        <Badge variant="secondary" className="flex items-center gap-1">
-          <Newspaper className="h-3.5 w-3.5" />
-          Últimas
-        </Badge>
+    <Card className="surface-card flex flex-col">
+      <CardHeader className="space-y-2 pb-4">
+        <div className="flex items-center justify-between gap-3">
+          <CardTitle className="flex items-center gap-2 text-lg font-sans font-medium tracking-tight">
+            <Newspaper className="h-5 w-5 text-primary" /> Noticias
+          </CardTitle>
+          <Badge variant="outline" className="flex items-center gap-2 rounded-full px-3 py-1 text-xs font-medium">
+            <Newspaper className="h-3.5 w-3.5" /> Últimas
+          </Badge>
+        </div>
+        <CardDescription>Descubre las señales más relevantes del mercado en tiempo real.</CardDescription>
       </CardHeader>
       <CardContent className="space-y-3">
         {isLoading && (
           <div className="space-y-2" data-testid="news-loading">
             {[0, 1, 2].map((index) => (
-              <div key={index} className="space-y-2 rounded-lg border p-3">
+              <div key={index} className="space-y-2 rounded-xl border border-border/40 bg-[hsl(var(--surface))] p-3">
                 <Skeleton className="h-4 w-3/4" />
                 <Skeleton className="h-3 w-full" />
                 <Skeleton className="h-3 w-1/2" />
@@ -65,9 +69,12 @@ function NewsPanelContent({ token }: NewsPanelProps) {
           />
         )}
         {sortedNews?.slice(0, 6).map((item) => (
-          <article key={item.id} className="space-y-1 rounded-lg border p-3">
-            <h3 className="text-sm font-semibold">{item.title}</h3>
-            {item.summary && <p className="text-xs text-muted-foreground">{item.summary}</p>}
+          <article
+            key={item.id}
+            className="space-y-2 rounded-2xl border border-border/40 bg-[hsl(var(--surface))] p-4 transition-all duration-300 hover:border-border hover:bg-[hsl(var(--surface-hover))]"
+          >
+            <h3 className="text-sm font-medium text-card-foreground">{item.title}</h3>
+            {item.summary && <p className="text-xs text-muted-foreground leading-relaxed">{item.summary}</p>}
             <div className="flex items-center justify-between text-xs text-muted-foreground">
               <span>{item.source ?? "Fuente desconocida"}</span>
               {item.published_at && (
@@ -78,7 +85,7 @@ function NewsPanelContent({ token }: NewsPanelProps) {
               href={item.url}
               target="_blank"
               rel="noreferrer"
-              className="text-xs font-medium text-primary hover:underline"
+              className="inline-flex items-center gap-1 text-xs font-medium text-primary transition-colors hover:text-primary/80"
             >
               Leer noticia
             </Link>
@@ -91,12 +98,14 @@ function NewsPanelContent({ token }: NewsPanelProps) {
 
 function NewsPanelFallback() {
   return (
-    <Card className="flex flex-col">
-      <CardHeader className="space-y-1">
-        <CardTitle className="text-lg font-medium">Noticias</CardTitle>
-        <p className="text-sm text-muted-foreground">
+    <Card className="surface-card flex flex-col">
+      <CardHeader className="space-y-2">
+        <CardTitle className="flex items-center gap-2 text-lg font-sans font-medium tracking-tight">
+          <Newspaper className="h-5 w-5 text-primary" /> Noticias
+        </CardTitle>
+        <CardDescription>
           No se pudo cargar esta sección. Intenta nuevamente en unos instantes.
-        </p>
+        </CardDescription>
       </CardHeader>
       <CardContent>
         <EmptyState

--- a/frontend/src/components/portfolio/PortfolioPanel.tsx
+++ b/frontend/src/components/portfolio/PortfolioPanel.tsx
@@ -2,7 +2,7 @@
 
 import { type ChangeEvent, useCallback, useMemo, useRef, useState } from "react";
 import useSWR from "swr";
-import { PlusCircle, Trash2 } from "lucide-react";
+import { BriefcaseBusiness, PlusCircle, Trash2 } from "lucide-react";
 
 import {
   PortfolioItem,
@@ -212,22 +212,26 @@ function PortfolioPanelContent({ token }: PortfolioPanelProps) {
   }, []);
 
   return (
-    <Card className="flex flex-col">
-      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-3">
-        <div>
-          <CardTitle className="text-lg font-medium">Portafolio</CardTitle>
-          <p className="text-sm text-muted-foreground">
-            Administra tus posiciones y consulta su valoración estimada.
-          </p>
+    <Card className="surface-card flex flex-col">
+      <CardHeader className="flex flex-col gap-3 pb-4">
+        <div className="flex items-center justify-between gap-3">
+          <CardTitle className="flex items-center gap-2 text-lg font-sans font-medium tracking-tight">
+            <BriefcaseBusiness className="h-5 w-5 text-primary" /> Mi portafolio
+          </CardTitle>
+          <Badge variant="outline" className="rounded-full px-3 py-1 text-xs font-medium">
+            Total: {formattedTotal}
+          </Badge>
         </div>
-        <Badge variant="secondary">Total: {formattedTotal}</Badge>
+        <p className="text-sm text-muted-foreground">
+          Administra tus posiciones y consulta su valoración estimada.
+        </p>
       </CardHeader>
       <CardContent className="space-y-4">
         {csvEnabled && (
-          <div className="space-y-3 rounded-lg border border-dashed p-3">
-            <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+          <div className="space-y-3 rounded-2xl border border-dashed border-border/50 bg-[hsl(var(--surface))] p-4">
+            <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
               <div className="space-y-1">
-                <p className="text-sm font-medium">Importar / exportar cartera</p>
+                <p className="text-sm font-medium text-card-foreground">Importar / exportar cartera</p>
                 <p className="text-xs text-muted-foreground">
                   Trabaja con archivos CSV usando las columnas <code>symbol</code> y <code>amount</code>.
                 </p>
@@ -264,10 +268,10 @@ function PortfolioPanelContent({ token }: PortfolioPanelProps) {
               <div
                 role="status"
                 className={cn(
-                  "rounded-md border p-3 text-sm",
+                  "rounded-xl border p-3 text-sm",
                   csvFeedback.variant === "error" && "border-destructive/40 text-destructive",
-                  csvFeedback.variant === "warning" && "border-yellow-500/50 text-yellow-600",
-                  csvFeedback.variant === "success" && "border-emerald-500/40 text-emerald-600"
+                  csvFeedback.variant === "warning" && "border-warning/40 text-warning",
+                  csvFeedback.variant === "success" && "border-success/40 text-success"
                 )}
               >
                 <p>{csvFeedback.message}</p>
@@ -340,17 +344,17 @@ function PortfolioPanelContent({ token }: PortfolioPanelProps) {
             return (
               <div
                 key={item.id}
-                className="flex flex-col gap-2 rounded-lg border p-3 md:flex-row md:items-center md:justify-between"
+                className="flex flex-col gap-3 rounded-2xl border border-border/40 bg-[hsl(var(--surface))] p-4 transition-all duration-300 hover:border-border hover:bg-[hsl(var(--surface-hover))] md:flex-row md:items-center md:justify-between"
               >
                 <div>
-                  <p className="font-medium">{item.symbol}</p>
+                  <p className="text-sm font-medium text-card-foreground">{item.symbol}</p>
                   <p className="text-xs text-muted-foreground">
                     Cantidad: {item.amount.toLocaleString("en-US")}
                   </p>
                   <p className="text-xs text-muted-foreground">Precio: {priceLabel}</p>
                 </div>
                 <div className="flex items-center gap-3">
-                  <p className="text-sm font-semibold">{valueLabel}</p>
+                  <p className="text-sm font-semibold text-card-foreground">{valueLabel}</p>
                   <Button
                     type="button"
                     variant="destructive"

--- a/frontend/src/components/providers/theme-provider.tsx
+++ b/frontend/src/components/providers/theme-provider.tsx
@@ -9,6 +9,9 @@ export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
       defaultTheme="system"
       attribute="class"
       enableSystem
+      enableColorScheme
+      disableTransitionOnChange
+      themes={props.themes ?? ["light", "dark"]}
       {...props}
     >
       {children}

--- a/frontend/src/components/sidebar/market-sidebar.tsx
+++ b/frontend/src/components/sidebar/market-sidebar.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import useSWR from "swr";
 import { useMemo } from "react";
-import { LineChart, Coins, Wallet } from "lucide-react";
+import { LineChart, Coins, Wallet, LogOut } from "lucide-react";
 
 import { MarketQuote, UserProfile, getMarketQuote } from "@/lib/api";
 import { Card, CardContent } from "@/components/ui/card";
@@ -83,13 +83,13 @@ export function MarketSidebar({ token, user, onLogout }: MarketSidebarProps) {
 
   return (
     <div className="flex h-full flex-col gap-4 p-4" data-testid="market-sidebar-root">
-      <Card className="border-none bg-transparent shadow-none">
-        <CardContent className="space-y-3 p-0">
+      <Card className="surface-card">
+        <CardContent className="space-y-4">
           <div>
-            <h2 className="text-xl font-semibold">BullBearBroker</h2>
+            <h2 className="text-xl font-sans font-semibold tracking-tight text-card-foreground">BullBearBroker</h2>
             <p className="text-sm text-muted-foreground">{user.email}</p>
           </div>
-          <Button variant="secondary" size="sm" className="w-full" asChild>
+          <Button variant="outline" size="sm" className="w-full" asChild>
             <Link href="/portfolio" className="flex items-center justify-center gap-2">
               <Wallet className="h-4 w-4" />
               <span>Ver portafolio</span>
@@ -105,7 +105,8 @@ export function MarketSidebar({ token, user, onLogout }: MarketSidebarProps) {
         </div>
       </ScrollArea>
       <Separator />
-      <Button variant="outline" onClick={onLogout}>
+      <Button variant="outline" onClick={onLogout} className="flex items-center justify-center gap-2">
+        <LogOut className="h-4 w-4" />
         Cerrar sesión
       </Button>
     </div>
@@ -123,14 +124,16 @@ function MarketSection({ label, items, token }: MarketSectionProps) {
   const Icon = icons[type];
 
   return (
-    <Card>
+    <Card className="surface-card">
       <CardContent className="space-y-3 pt-4">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">
             <Icon className="h-4 w-4 text-primary" />
-            <h3 className="font-medium">{label}</h3>
+            <h3 className="text-sm font-medium text-card-foreground">{label}</h3>
           </div>
-          <Badge variant="secondary">Tiempo real</Badge>
+          <Badge variant="outline" className="rounded-full px-3 py-1 text-[10px] font-medium uppercase tracking-wide">
+            Tiempo real
+          </Badge>
         </div>
         <div className="space-y-2">
           {items.map((item) => (
@@ -168,17 +171,18 @@ function MarketRow({ config, token }: MarketRowProps) {
 
   const change = typeof data?.raw_change === "number" ? data.raw_change : null;
   const changeText = change !== null ? `${change > 0 ? "+" : ""}${change.toFixed(2)}%` : "--";
-  const changeClass = change === null ? "text-muted-foreground" : change >= 0 ? "text-emerald-500" : "text-red-500";
+  const changeClass =
+    change === null ? "text-muted-foreground" : change >= 0 ? "text-success" : "text-destructive";
 
   return (
-    <div className="flex flex-col gap-2 rounded-md bg-muted/40 p-2">
+    <div className="flex flex-col gap-2 rounded-2xl border border-border/40 bg-[hsl(var(--surface))] p-3 transition-all duration-300 hover:border-border hover:bg-[hsl(var(--surface-hover))]">
       <div className="flex items-center justify-between">
         <div>
-          <p className="text-sm font-semibold">{config.displaySymbol}</p>
+          <p className="text-sm font-semibold text-card-foreground">{config.displaySymbol}</p>
           <p className="text-xs text-muted-foreground">{config.label}</p>
         </div>
         <div className="text-right">
-          <p className="text-sm font-semibold">{priceText}</p>
+          <p className="text-sm font-semibold text-card-foreground">{priceText}</p>
           <p className={`text-xs ${changeClass}`}>{changeText}</p>
         </div>
       </div>
@@ -206,7 +210,12 @@ function Sparkline({ change, positive, loading }: SparklineProps) {
   const slope = clamped * 0.6;
   const mid = baseline - slope / 2;
   const end = baseline - slope;
-  const color = positive === undefined ? "currentColor" : positive ? "#10b981" : "#ef4444";
+  const color =
+    positive === undefined
+      ? "hsl(var(--muted-foreground))"
+      : positive
+      ? "hsl(var(--success))"
+      : "hsl(var(--destructive))";
 
   return (
     <svg viewBox="0 0 100 32" className="h-6 w-16">

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -15,6 +15,11 @@
   --card: 0 0% 100%;
   --card-foreground: 224 71.4% 4.1%;
 
+  --surface: 210 40% 98%;
+  --surface-foreground: 224 71.4% 4.1%;
+  --surface-muted: 210 30% 96%;
+  --surface-hover: 210 20% 93%;
+
   --border: 220 13% 91%;
   --input: 220 13% 91%;
 
@@ -30,9 +35,19 @@
   --destructive: 0 84.2% 60.2%;
   --destructive-foreground: 210 20% 98%;
 
+  --success: 142 71% 45%;
+  --success-foreground: 140 12% 15%;
+
+  --warning: 38 92% 50%;
+  --warning-foreground: 25 86% 15%;
+
+  --info: 213 94% 68%;
+  --info-foreground: 215 28% 19%;
+
   --ring: 262.1 83.3% 57.8%;
 
   --radius: 0.75rem;
+  --panel-gap: 1.5rem;
 }
 
 .dark {
@@ -45,8 +60,13 @@
   --popover: 222.2 84% 4.9%;
   --popover-foreground: 210 40% 98%;
 
-  --card: 222.2 84% 4.9%;
+  --card: 222.2 84% 6%;
   --card-foreground: 210 40% 98%;
+
+  --surface: 217.2 32.6% 12.5%;
+  --surface-foreground: 210 40% 96%;
+  --surface-muted: 217.2 22% 18%;
+  --surface-hover: 217.2 18% 24%;
 
   --border: 217.2 32.6% 17.5%;
   --input: 217.2 32.6% 17.5%;
@@ -63,7 +83,18 @@
   --destructive: 0 62.8% 30.6%;
   --destructive-foreground: 210 40% 98%;
 
+  --success: 142 70% 45%;
+  --success-foreground: 141 34% 15%;
+
+  --warning: 42 97% 55%;
+  --warning-foreground: 240 9% 8%;
+
+  --info: 214 95% 78%;
+  --info-foreground: 223 47% 14%;
+
   --ring: 263.4 70% 50.4%;
+
+  --panel-gap: 1.5rem;
 }
 
 body {
@@ -77,5 +108,30 @@ body {
 
   body {
     @apply bg-background text-foreground;
+  }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    @apply font-sans font-medium tracking-tight text-card-foreground;
+  }
+}
+
+@layer components {
+  .surface-card {
+    @apply rounded-2xl border border-border/50 bg-card text-card-foreground shadow-sm transition-all duration-300 hover:border-border hover:shadow-md;
+  }
+  .surface-subtle {
+    background-color: hsl(var(--surface-muted));
+  }
+  .surface-hoverable {
+    @apply transition-colors duration-300;
+    background: hsl(var(--surface));
+  }
+  .surface-hoverable:hover {
+    background: hsl(var(--surface-hover));
   }
 }

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -46,6 +46,27 @@ export default {
           DEFAULT: "hsl(var(--card))",
           foreground: "hsl(var(--card-foreground))",
         },
+        success: {
+          DEFAULT: "hsl(var(--success))",
+          foreground: "hsl(var(--success-foreground))",
+        },
+        warning: {
+          DEFAULT: "hsl(var(--warning))",
+          foreground: "hsl(var(--warning-foreground))",
+        },
+        info: {
+          DEFAULT: "hsl(var(--info))",
+          foreground: "hsl(var(--info-foreground))",
+        },
+        surface: {
+          DEFAULT: "hsl(var(--surface))",
+          foreground: "hsl(var(--surface-foreground))",
+          muted: "hsl(var(--surface-muted))",
+          hover: "hsl(var(--surface-hover))",
+        },
+      },
+      spacing: {
+        panel: "var(--panel-gap)",
       },
       borderRadius: {
         lg: "var(--radius)",


### PR DESCRIPTION
## Summary
- align the dashboard shell with consistent card surfaces, animated entry states, and refreshed notification management controls
- polish portfolio, news, and sidebar panels with unified typography, iconography, and hover feedback while improving indicator visuals and insights layout
- extend the theme tokens and Tailwind palette to cover surface, status, and spacing variables for cohesive light/dark treatments

## Testing
- `pnpm --dir frontend lint` *(fails: existing lint violations in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68e4639de9d8832194c135760b89dd1a