### PR TITLE
Improve VAPID key loading and push dispatcher integration

### DIFF
--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -1,21 +1,87 @@
 """Core configuration helpers for BullBearBroker backend."""
 
+from __future__ import annotations
+
+import json
+import logging
 import os
+from pathlib import Path
+from typing import Any
+
+
+LOGGER = logging.getLogger(__name__)
 
 
 class Settings:
     """Centralized access to environment-driven configuration values."""
 
-    APP_ENV: str = os.getenv("APP_ENV", "local")
-    VAPID_PUBLIC_KEY: str = os.getenv("VAPID_PUBLIC_KEY", "")
-    VAPID_PRIVATE_KEY: str = os.getenv("VAPID_PRIVATE_KEY", "")
+    def __init__(self) -> None:
+        self.APP_ENV: str = os.getenv("APP_ENV", "local")
+        self.VAPID_PUBLIC_KEY: str | None = os.getenv("VAPID_PUBLIC_KEY")
+        self.VAPID_PRIVATE_KEY: str | None = os.getenv("VAPID_PRIVATE_KEY")
+
+        if not self.VAPID_PUBLIC_KEY or not self.VAPID_PRIVATE_KEY:
+            self._load_vapid_keys_from_file()
+
+        if not self.VAPID_PUBLIC_KEY or not self.VAPID_PRIVATE_KEY:
+            LOGGER.warning("VAPID keys not found")
+
+    def _load_vapid_keys_from_file(self) -> None:
+        """Attempt to populate VAPID keys from a local JSON file."""
+
+        keys_path = os.getenv("VAPID_KEYS_PATH", "vapid_keys.json")
+        candidate_paths = self._candidate_paths(keys_path)
+
+        for path in candidate_paths:
+            try:
+                with path.open("r", encoding="utf-8") as file:
+                    payload: dict[str, Any] = json.load(file)
+            except FileNotFoundError:
+                continue
+            except (OSError, json.JSONDecodeError):
+                LOGGER.warning("Failed to read VAPID keys from %s", path, exc_info=True)
+                continue
+
+            self.VAPID_PUBLIC_KEY = payload.get("publicKey") or payload.get(
+                "public_key"
+            )
+            self.VAPID_PRIVATE_KEY = payload.get("privateKey") or payload.get(
+                "private_key"
+            )
+
+            if self.VAPID_PUBLIC_KEY and self.VAPID_PRIVATE_KEY:
+                return
+
+        # No valid keys found across candidates – keep existing values (likely ``None``).
+
+    def _candidate_paths(self, filename: str) -> list[Path]:
+        base_path = Path(filename)
+        if base_path.is_absolute():
+            return [base_path]
+
+        here = Path(__file__).resolve()
+        candidates = [
+            Path(filename),
+            here.parent / filename,
+            here.parents[1] / filename,
+            here.parents[2] / filename,
+        ]
+        # Ensure uniqueness while preserving order
+        seen: set[Path] = set()
+        ordered_candidates: list[Path] = []
+        for candidate in candidates:
+            try:
+                resolved = candidate.resolve()
+            except FileNotFoundError:
+                resolved = candidate
+            if resolved not in seen:
+                seen.add(resolved)
+                ordered_candidates.append(candidate)
+        return ordered_candidates
 
 
 settings = Settings()
 
 # Backwards compatibility for modules that import module-level constants.
-VAPID_PUBLIC_KEY = settings.VAPID_PUBLIC_KEY
-VAPID_PRIVATE_KEY = settings.VAPID_PRIVATE_KEY
-
-if settings.APP_ENV == "local" and not settings.VAPID_PUBLIC_KEY:
-    print("⚠️ Warning: VAPID_PUBLIC_KEY not set in environment.")
+VAPID_PUBLIC_KEY = settings.VAPID_PUBLIC_KEY or ""
+VAPID_PRIVATE_KEY = settings.VAPID_PRIVATE_KEY or ""

--- a/backend/scripts/send_test_notification.py
+++ b/backend/scripts/send_test_notification.py
@@ -1,12 +1,12 @@
 """Utility script to broadcast a test notification through the dispatcher."""
 
 import asyncio
-import uuid
-from datetime import UTC, datetime
 
-from backend.schemas.notifications import NotificationEvent
 from backend.services.audit_service import AuditService
-from backend.services.notification_dispatcher import NotificationDispatcher
+from backend.services.notification_dispatcher import (
+    NotificationDispatcher,
+    PushBroadcastChannel,
+)
 from backend.services.push_service import push_service
 from backend.services.realtime_service import RealtimeService
 
@@ -14,19 +14,18 @@ from backend.services.realtime_service import RealtimeService
 async def main() -> None:
     dispatcher = NotificationDispatcher(
         realtime_service=RealtimeService(),
-        push_service_channel=push_service,
+        push_service_channel=PushBroadcastChannel(push_service),
         audit_service=AuditService(),
     )
 
-    event = NotificationEvent(
-        id=uuid.uuid4(),
-        title="🚀 Notificación de prueba",
-        body=f"Emitida a las {datetime.now(UTC).isoformat()}",
-        meta={"type": "test"},
-    )
+    payload = {
+        "title": "🚀 Notificación de prueba",
+        "body": "Push activo",
+        "type": "test",
+    }
 
-    await dispatcher.broadcast_event("test", event.model_dump())
-    print("✅ Notificación de prueba enviada vía WebSocket y registrada en logs")
+    await dispatcher.broadcast_test(payload)
+    print("✅ Notificación enviada vía WebSocket y Push")
 
 
 if __name__ == "__main__":

--- a/backend/utils/config.py
+++ b/backend/utils/config.py
@@ -9,6 +9,8 @@ import redis.asyncio as redis
 from dotenv import load_dotenv
 from passlib.context import CryptContext
 
+from backend.core.config import settings as core_settings
+
 load_dotenv()
 
 LOGGER = logging.getLogger(__name__)
@@ -127,8 +129,12 @@ class Config:
     TELEGRAM_DEFAULT_CHAT_ID = _get_env("TELEGRAM_DEFAULT_CHAT_ID")
     DISCORD_BOT_TOKEN = _get_env("DISCORD_BOT_TOKEN")
     DISCORD_APPLICATION_ID = _get_env("DISCORD_APPLICATION_ID")
-    PUSH_VAPID_PUBLIC_KEY = _get_env("PUSH_VAPID_PUBLIC_KEY")
-    PUSH_VAPID_PRIVATE_KEY = _get_env("PUSH_VAPID_PRIVATE_KEY")
+    PUSH_VAPID_PUBLIC_KEY = _get_env("PUSH_VAPID_PUBLIC_KEY") or getattr(
+        core_settings, "VAPID_PUBLIC_KEY", None
+    )
+    PUSH_VAPID_PRIVATE_KEY = _get_env("PUSH_VAPID_PRIVATE_KEY") or getattr(
+        core_settings, "VAPID_PRIVATE_KEY", None
+    )
     PUSH_CONTACT_EMAIL = _get_env("PUSH_CONTACT_EMAIL", "support@bullbear.ai")
 
     API_BASE_URL = _get_env(


### PR DESCRIPTION
## Summary
- load VAPID keys from environment or a vapid_keys.json file and warn when missing
- propagate configured keys through Config, push service, and dispatcher to ensure push payloads are respected
- add a test dispatcher helper and update the test notification script to send a simple payload

## Testing
- pytest backend/tests/test_notification_dispatcher.py

------
https://chatgpt.com/codex/tasks/task_e_68e476b60ae883219a5a1b6dbe34e025