### PR TITLE
Handle analyze mode font loading

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from "next";
 import "@/styles/globals.css";
-import { Inter } from "next/font/google";
 
 import { AuthProvider } from "@/components/providers/auth-provider";
 import { ThemeProvider } from "@/components/providers/theme-provider";
@@ -21,11 +20,20 @@ const metadataBase = (() => {
   }
 })();
 
-const inter = Inter({
-  subsets: ["latin"],
-  display: "swap",
-  variable: "--font-inter",
-});
+let inter: { className: string; variable: string };
+
+if (process.env.ANALYZE === "true") {
+  // 🚧 En modo análisis desactivamos next/font (incompatible con Babel)
+  inter = { className: "", variable: "" };
+} else {
+  // ✅ En ejecución normal usamos next/font
+  const { Inter } = require("next/font/google") as typeof import("next/font/google");
+  inter = Inter({
+    subsets: ["latin"],
+    display: "swap",
+    variable: "--font-inter",
+  });
+}
 
 const apiPreconnectOrigin = (() => {
   const apiUrl = process.env.NEXT_PUBLIC_API_URL;


### PR DESCRIPTION
## Summary
- add a conditional next/font initialization that bypasses the loader when ANALYZE=true
- preserve the existing Inter font configuration during normal execution

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e54ccd0a5c832188f11f146a018e9c