### PR TITLE
Add staging environment configuration support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,8 @@ pnpm-debug.log*
 .env
 .env.local
 .env.staging
+!backend/.env.staging
+!frontend/.env.staging
 .env.supabase
 .env.production
 *.secret

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,10 @@ up-staging:
 	@echo "🚀 Iniciando backend en modo staging..."
 	@APP_ENV=staging uvicorn $(APP) --port $(PORT)
 
+frontend-staging:
+	@echo "🚀 Iniciando frontend en modo staging..."
+	@NEXT_PUBLIC_ENV=staging pnpm --prefix frontend dev --port 3001
+
 # --- 🧩 MIGRACIONES ---
 migrate:
 	@echo "🧩 Aplicando migraciones Alembic..."

--- a/backend/.env.staging
+++ b/backend/.env.staging
@@ -1,0 +1,6 @@
+# 🧩 Codex staging env: valores de placeholder
+APP_ENV=staging
+DATABASE_URL=postgresql+asyncpg://user:pass@host:5432/bullbearbroker  # pragma: allowlist secret
+JWT_SECRET_KEY=${JWT_SECRET_KEY}
+SUPABASE_URL=https://staging.supabase.co
+SUPABASE_KEY=${SUPABASE_KEY}

--- a/backend/main.py
+++ b/backend/main.py
@@ -45,7 +45,7 @@ from backend.services.alert_service import alert_service
 from backend.services.integration_reporter import log_api_integration_report
 from backend.services.notification_dispatcher import notification_dispatcher
 from backend.services.websocket_manager import AlertWebSocketManager
-from backend.utils.config import ENV, Config
+from backend.utils.config import APP_ENV, Config
 
 # Routers de la app
 # ✅ Codex fix: Import Prometheus metrics router
@@ -109,7 +109,7 @@ async def lifespan(app: FastAPI):
 
         database_engine = getattr(database_module, "engine", None)
         database_ready = True
-        if ENV in {"local", "test"}:
+        if APP_ENV == "local":
             try:
                 if database_engine is None:
                     raise RuntimeError("database engine is not configured")
@@ -127,7 +127,7 @@ async def lifespan(app: FastAPI):
                     error=database_setup_error_message,
                 )
         else:
-            logger.info("database_migrations_required", env=ENV)
+            logger.info("database_migrations_required", env=APP_ENV)
 
         if database_ready:
             default_email = os.environ.get("BULLBEAR_DEFAULT_USER", "test@bullbear.ai")

--- a/frontend/.env.staging
+++ b/frontend/.env.staging
@@ -1,0 +1,4 @@
+# 🧩 Codex staging env: placeholders seguros
+NEXT_PUBLIC_API_URL=https://staging.api.bullbearbroker.com
+NEXT_PUBLIC_SUPABASE_URL=https://staging.supabase.co
+NEXT_PUBLIC_ENV=staging


### PR DESCRIPTION
## Summary
- add explicit environment defaults for local, staging, and production in the backend config so APP_ENV drives staging behaviour
- commit placeholder .env.staging files for backend and frontend and expose them via gitignore exceptions
- add a frontend staging Makefile target to complement the backend script

## Testing
- APP_ENV=staging PYTHONPATH=. python backend/scripts/send_test_notification.py *(fails: missing optional dependency `transformers` in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e5a2dc1d8083219e32d059902bcc5e