### PR TITLE
Fix VAPID key retrieval and retry push registration

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -521,7 +521,7 @@ export interface PushConfigResponse {
 export async function fetchVapidPublicKey(): Promise<string | null> {
   try {
     const { vapidPublicKey } = await request<PushConfigResponse>(
-      "/api/config/push-key"
+      "/api/notifications/vapid-public-key"
     );
     if (typeof vapidPublicKey === "string" && vapidPublicKey.length > 0) {
       return vapidPublicKey;


### PR DESCRIPTION
## Summary
- update the frontend API client to request the VAPID key from `/api/notifications/vapid-public-key`
- retry push registration when the backend VAPID key is missing and surface a toast error before failing

## Testing
- pnpm --prefix frontend test:dev -- src/components/dashboard/__tests__/dashboard-page.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e51911f9708321870e0531805a821d