### PR TITLE
feat: integrate real VAPID key in push notifications

### DIFF
--- a/frontend/src/components/dashboard/notification-center-card.tsx
+++ b/frontend/src/components/dashboard/notification-center-card.tsx
@@ -8,7 +8,10 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { usePushNotifications } from "@/hooks/usePushNotifications";
+import {
+  PERMISSION_DENIED_MESSAGE,
+  usePushNotifications,
+} from "@/hooks/usePushNotifications";
 // 🧩 Bloque 9B
 import { useLiveNotifications } from "@/hooks/useLiveNotifications";
 // 🧩 Bloque 9B
@@ -25,6 +28,7 @@ const STORAGE_KEY = "notificationHistory";
 
 export default function NotificationCenterCard() {
   const {
+    error,
     permission,
     requestPermission,
     sendTestNotification,
@@ -35,6 +39,7 @@ export default function NotificationCenterCard() {
   const { token } = useAuth();
   // 🧩 Bloque 9B
   const { events, status } = useLiveNotifications(token ?? undefined);
+  const [toastMessage, setToastMessage] = useState<string | null>(null);
   const [history, setHistory] = useState<NotificationLog[]>(() => {
     if (typeof window === "undefined") {
       return notificationHistory;
@@ -54,6 +59,27 @@ export default function NotificationCenterCard() {
       return notificationHistory;
     }
   });
+
+  useEffect(() => {
+    if (permission === "denied") {
+      setToastMessage(PERMISSION_DENIED_MESSAGE);
+    }
+  }, [permission]);
+
+  useEffect(() => {
+    if (!error) {
+      return;
+    }
+    setToastMessage(error);
+  }, [error]);
+
+  useEffect(() => {
+    if (!toastMessage) {
+      return;
+    }
+    const timeout = window.setTimeout(() => setToastMessage(null), 5000);
+    return () => window.clearTimeout(timeout);
+  }, [toastMessage]);
 
   // 🧩 Bloque 8B
   useEffect(() => {
@@ -149,6 +175,14 @@ export default function NotificationCenterCard() {
 
   return (
     <Card className="surface-card">
+      {toastMessage ? (
+        <div
+          role="alert"
+          className="fixed bottom-6 right-6 z-50 max-w-sm rounded-xl border border-border/60 bg-background/90 px-4 py-3 text-sm text-foreground shadow-lg backdrop-blur"
+        >
+          {toastMessage}
+        </div>
+      ) : null}
       <CardHeader className="space-y-3 pb-4">
         <div className="flex flex-col gap-2">
           <CardTitle className="flex items-center gap-2 text-lg font-sans font-medium tracking-tight">

--- a/frontend/src/components/providers/service-worker-provider.tsx
+++ b/frontend/src/components/providers/service-worker-provider.tsx
@@ -17,9 +17,12 @@ export function ServiceWorkerProvider() {
 
     const registerServiceWorker = async () => {
       try {
-        const registration = await navigator.serviceWorker.register(
+        const existing = await navigator.serviceWorker.getRegistration(
           SERVICE_WORKER_PATH,
         );
+        const registration =
+          existing ??
+          (await navigator.serviceWorker.register(SERVICE_WORKER_PATH));
 
         if (cancelled) {
           return;

--- a/frontend/src/hooks/__tests__/usePushNotifications.integration.test.tsx
+++ b/frontend/src/hooks/__tests__/usePushNotifications.integration.test.tsx
@@ -81,6 +81,10 @@ describe("usePushNotifications integration", () => {
       configurable: true,
       value: {
         register: jest.fn().mockResolvedValue(registration),
+        ready: Promise.resolve(registration),
+        getRegistration: jest
+          .fn()
+          .mockResolvedValue(registration),
         addEventListener: eventTarget.addEventListener.bind(eventTarget),
         removeEventListener: eventTarget.removeEventListener.bind(eventTarget),
       },

--- a/frontend/src/hooks/__tests__/usePushNotifications.test.ts
+++ b/frontend/src/hooks/__tests__/usePushNotifications.test.ts
@@ -1,6 +1,6 @@
 import { act, renderHook, waitFor } from "@/tests/utils/renderWithProviders";
 
-import { subscribePush } from "@/lib/api";
+import { fetchVapidPublicKey, subscribePush } from "@/lib/api";
 import { usePushNotifications } from "../usePushNotifications";
 
 // # QA fix: mock seguro para Notification y ServiceWorker (evita redefinir varias veces)
@@ -41,6 +41,8 @@ describe("usePushNotifications", () => {
   const originalPushManager = (window as any).PushManager;
   const originalAtob = (global as any).atob;
   const mockedSubscribePush = subscribePush as jest.MockedFunction<typeof subscribePush>;
+  const mockedFetchVapidPublicKey =
+    fetchVapidPublicKey as jest.MockedFunction<typeof fetchVapidPublicKey>;
 
   beforeEach(() => {
     process.env.NEXT_PUBLIC_PUSH_VAPID_PUBLIC_KEY = "dGVzdA==";
@@ -134,6 +136,7 @@ describe("usePushNotifications", () => {
   it("reporta error cuando falta la clave VAPID", async () => {
     process.env.NEXT_PUBLIC_PUSH_VAPID_PUBLIC_KEY = "";
     process.env.NEXT_PUBLIC_VAPID_KEY = "";
+    mockedFetchVapidPublicKey.mockResolvedValueOnce(null);
 
     const { result } = renderHook(() => usePushNotifications("token"));
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -514,13 +514,25 @@ export interface PushSubscriptionResponse {
 }
 
 // 🧩 Bloque 8A
-export async function fetchVapidPublicKey(): Promise<string> {
-  const res = await fetch("/api/notifications/vapid-key");
-  if (!res.ok) {
-    throw new Error("Failed to fetch VAPID public key");
+export interface PushConfigResponse {
+  vapidPublicKey?: string | null;
+}
+
+export async function fetchVapidPublicKey(): Promise<string | null> {
+  try {
+    const { vapidPublicKey } = await request<PushConfigResponse>(
+      "/api/config/push-key"
+    );
+    if (typeof vapidPublicKey === "string" && vapidPublicKey.length > 0) {
+      return vapidPublicKey;
+    }
+    return null;
+  } catch (error) {
+    if (process.env.NODE_ENV !== "production") {
+      console.warn("Failed to retrieve VAPID public key from backend", error);
+    }
+    return null;
   }
-  const data = await res.json();
-  return data.vapidPublicKey;
 }
 
 export function subscribePush(


### PR DESCRIPTION
## Summary
- load the VAPID key from `/api/config/push-key` and reuse it when creating push subscriptions
- register the service worker once, improve permission error handling, and surface denial feedback in the dashboard
- ensure the service worker shows the received payload in system notifications and update push notification tests

## Testing
- npm run test -- usePushNotifications.integration.test.tsx
- npm run test -- usePushNotifications.test.ts


------
https://chatgpt.com/codex/tasks/task_e_68e479604c5483219ea900f59dcb08b8